### PR TITLE
Release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.12] - 2026-02-05
+
+### Added
+- Prefill mode for cache warmup in benchmark tool
+- Segment compaction on item deletion with spare segment pool
+- Two-queue spare segment pool for compaction operations
+
+### Changed
+- Increased max value size to 4 GiB and segment size to 128 MiB
+- Adaptive threshold for merge eviction policy
+- Removed manual recv_mode and zero_copy config options from io-driver
+
+### Fixed
+- Memory pool now reserves segments for writes (prevents OutOfMemory with small heaps)
+- Server banner now shows configured I/O engine
+- Benchmark excludes prefill/warmup from bandwidth metrics
+- Benchmark division by zero in output formatters
+- Large value responses in server
+- Drain oversized SET values to prevent protocol desync
+
 ## [0.2.11] - 2026-02-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Memory pool now reserves segments for writes (prevents OutOfMemory with small heaps)
+- Memory pool `free_count()` now correctly excludes spare queue from eviction decisions
 - Server banner now shows configured I/O engine
 - Benchmark excludes prefill/warmup from bandwidth metrics
 - Benchmark division by zero in output formatters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adaptive threshold for merge eviction policy
 - Removed manual recv_mode and zero_copy config options from io-driver
 
+### Security
+- Update `bytes` to 1.11.1 to fix integer overflow in `BytesMut::reserve` (CVE-2026-25541)
+
 ### Fixed
 - Memory pool now reserves segments for writes (prevents OutOfMemory with small heaps)
 - Server banner now shows configured I/O engine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "arrow",
  "axum",
@@ -535,7 +535,7 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cache-core"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "ahash",
  "bytes",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "http2",
@@ -1088,7 +1088,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1271,7 +1271,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "metriken",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "itoa",
  "memchr",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "bytes",
  "grpc",
@@ -2135,14 +2135,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "itoa",
  "memchr",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "ahash",
  "axum",
@@ -2473,7 +2473,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "axum",
  "bytes",
@@ -2665,7 +2665,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,9 +529,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ repository = "https://github.com/brayniac/crucible"
 [workspace.dependencies]
 # Shared dependencies across workspace
 ahash = "0.8"
-bytes = "1.10"
+bytes = "1.11.1"
 clap = "4"
 clocksource = "0.8"
 crossbeam-channel = "0.5"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.12-alpha.0"
+version = "0.2.12"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump version from 0.2.12-alpha.0 to 0.2.12
- Update CHANGELOG.md with changes since v0.2.11

## Changes in this release

### Added
- Prefill mode for cache warmup in benchmark tool
- Segment compaction on item deletion with spare segment pool
- Two-queue spare segment pool for compaction operations

### Changed
- Increased max value size to 4 GiB and segment size to 128 MiB
- Adaptive threshold for merge eviction policy
- Removed manual recv_mode and zero_copy config options from io-driver

### Security
- Update `bytes` to 1.11.1 to fix integer overflow in `BytesMut::reserve` (CVE-2026-25541)

### Fixed
- Memory pool now reserves segments for writes (prevents OutOfMemory with small heaps)
- Memory pool `free_count()` now correctly excludes spare queue from eviction decisions
- Server banner now shows configured I/O engine
- Benchmark excludes prefill/warmup from bandwidth metrics
- Benchmark division by zero in output formatters
- Large value responses in server
- Drain oversized SET values to prevent protocol desync

🤖 Generated with [Claude Code](https://claude.com/claude-code)