### PR TITLE
perf: reduce cpu utilization

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Duration;
 use tic::Receiver;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -20,6 +21,7 @@ pub fn init(listen: Option<String>) -> Receiver<Metric> {
     let mut config = Receiver::<Metric>::configure()
         .batch_size(1)
         .capacity(4096)
+        .poll_delay(Some(Duration::new(0, 1_000_000)))
         .service(true);
 
     if let Some(addr) = listen {

--- a/src/webhook/mod.rs
+++ b/src/webhook/mod.rs
@@ -1,12 +1,14 @@
 extern crate getopts;
 extern crate json;
 extern crate mpmc;
+extern crate shuteye;
 extern crate tic;
 extern crate tiny_http;
 
 use metrics::Metric;
 use mpmc::Queue;
 use std::default::Default;
+use std::time::Duration;
 use tic::{Clocksource, Sample, Sender};
 use tiny_http::{Method, Request, Response};
 
@@ -97,22 +99,19 @@ impl Server {
         Config::default().build()
     }
 
-    // non-blocking receive
-    pub fn try_recv(&mut self) {
-        if let Ok(Some(request)) = self.server.try_recv() {
-            trace!("handle request");
-            let t0 = self.time();
-            self.handle_http(request);
-            let t1 = self.time();
-            self.send_stat(t0, t1, Metric::Request);
-        }
-    }
-
     // run the server forever
     pub fn run(&mut self) {
         info!("listening HTTP {}", self.config.addr);
         loop {
-            self.try_recv();
+            if let Ok(Some(request)) = self.server.try_recv() {
+                trace!("handle request");
+                let t0 = self.time();
+                self.handle_http(request);
+                let t1 = self.time();
+                self.send_stat(t0, t1, Metric::Request);
+            } else {
+                shuteye::sleep(Duration::new(0, 1_000_000));
+            }
         }
     }
 


### PR DESCRIPTION
- add delays to reduce cpu utilization in threads
- add 1ms delay to webhook server when no try_recv returns no event
- add 1ms delay to stats receiver poll_delay