### PR TITLE
release: v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.3] - 2026-01-29
+
+### Fixed
+- Slab eviction (LRC, LRA, Random) segfault when evicting slabs with uninitialized slots
+- Slab random eviction failing due to including evicted/zombie slabs in selection
+
 ## [0.2.2] - 2026-01-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "arrow",
  "axum",
@@ -536,7 +536,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cache-core"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "ahash",
  "bytes",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "http2",
@@ -1089,7 +1089,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1269,7 +1269,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "metriken",
 ]
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "grpc",
@@ -2117,14 +2117,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2439,7 +2439,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "axum",
  "bytes",
@@ -2632,7 +2632,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.2.3

This PR prepares the release of v0.2.3.

### Changes
- Version bump across all crates
- Changelog update

### Fixed
- Slab eviction (LRC, LRA, Random) segfault when evicting slabs with uninitialized slots
- Slab random eviction failing due to including evicted/zombie slabs in selection

### After Merge
The release workflow will automatically:
1. Create git tag `v0.2.3`
2. Build and publish release artifacts
3. Bump to next development version (`0.2.4-alpha.0`)

---
See CHANGELOG.md for details.