### PR TITLE
refactor: consumer

### DIFF
--- a/src/consumer/config.rs
+++ b/src/consumer/config.rs
@@ -1,0 +1,67 @@
+
+
+use super::Consumer;
+use metrics::Metric;
+use mpmc::Queue;
+use std::default::Default;
+use tic::{Clocksource, Sender};
+use webhook::event::Event;
+
+pub struct Config {
+    pub events: Option<Queue<Event>>,
+    pub clock: Option<Clocksource>,
+    pub stats: Option<Sender<Metric>>,
+    pub token: Option<String>,
+    pub repo: Option<String>,
+    pub author: Option<String>,
+}
+
+impl Config {
+    pub fn build(self) -> Result<Consumer, &'static str> {
+        Consumer::configured(self)
+    }
+
+    pub fn clock(mut self, clock: Clocksource) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    pub fn events(mut self, queue: Queue<Event>) -> Self {
+        self.events = Some(queue);
+        self
+    }
+
+    pub fn stats(mut self, sender: Sender<Metric>) -> Self {
+        self.stats = Some(sender);
+        self
+    }
+
+    pub fn token(mut self, token: String) -> Self {
+        self.token = Some(token);
+        self
+    }
+
+    pub fn repo(mut self, repo: String) -> Self {
+        self.repo = Some(repo);
+        self
+    }
+
+    pub fn author(mut self, author: String) -> Self {
+        self.author = Some(author);
+        self
+    }
+}
+
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            events: None,
+            clock: None,
+            stats: None,
+            token: None,
+            repo: None,
+            author: None,
+        }
+    }
+}

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -11,64 +11,9 @@ use std::time::Duration;
 use tic::{Clocksource, Sample, Sender};
 use webhook::event::*;
 
-pub struct Config {
-    events: Option<Queue<Event>>,
-    clock: Option<Clocksource>,
-    stats: Option<Sender<Metric>>,
-    token: Option<String>,
-    repo: Option<String>,
-    author: Option<String>,
-}
+mod config;
 
-impl Config {
-    pub fn build(self) -> Result<Consumer, &'static str> {
-        Consumer::configured(self)
-    }
-
-    pub fn clock(mut self, clock: Clocksource) -> Self {
-        self.clock = Some(clock);
-        self
-    }
-
-    pub fn events(mut self, queue: Queue<Event>) -> Self {
-        self.events = Some(queue);
-        self
-    }
-
-    pub fn stats(mut self, sender: Sender<Metric>) -> Self {
-        self.stats = Some(sender);
-        self
-    }
-
-    pub fn token(mut self, token: String) -> Self {
-        self.token = Some(token);
-        self
-    }
-
-    pub fn repo(mut self, repo: String) -> Self {
-        self.repo = Some(repo);
-        self
-    }
-
-    pub fn author(mut self, author: String) -> Self {
-        self.author = Some(author);
-        self
-    }
-}
-
-
-impl Default for Config {
-    fn default() -> Config {
-        Config {
-            events: None,
-            clock: None,
-            stats: None,
-            token: None,
-            repo: None,
-            author: None,
-        }
-    }
-}
+pub use self::config::Config;
 
 pub struct Consumer {
     clock: Clocksource,
@@ -176,46 +121,35 @@ impl Consumer {
         trace!("response: {}", forced_string(response));
     }
 
-    fn handle_event(&mut self, event: Event) {
-        let repo = match event.clone() {
-            Event::PullRequest(pr) => pr.repo(),
-            Event::Push(push) => push.repo(),
-            _ => {
-                return;
-            }
-        };
+    fn should_handle(&mut self, event: &Event) -> bool {
+        // events must have a repo
+        if event.repo().is_none() {
+            return false;
+        }
+
+        // skip events with this sha, happens when branch deleted
+        if event.sha() == Some("0000000000000000000000000000000000000000".to_owned()) {
+            debug!("skip event with zero-SHA");
+            return false;
+        }
+
+        // repository whitelist
         if let Some(ref whitelist) = self.repo {
-            if repo != *whitelist {
-                return;
+            if event.repo().unwrap() != *whitelist {
+                debug!("repo: {} not in whitelist", event.repo().unwrap());
+                debug!("whitelist: {:?}", *whitelist);
+                return false;
             }
         }
 
-        let temp_dir = Temp::new_dir_in(Path::new("/mnt/scratch/")).unwrap();
-        let path = temp_dir.to_path_buf();
-
-        let description = match event {
-            Event::Push(_) => "continuous-integration/crucible/push",
-            Event::PullRequest(_) => "continuous-integration/crucible/pr",
-            _ => {
-                return;
-            }
-        };
-
-        // skip events with this sha, happens when branch deleted
-        if let Event::Push(push) = event.clone() {
-            if push.sha() == "0000000000000000000000000000000000000000" {
-                return;
+        // author whitelist
+        if let Some(ref whitelist) = self.author {
+            if event.author().unwrap() != *whitelist {
+                debug!("author: {} not in whitelist", event.author().unwrap());
+                debug!("whitelist: {:?}", *whitelist);
+                return false;
             }
         }
-        // skip events with this sha, happens when branch deleted
-        if let Some(ref author) = self.author {
-            if let Event::PullRequest(pull) = event.clone() {
-                if pull.author() != *author {
-                    return;
-                }
-            }
-        }
-
 
         // skip pull requests that aren't either opened or edited
         // this avoids retesting a closed pull request
@@ -224,25 +158,32 @@ impl Consumer {
             match action.as_str() {
                 "opened" | "edited" | "synchronize" => {}
                 _ => {
-                    return;
+                    return false;
                 }
             }
         }
 
-        let sha = match event.clone() {
-            Event::PullRequest(pr) => pr.sha(),
-            Event::Push(push) => push.sha(),
-            _ => {
-                panic!("unsupported event");
-            }
+        true
+    }
+
+    fn handle_event(&mut self, event: Event) {
+        if !self.should_handle(&event) {
+            return;
+        }
+
+        let repo = event.repo().unwrap();
+
+        let temp_dir = Temp::new_dir_in(Path::new("/mnt/scratch/")).unwrap();
+        let path = temp_dir.to_path_buf();
+
+        let description = match event {
+            Event::Push(_) => "continuous-integration/crucible/push",
+            Event::PullRequest(_) => "continuous-integration/crucible/pr",
+            _ => unreachable!(),
         };
-        let url = match event.clone() {
-            Event::PullRequest(pr) => pr.url(),
-            Event::Push(push) => push.url(),
-            _ => {
-                panic!("unsupported event");
-            }
-        };
+
+        let sha = event.sha().expect("event is missing a sha");
+        let url = event.url().expect("event is missing a url");
 
         // inform github we're running a test
         self.send_status(&repo,

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -35,7 +35,7 @@ impl Consumer {
         let stats = config.stats.clone();
         let token = config.token.clone();
         let repo = config.repo.clone();
-        let author = config.repo.clone();
+        let author = config.author.clone();
 
         if events.is_none() {
             return Err("need events queue");

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,9 +55,11 @@ fn main() {
         .events(events)
         .token(token);
     if let Some(repo) = options.opt_str("repo") {
+        info!("repo whitelist: {}", repo);
         consumer_config = consumer_config.repo(repo);
     }
     if let Some(author) = options.opt_str("author") {
+        info!("author whitelist: {}", author);
         consumer_config = consumer_config.author(author);
     }
     let mut consumer = consumer_config.build().unwrap();

--- a/src/webhook/event/mod.rs
+++ b/src/webhook/event/mod.rs
@@ -73,4 +73,36 @@ impl Event {
         }
         e
     }
+
+    pub fn repo(&self) -> Option<String> {
+        match self {
+            &Event::PullRequest(ref pr) => Some(pr.repo()),
+            &Event::Push(ref push) => Some(push.repo()),
+            _ => None,
+        }
+    }
+
+    pub fn sha(&self) -> Option<String> {
+        match self {
+            &Event::PullRequest(ref pr) => Some(pr.sha()),
+            &Event::Push(ref push) => Some(push.sha()),
+            _ => None,
+        }
+    }
+
+    pub fn url(&self) -> Option<String> {
+        match self {
+            &Event::PullRequest(ref pr) => Some(pr.url()),
+            &Event::Push(ref push) => Some(push.url()),
+            _ => None,
+        }
+    }
+
+    pub fn author(&self) -> Option<String> {
+        match self {
+            &Event::PullRequest(ref pr) => Some(pr.author()),
+            &Event::Push(ref push) => Some(push.author()),
+            _ => None,
+        }
+    }
 }

--- a/src/webhook/event/push.rs
+++ b/src/webhook/event/push.rs
@@ -9,6 +9,7 @@ pub struct Push {
     repo: String,
     clone_url: String,
     sha: String,
+    author: String,
 }
 
 impl Push {
@@ -22,6 +23,10 @@ impl Push {
 
     pub fn sha(&self) -> String {
         self.sha.clone()
+    }
+
+    pub fn author(&self) -> String {
+        self.author.clone()
     }
 }
 
@@ -45,9 +50,11 @@ impl FromStr for Push {
             let git_ref = parsed["ref"].as_str();
             let repo = parsed["repository"]["full_name"].as_str();
             let clone_url = parsed["repository"]["clone_url"].as_str();
+            let author = parsed["pusher"]["name"].as_str();
             let sha = parsed["after"].as_str();
 
-            if git_ref.is_none() || repo.is_none() || clone_url.is_none() || sha.is_none() {
+            if git_ref.is_none() || repo.is_none() || clone_url.is_none() || sha.is_none() ||
+               author.is_none() {
                 return Err(ParseError { _priv: () });
             }
 
@@ -56,6 +63,7 @@ impl FromStr for Push {
                 repo: repo.unwrap().to_owned(),
                 clone_url: clone_url.unwrap().to_owned(),
                 sha: sha.unwrap().to_owned(),
+                author: author.unwrap().to_owned(),
             };
 
             debug!("{:?}", event);
@@ -79,5 +87,6 @@ mod test {
         assert_eq!(push.clone_url,
                    "https://github.com/baxterthehacker/public-repo.git");
         assert_eq!(push.sha, "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c");
+        assert_eq!(push.author, "baxterthehacker");
     }
 }


### PR DESCRIPTION
- split config
- add repo() to Event
- filter events in one function