### PR TITLE
bugfix: pull request

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -196,6 +196,18 @@ impl Consumer {
             }
         }
 
+        // skip pull requests that aren't either opened or edited
+        // this avoids retesting a closed pull request
+        if let Event::PullRequest(pr) = event.clone() {
+            let action = pr.action();
+            match action.as_str() {
+                "opened" | "edited" => {},
+                _ => {
+                    return;
+                }
+            }
+        }
+
         let repo = match event.clone() {
             Event::PullRequest(pr) => pr.repo(),
             Event::Push(push) => push.repo(),

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -183,7 +183,9 @@ impl Consumer {
         let description = match event {
             Event::Push(_) => "continuous-integration/crucible/push",
             Event::PullRequest(_) => "continuous-integration/crucible/pr",
-            _ => panic!("unimplemented"),
+            _ => {
+                return;
+            },
         };
 
         let id = "temp";

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -185,7 +185,7 @@ impl Consumer {
             Event::PullRequest(_) => "continuous-integration/crucible/pr",
             _ => {
                 return;
-            },
+            }
         };
 
         let id = "temp";
@@ -203,7 +203,7 @@ impl Consumer {
         if let Event::PullRequest(pr) = event.clone() {
             let action = pr.action();
             match action.as_str() {
-                "opened" | "edited" => {},
+                "opened" | "edited" => {}
                 _ => {
                     return;
                 }


### PR DESCRIPTION
- skip PRs where action != edited | opened
- return early instead of panicing for unknown events