### PR TITLE
feat(heap): add jemalloc support and Random eviction policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           - segment-merge
           - heap-s3fifo
           - heap-lfu
+          - heap-random
           - slab-lra
           - slab-lrc
           - slab-random

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,6 @@ dependencies = [
  "protocol-resp",
  "rand 0.9.2",
  "rand_xoshiro",
- "ratelimit",
  "ringlog",
  "serde",
  "serde_json",
@@ -1094,6 +1093,7 @@ dependencies = [
  "cache-core",
  "clocksource",
  "loom",
+ "tikv-jemalloc-ctl",
 ]
 
 [[package]]
@@ -2201,17 +2201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratelimit"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
-dependencies = [
- "clocksource",
- "parking_lot",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,6 +2574,7 @@ dependencies = [
  "serde",
  "slab",
  "slab-cache",
+ "tikv-jemallocator",
  "tokio",
  "toml",
  "tracing",
@@ -2797,6 +2787,37 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ metrics = { path = "metrics" }
 # Platform-specific (Linux io_uring)
 io-uring = "0.7"
 
+# Jemalloc allocator
+tikv-jemallocator = "0.6"
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -10,9 +10,10 @@ description = "Heap-allocated cache using system allocator with MultiChoiceHasht
 [features]
 default = []
 loom = ["cache-core/loom", "dep:loom"]
-jemalloc = []
+jemalloc = ["dep:tikv-jemalloc-ctl"]
 
 [dependencies]
 cache-core = { workspace = true }
 clocksource = { workspace = true }
 loom = { workspace = true, optional = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,8 @@ io_uring = ["io-driver/io_uring"]
 # Enables magic bytes and checksum validation for item headers. Useful for
 # debugging corruption issues but adds overhead to every read operation.
 validation = ["segcache/validation", "slab-cache/validation"]
+# Use jemalloc as the global allocator for better memory stats and fragmentation tracking
+jemalloc = ["dep:tikv-jemallocator", "heap-cache/jemalloc"]
 
 [dependencies]
 # Cache core trait
@@ -68,6 +70,9 @@ tokio = { workspace = true, features = ["rt", "net", "sync", "time", "macros"] }
 hyper = { workspace = true, optional = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, optional = true, features = ["tokio"] }
 http-body-util = { workspace = true, optional = true }
+
+# Jemalloc allocator (optional)
+tikv-jemallocator = { workspace = true, optional = true }
 
 [[bin]]
 name = "crucible-server"

--- a/server/config/smoketest/heap-random.toml
+++ b/server/config/smoketest/heap-random.toml
@@ -1,0 +1,18 @@
+# Smoketest: heap backend with random eviction
+runtime = "native"
+
+[workers]
+threads = 2
+
+[cache]
+backend = "heap"
+policy = "random"
+heap_size = "32MB"
+hashtable_power = 14
+
+[[listener]]
+protocol = "resp"
+address = "127.0.0.1:6379"
+
+[metrics]
+address = "127.0.0.1:9090"

--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -1,5 +1,9 @@
 //! Crucible cache server binary.
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::Parser;
 use server::admin::{self, AdminConfig};
 use server::banner::{BannerConfig, print_banner};
@@ -275,6 +279,7 @@ fn create_heap(
     let heap_policy = match policy {
         EvictionPolicy::S3Fifo => HeapEvictionPolicy::S3Fifo,
         EvictionPolicy::Lfu => HeapEvictionPolicy::Lfu,
+        EvictionPolicy::Random => HeapEvictionPolicy::Random,
         _ => unreachable!("invalid policy for heap backend"),
     };
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -345,7 +345,10 @@ impl CacheBackend {
                     | EvictionPolicy::Merge
             ),
             CacheBackend::Heap => {
-                matches!(policy, EvictionPolicy::S3Fifo | EvictionPolicy::Lfu)
+                matches!(
+                    policy,
+                    EvictionPolicy::S3Fifo | EvictionPolicy::Lfu | EvictionPolicy::Random
+                )
             }
             CacheBackend::Slab => matches!(
                 policy,
@@ -362,7 +365,7 @@ impl CacheBackend {
 ///
 /// Not all policies are valid for all backends:
 /// - Segment: s3fifo, fifo, random, cte, merge
-/// - Heap: s3fifo, lfu
+/// - Heap: s3fifo, lfu, random
 /// - Slab: lra, lrc, random, none
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
## Summary

- Add optional jemalloc integration for accurate memory stats and fragmentation detection
- Add Random eviction policy for heap-cache (similar to Redis `allkeys-random`)
- Add `heap-random` smoketest to CI matrix

## Changes

### Jemalloc Integration
- Add `tikv-jemallocator` and `tikv-jemalloc-ctl` workspace dependencies
- `heap-cache`: Implement `query_allocator_memory()` using jemalloc stats when `jemalloc` feature enabled
- `heap-cache`: Add public `jemalloc_fragmentation_ratio()` function (resident/allocated * 100)
- `server`: Add `jemalloc` feature that sets the global allocator and enables heap-cache jemalloc

### Random Eviction Policy
- Add `EvictionPolicy::Random` variant to heap-cache
- Implement `evict_random()` - picks first occupied slot from pseudo-random starting point
- Simple and fast, no frequency tracking overhead
- Useful for workloads where eviction policy doesn't significantly impact hit rate

### CI
- Add `heap-random` configuration to smoketest matrix

## Test plan

- [x] `cargo build` - compiles without jemalloc
- [x] `cargo build -p server --features jemalloc` - compiles with jemalloc
- [x] `cargo test -p heap-cache` - all tests pass (49 tests including 3 new Random tests)
- [x] Smoketest with heap+random policy passes
- [x] CI will run heap-random smoketest

🤖 Generated with [Claude Code](https://claude.ai/code)