### PR TITLE
release: v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.10] - 2026-02-02
+
+### Added
+- `get_or_insert` and `get_or_insert_with` methods on ArcCache for atomic insertion semantics
+- New `crucible-proxy` crate: Redis-compatible caching proxy with local SegCache layer
+  - Thread-per-core architecture with io_uring support
+  - Connection pooling with least-loaded backend selection
+  - Configurable eviction policies (random, fifo, cte, merge, s3fifo)
+  - Automatic cache invalidation on write commands (SET, DEL)
+
+### Changed
+- io_uring driver removes redundant `submit()` call before `submit_and_wait()` (reduces syscalls)
+- Proxy uses sharded counters to eliminate metric contention at high throughput
+
+### Fixed
+- Benchmark parquet recorder now skips snapshots during warmup phase to avoid empty leading data
+
 ## [0.2.9] - 2026-01-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "arrow",
  "axum",
@@ -535,7 +535,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cache-core"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "ahash",
  "bytes",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "http2",
@@ -1088,7 +1088,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1271,7 +1271,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "metriken",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "itoa",
  "memchr",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "bytes",
  "grpc",
@@ -2135,14 +2135,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "itoa",
  "memchr",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ahash",
  "axum",
@@ -2169,6 +2169,7 @@ dependencies = [
  "segcache",
  "serde",
  "slab",
+ "socket2 0.5.10",
  "tikv-jemallocator",
  "tokio",
  "toml",
@@ -2472,7 +2473,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2593,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "axum",
  "bytes",
@@ -2666,7 +2667,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.10-alpha.0"
+version = "0.2.10"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Version bump across all crates (0.2.10-alpha.0 → 0.2.10)
- Changelog update for v0.2.10

### Key Changes in This Release
- New `get_or_insert` and `get_or_insert_with` methods on ArcCache for atomic insertion
- New `crucible-proxy` crate: Redis-compatible caching proxy with local SegCache layer
- io_uring syscall reduction by removing redundant submit() call
- Benchmark parquet recorder fix for warmup phase

## After Merge
The release workflow will automatically:
1. Create git tag `v0.2.10`
2. Build and publish release artifacts
3. Bump to next development version (`0.2.11-alpha.0`)

---
See CHANGELOG.md for full details.

🤖 Generated with [Claude Code](https://claude.ai/code)