### PR TITLE
release: v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.16] - 2026-02-08
+
+### Changed
+- Re-enabled io_uring as default I/O engine (was temporarily disabled in 0.2.15)
+- io_uring poll() now drains partial send continuations in a tight loop, matching mio's
+  write loop behavior and eliminating per-partial-send event loop round-trips
+
+### Fixed
+- Benchmark client latency measurement inflated by pipelining: now measures from when bytes
+  are sent to kernel (`sent_at`) instead of when request is encoded into buffer (`queued_at`)
+- Clippy warnings in large value I/O tests
+
 ## [0.2.15] - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "arrow",
  "axum",
@@ -535,7 +535,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-core"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "ahash",
  "bytes",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "http2",
@@ -1088,7 +1088,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1270,7 +1270,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "metriken",
 ]
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "itoa",
  "memchr",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "bytes",
  "grpc",
@@ -2125,14 +2125,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "itoa",
  "memchr",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "ahash",
  "axum",
@@ -2463,7 +2463,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "axum",
  "bytes",
@@ -2655,7 +2655,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.16-alpha.0"
+version = "0.2.16"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/tests/large_value_io_tests.rs
+++ b/server/tests/large_value_io_tests.rs
@@ -573,7 +573,6 @@ fn test_uring_large_values_4m_to_16m() {
         heap_size_mb: 512,
         segment_size_mb: 64,
         max_value_size_mb: 63,
-        ..Default::default()
     });
 }
 
@@ -587,7 +586,6 @@ fn test_uring_large_values_64m() {
         heap_size_mb: 1024,
         segment_size_mb: 128,
         max_value_size_mb: 127,
-        ..Default::default()
     });
 }
 


### PR DESCRIPTION
## Release v0.2.16

This PR prepares the release of v0.2.16.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- **io_uring CQE drain loop**: Partial send continuations are now drained in a tight loop inside `poll()`, eliminating per-partial-send event loop round-trips. This restores io_uring performance to match mio's write loop behavior.
- **io_uring re-enabled as default**: The temporary mio-only default from v0.2.15 is reverted.
- **Benchmark latency fix**: Client now measures latency from `sent_at` (when bytes reach the kernel) instead of `queued_at` (when request is encoded into the send buffer), eliminating inflated latency from pipelining head-of-line blocking.

### After Merge
The release workflow will automatically:
1. Create git tag `v0.2.16`
2. Build and publish release artifacts
3. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.