### PR TITLE
cargo-crucible: binary to run tests locally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,14 @@ readme = "README.md"
 
 keywords = [ ]
 
+[[bin]]
+name = "crucible"
+path = "./src/main.rs"
+
+[[bin]]
+name = "cargo-crucible"
+path = "./src/cargo-crucible.rs"
+
 [profile.bench]
 opt-level = 3
 debug = true

--- a/src/cargo-crucible.rs
+++ b/src/cargo-crucible.rs
@@ -1,0 +1,149 @@
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate json;
+extern crate curl;
+extern crate getopts;
+extern crate mktemp;
+extern crate mpmc;
+extern crate regex;
+extern crate shuteye;
+extern crate tic;
+extern crate tiny_http;
+extern crate toml;
+extern crate sha_1;
+extern crate hmac;
+extern crate rustc_serialize;
+
+mod common;
+mod consumer;
+mod webhook;
+mod publisher;
+
+use common::logging::set_log_level;
+use consumer::cargo;
+use getopts::Options;
+use std::{env, process};
+
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const PROGRAM: &'static str = env!("CARGO_PKG_NAME");
+
+fn print_usage(program: &str, opts: &Options) {
+    let brief = format!("Usage: {} [options]", program);
+    print!("{}", opts.usage(&brief));
+}
+
+fn opts() -> Options {
+    let mut opts = Options::new();
+
+    // general
+    opts.optflag("h", "help", "print this help menu");
+    opts.optflag("", "version", "show version and exit");
+    opts.optflagmulti("v", "verbose", "verbosity (stacking)");
+
+    // clippy
+    opts.optflag("", "no-clippy", "skip clippy");
+
+    // fuzzing
+    opts.optflag("", "no-fuzz", "skip fuzzing");
+    opts.optopt("d", "fuzz-duration", "time per fuzz target", "[SECONDS]");
+    opts.optopt(
+        "c",
+        "fuzz-cores",
+        "number of cores to use during fuzzing",
+        "[CORES]",
+    );
+
+    // cross targets
+    opts.optflag("", "no-cross", "skip cross targets");
+
+    opts
+}
+
+pub fn init() -> getopts::Matches {
+    let args: Vec<String> = env::args().collect();
+    let program = &args[0];
+    let opts = opts();
+
+    let options = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => {
+            println!("Failed to parse command line args: {}", f);
+            process::exit(1);
+        }
+    };
+
+    if options.opt_present("help") {
+        print_usage(program, &opts);
+        process::exit(0);
+    }
+
+    if options.opt_present("version") {
+        println!("{} {}", PROGRAM, VERSION);
+        process::exit(0);
+    }
+
+    options
+}
+
+fn main() {
+    let options = init();
+
+    // initialize logging
+    set_log_level(options.opt_count("verbose"));
+    info!("{} {}", PROGRAM, VERSION);
+
+    let fuzz_duration: usize = options
+        .opt_str("fuzz-duration")
+        .unwrap_or("10".to_owned())
+        .parse()
+        .expect("--fuzz-duration invalid");
+
+    let fuzz_cores: usize = options
+        .opt_str("fuzz-cores")
+        .unwrap_or("1".to_owned())
+        .parse()
+        .expect("--fuzz-duration invalid");
+
+    // complete set of tests - native target
+    let mut cargo = cargo::Cargo::new(".".to_owned());
+    cargo.build().expect("cargo build: failed");
+    cargo.test().expect("cargo test: failed");
+    cargo.fmt().expect("cargo fmt: failed");
+    if !options.opt_present("no-clippy") {
+        cargo.clippy().expect("cargo clippy: failed");
+    }
+    if !options.opt_present("no-fuzz") {
+        cargo.fuzz_all(fuzz_duration, fuzz_cores).expect(
+            "cargo fuzz: failed",
+        );
+    }
+    cargo.set_release(true);
+    cargo.build().expect("cargo build --release: failed");
+    cargo.test().expect("cargo test --release: failed");
+
+    if !options.opt_present("no-cross") {
+        let targets = vec![
+            "aarch64-unknown-linux-gnu", // Tier-2
+            "arm-unknown-linux-gnueabi", // Tier-2
+            "arm-unknown-linux-gnueabihf", // Tier-2
+            "armv7-unknown-linux-gnueabihf", // Tier-2
+            "i686-unknown-linux-gnu", // Tier-1
+            "i686-unknown-linux-musl", // Tier-2
+            "x86_64-unknown-linux-gnu", // Tier-1
+            "x86_64-unknown-linux-musl", // Tier-2
+        ];
+
+        // cross target tests
+        for target in targets {
+            info!("target: {}", target);
+            let mut cargo = cargo::Cargo::new(".".to_owned());
+            cargo.set_target(target.to_owned());
+            cargo.build().expect("cargo build: failed");
+            cargo.test().expect("cargo test: failed");
+            cargo.set_release(true);
+            cargo.build().expect("cargo build --release: failed");
+            cargo.test().expect("cargo test --release: failed");
+        }
+    }
+}

--- a/src/consumer/cargo.rs
+++ b/src/consumer/cargo.rs
@@ -3,7 +3,56 @@ use regex::Regex;
 use std::path::Path;
 use std::process::Command;
 
-pub fn build(path: &Path, release: bool) -> Result<(), ()> {
+pub struct Cargo {
+    path: String,
+    release: bool,
+    target: Option<String>,
+}
+
+impl Cargo {
+    pub fn new(path: String) -> Cargo {
+        Cargo {
+            path: path,
+            release: false,
+            target: None,
+        }
+    }
+
+    pub fn build(&self) -> Result<(), ()> {
+        build(Path::new(&self.path), self.release, self.target.clone())
+    }
+
+    pub fn clean(&self) -> Result<(), ()> {
+        clean(Path::new(&self.path))
+    }
+
+    pub fn clippy(&self) -> Result<(), ()> {
+        clippy(Path::new(&self.path))
+    }
+
+    pub fn test(&self) -> Result<(), ()> {
+        test(Path::new(&self.path), self.release, self.target.clone())
+    }
+
+    pub fn fmt(&self) -> Result<(), ()> {
+        fmt(Path::new(&self.path))
+    }
+
+    pub fn fuzz_all(&self, seconds: usize, cores: usize) -> Result<(), ()> {
+        fuzz_all(Path::new(&self.path), seconds, cores)
+    }
+
+    pub fn set_release(&mut self, enable: bool) {
+        self.release = enable;
+    }
+
+    pub fn set_target(&mut self, target: String) {
+        self.target = Some(target);
+    }
+}
+
+// run cargo build in given path in either debug or release mode
+fn build(path: &Path, release: bool, target: Option<String>) -> Result<(), ()> {
     let label = match release {
         true => "cargo build --release:",
         false => "cargo build:",
@@ -14,6 +63,10 @@ pub fn build(path: &Path, release: bool) -> Result<(), ()> {
     command.arg("build").arg("--verbose");
     if release {
         command.arg("--release");
+    }
+    if let Some(t) = target {
+        command.arg("--target");
+        command.arg(t);
     }
     let output = command.current_dir(path).output().expect(
         "failed to run cargo build",
@@ -31,7 +84,8 @@ pub fn build(path: &Path, release: bool) -> Result<(), ()> {
     }
 }
 
-pub fn clean(path: &Path) -> Result<(), ()> {
+// run cargo clean in the given path
+fn clean(path: &Path) -> Result<(), ()> {
     info!("cargo clean: starting");
     let output = Command::new("cargo")
         .arg("clean")
@@ -51,7 +105,7 @@ pub fn clean(path: &Path) -> Result<(), ()> {
     }
 }
 
-pub fn test(path: &Path, release: bool) -> Result<(), ()> {
+fn test(path: &Path, release: bool, target: Option<String>) -> Result<(), ()> {
     let label = match release {
         true => "cargo test --release:",
         false => "cargo test:",
@@ -62,6 +116,10 @@ pub fn test(path: &Path, release: bool) -> Result<(), ()> {
     command.arg("test").arg("--verbose");
     if release {
         command.arg("--release");
+    }
+    if let Some(t) = target {
+        command.arg("--target");
+        command.arg(t);
     }
     let output = command.current_dir(path).output().expect(
         "failed to run cargo test",
@@ -79,7 +137,9 @@ pub fn test(path: &Path, release: bool) -> Result<(), ()> {
     }
 }
 
-pub fn clippy(path: &Path) -> Result<(), ()> {
+// run cargo clippy
+// toolchain: nightly
+fn clippy(path: &Path) -> Result<(), ()> {
     info!("cargo clippy: started");
     let output = Command::new("cargo")
         .arg("+nightly")
@@ -100,7 +160,9 @@ pub fn clippy(path: &Path) -> Result<(), ()> {
     }
 }
 
-pub fn fmt(path: &Path) -> Result<(), ()> {
+// run cargo fmt detecting differences
+// toolchain: stable
+fn fmt(path: &Path) -> Result<(), ()> {
     info!("cargo fmt: started");
     let output = Command::new("cargo")
         .arg("fmt")
@@ -122,7 +184,9 @@ pub fn fmt(path: &Path) -> Result<(), ()> {
     }
 }
 
-pub fn fuzz_all(path: &Path, seconds: usize, cores: usize) -> Result<(), ()> {
+// run all of the fuzzers defined within the given path
+// toolchain: nightly
+fn fuzz_all(path: &Path, seconds: usize, cores: usize) -> Result<(), ()> {
     info!("cargo fuzz: started");
     if let Ok(targets) = fuzz_list(path) {
         for t in targets {
@@ -140,8 +204,11 @@ pub fn fuzz_all(path: &Path, seconds: usize, cores: usize) -> Result<(), ()> {
     Err(())
 }
 
-pub fn fuzz_list(path: &Path) -> Result<Vec<String>, ()> {
+// lists the available fuzzers
+// toolchain: nightly
+fn fuzz_list(path: &Path) -> Result<Vec<String>, ()> {
     let output = Command::new("cargo")
+        .arg("+nightly")
         .arg("fuzz")
         .arg("list")
         .current_dir(path)
@@ -155,8 +222,10 @@ pub fn fuzz_list(path: &Path) -> Result<Vec<String>, ()> {
     }
 }
 
-pub fn fuzz_run(path: &Path, fuzzer: &str, seconds: usize, cores: usize) -> Result<(), ()> {
-    info!("cargo fuzz {}: started", fuzzer);
+// run the named fuzzer in the given path
+fn fuzz_run(path: &Path, fuzzer: &str, seconds: usize, cores: usize) -> Result<(), ()> {
+    let label = format!("cargo fuzz {}:", fuzzer);
+    info!("{} started", label);
     let output = Command::new("cargo")
         .arg("+nightly")
         .arg("fuzz")
@@ -183,7 +252,8 @@ pub fn fuzz_run(path: &Path, fuzzer: &str, seconds: usize, cores: usize) -> Resu
     }
 }
 
-// this should be fuzz tested
+// parse the output of "cargo fuzz list" to get list of fuzz test names
+// note: marked pub for fuzz testing
 pub fn fuzz_list_parse(stdout: Vec<u8>) -> Result<Vec<String>, ()> {
     if let Ok(stdout) = String::from_utf8(stdout) {
         let re = Regex::new(r"(fuzz_\w+)\n").unwrap();

--- a/src/consumer/config.rs
+++ b/src/consumer/config.rs
@@ -17,52 +17,6 @@ pub struct Config {
     pub fuzz_cores: usize,
 }
 
-impl Config {
-    pub fn build(self) -> Result<Consumer, &'static str> {
-        Consumer::configured(self)
-    }
-
-    pub fn clock(mut self, clock: Clocksource) -> Self {
-        self.clock = Some(clock);
-        self
-    }
-
-    pub fn events(mut self, queue: Queue<Event>) -> Self {
-        self.events = Some(queue);
-        self
-    }
-
-    pub fn stats(mut self, sender: Sender<Metric>) -> Self {
-        self.stats = Some(sender);
-        self
-    }
-
-    pub fn publisher(mut self, queue: Queue<publisher::Event>) -> Self {
-        self.publisher = Some(queue);
-        self
-    }
-
-    pub fn repo(mut self, repo: String) -> Self {
-        self.repo = Some(repo);
-        self
-    }
-
-    pub fn author(mut self, author: String) -> Self {
-        self.author = Some(author);
-        self
-    }
-
-    pub fn fuzz_cores(mut self, cores: usize) -> Self {
-        self.fuzz_cores = cores;
-        self
-    }
-
-    pub fn fuzz_seconds(mut self, seconds: usize) -> Self {
-        self.fuzz_seconds = seconds;
-        self
-    }
-}
-
 impl Default for Config {
     fn default() -> Config {
         Config {
@@ -75,5 +29,60 @@ impl Default for Config {
             fuzz_seconds: 60,
             fuzz_cores: 8,
         }
+    }
+}
+
+impl Config {
+    // try to build a `Consumer` from the given `Config`
+    pub fn build(self) -> Result<Consumer, &'static str> {
+        Consumer::configured(self)
+    }
+
+    // set the `Clocksource`
+    pub fn clock(mut self, clock: Clocksource) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    // mpmc queue for receiving events
+    pub fn events(mut self, queue: Queue<Event>) -> Self {
+        self.events = Some(queue);
+        self
+    }
+
+    // a tic::Sender for stats
+    pub fn stats(mut self, sender: Sender<Metric>) -> Self {
+        self.stats = Some(sender);
+        self
+    }
+
+    // mpmc queue for publishing status back
+    pub fn publisher(mut self, queue: Queue<publisher::Event>) -> Self {
+        self.publisher = Some(queue);
+        self
+    }
+
+    // set the repo whitelist
+    pub fn repo(mut self, repo: String) -> Self {
+        self.repo = Some(repo);
+        self
+    }
+
+    // set the author whitelist
+    pub fn author(mut self, author: String) -> Self {
+        self.author = Some(author);
+        self
+    }
+
+    // set the number of parallel fuzz jobs and cores
+    pub fn fuzz_cores(mut self, cores: usize) -> Self {
+        self.fuzz_cores = cores;
+        self
+    }
+
+    // set the duration of each fuzz test in seconds
+    pub fn fuzz_seconds(mut self, seconds: usize) -> Self {
+        self.fuzz_seconds = seconds;
+        self
     }
 }

--- a/src/consumer/git.rs
+++ b/src/consumer/git.rs
@@ -25,6 +25,7 @@ pub fn clone_repo(path: &Path, name: &str, url: &str) -> Result<(), ()> {
     }
 }
 
+// fetch the pull request with the given number
 pub fn fetch_pull(path: &Path, number: &u64) -> Result<(), ()> {
     info!("git fetch: pr #{}", number);
     let pr_ref = format!("pull/{}/head:pr-{}", number, number);
@@ -48,6 +49,7 @@ pub fn fetch_pull(path: &Path, number: &u64) -> Result<(), ()> {
     }
 }
 
+// checkout the given pr after fetch
 pub fn checkout_pr(path: &Path, number: &u64) -> Result<(), ()> {
     info!("git checkout: pr #{}", number);
     let branch = format!("pr-{}", number);
@@ -70,6 +72,7 @@ pub fn checkout_pr(path: &Path, number: &u64) -> Result<(), ()> {
     }
 }
 
+// checkout the given sha
 pub fn checkout_sha(path: &Path, sha: &str) -> Result<(), ()> {
     info!("git checkout: sha {}", sha);
     let output = Command::new("git")

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,5 +1,5 @@
 mod caching;
-mod cargo;
+pub mod cargo;
 mod config;
 mod git;
 
@@ -228,47 +228,52 @@ impl Consumer {
             let mut errors = 0;
 
             let path = build_path.as_path();
-            if cargo::build(path, false).is_err() {
+            let mut cargo = cargo::Cargo::new(path.to_str().unwrap().to_owned());
+
+            if cargo.build().is_err() {
                 errors += 1;
             }
-            if cargo::build(path, true).is_err() {
+            if cargo.test().is_err() {
                 errors += 1;
             }
-            if cargo::test(path, false).is_err() {
+            if cargo.fmt().is_err() {
                 errors += 1;
             }
-            if cargo::test(path, true).is_err() {
+            cargo.set_release(true);
+            if cargo.build().is_err() {
                 errors += 1;
             }
-            if cargo::fmt(path).is_err() {
+            if cargo.test().is_err() {
                 errors += 1;
             }
 
             // save cache and clean buid dir
             let _ = caching::save(path, Path::new(&cache_dir));
-            let _ = cargo::clean(path);
+            let _ = cargo.clean();
+            cargo.set_release(false);
 
             // setup cache for nightly
             let cache_dir = "/mnt/cache/".to_owned() + &repo + "/nightly";
             let _ = caching::load(path, Path::new(&cache_dir));
 
             // run nightly tests
-            if cargo::build(path, false).is_err() {
+            if cargo.build().is_err() {
                 errors += 1;
             }
-            if cargo::build(path, true).is_err() {
+            if cargo.test().is_err() {
                 errors += 1;
             }
-            if cargo::test(path, false).is_err() {
+            if cargo.clippy().is_err() {
                 errors += 1;
             }
-            if cargo::test(path, true).is_err() {
+            if cargo.fuzz_all(self.fuzz_seconds, self.fuzz_cores).is_err() {
                 errors += 1;
             }
-            if cargo::clippy(path).is_err() {
+            cargo.set_release(true);
+            if cargo.build().is_err() {
                 errors += 1;
             }
-            if cargo::fuzz_all(path, self.fuzz_seconds, self.fuzz_cores).is_err() {
+            if cargo.test().is_err() {
                 errors += 1;
             }
 


### PR DESCRIPTION
- add new binary target cargo-crucible, which runs tests locally
- move cargo functionality into OO-model