### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [0.1.0] - Unreleased
+## [0.2.0] - 2026-01-28
 
-Initial release.
+First public release.
+
+### Added
+- Cache server with RESP (Redis) and Memcache protocol support
+- Multiple storage backends: segment (default), slab, heap
+- Multiple eviction policies: S3-FIFO, FIFO, LRU variants, random, CTE, merge
+- RAM to disk tiering for segment and slab backends
+- Custom io-driver with io_uring support (Linux 6.0+) and mio fallback
+- Thread-per-core architecture with CPU pinning
+- Lock-free multi-choice hashtable with ghost entries
+- Zero-copy I/O paths where possible
+- Hugepage support (2MB/1GB)
+- NUMA-aware memory allocation
+- Prometheus metrics endpoint
+- Benchmark tool with web dashboard viewer
+- Parquet output for benchmark results
+- Rezolus telemetry correlation in viewer
 
 ### Added
 - Cache server with RESP (Redis) and Memcache protocol support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "axum",
@@ -536,7 +536,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cache-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "bytes",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "http2",
@@ -1089,7 +1089,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1269,7 +1269,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "metriken",
 ]
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itoa",
  "memchr",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "grpc",
@@ -2117,14 +2117,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "itoa",
  "memchr",
@@ -2439,7 +2439,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2632,7 +2632,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slab-cache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/release.toml
+++ b/release.toml
@@ -39,9 +39,6 @@ allow-branch = ["main"]
 # Consolidate commits: one commit for version bump across all crates
 consolidate-commits = true
 
-# Don't run cargo publish (redundant with publish=false, but explicit)
-no-verify = false
-
 # What to do before release
 pre-release-replacements = []
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.2.0

This PR prepares the release of v0.2.0.

### Changes
- Version bump across all crates
- Changelog update

### After Merge
The release workflow will automatically:
1. Create git tag `v0.2.0`
2. Build and publish release artifacts
3. Bump to next development version (`0.2.1-alpha.0`)

---
See CHANGELOG.md for details.