### PR TITLE
release: v0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.2.18] - 2026-02-09
+
+### Changed
+- io_uring ring setup now uses COOP_TASKRUN and SINGLE_ISSUER flags for reduced context
+  switches and kernel-side lock-free optimizations
+- io_uring send path uses hybrid direct write: tries write() on the raw fd first, falls back
+  to SQE-based send only when the socket buffer is full or sends are in flight
+- io_uring smart poll loop re-waits when only SendReady completions arrive, reducing
+  unnecessary event loop wakeups for the benchmark client
+
+### Fixed
+- io_uring high latency variance under sustained load caused by DEFER_TASKRUN batching CQEs
+- Clippy 1.93 collapsible-if warning in io_uring poll loop
+
 ## [0.2.17] - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "arrow",
  "axum",
@@ -535,7 +535,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-core"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "ahash",
  "bytes",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "http2",
@@ -1088,7 +1088,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "io-driver",
@@ -1270,7 +1270,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-driver"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "metriken",
 ]
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "itoa",
  "memchr",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "bytes",
  "grpc",
@@ -2125,14 +2125,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "itoa",
  "memchr",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "ahash",
  "axum",
@@ -2463,7 +2463,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "axum",
  "bytes",
@@ -2655,7 +2655,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/Cargo.toml
+++ b/io/driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-driver"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/driver/src/uring/mod.rs
+++ b/io/driver/src/uring/mod.rs
@@ -1835,7 +1835,8 @@ impl IoDriver for UringDriver {
         // no buffered data — otherwise we'd send out of order.
         if conn.all_sends_complete() {
             let raw_fd = conn.raw_fd;
-            let n = unsafe { libc::write(raw_fd, data.as_ptr() as *const libc::c_void, data.len()) };
+            let n =
+                unsafe { libc::write(raw_fd, data.as_ptr() as *const libc::c_void, data.len()) };
             if n > 0 {
                 let written = n as usize;
                 if written == data.len() {

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.18-alpha.0"
+version = "0.2.18"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.2.18

This PR prepares the release of v0.2.18.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- io_uring ring setup with COOP_TASKRUN + SINGLE_ISSUER flags
- Hybrid direct-write send path (write() first, SQE fallback)
- Smart poll loop filtering for benchmark client
- Removed DEFER_TASKRUN (caused high latency variance under load)

### After Merge
The release workflow will automatically:
1. Create git tag `v0.2.18`
2. Build and publish release artifacts
3. Bump to next development version (`0.2.19-alpha.0`)

---
See CHANGELOG.md for details.