### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.3.0] - 2026-02-11
+
+### Added
+- New `kompio` I/O framework replacing `io-driver`: push-based io_uring event loop with
+  `EventHandler` trait callbacks, scatter-gather `send_parts()` API, `InFlightSendSlab` for
+  zero-copy SendMsgZc sends, and bundled acceptor/worker thread management
+- Scatter-gather send for large value responses: header + value + trailer sent as a single
+  atomic `SendMsgZc` operation instead of one 16KB chunk per event loop iteration, eliminating
+  ~1.3ms of added latency for 4MB responses
+- `RegionId::UNREGISTERED` sentinel for heap-backed zero-copy guards that skip io_uring
+  fixed buffer validation
+- `cache-bench`: standalone cache benchmarking tool for direct cache library performance testing
+
+### Changed
+- Server, benchmark, and proxy migrated from `io-driver` to `kompio` EventHandler trait
+- Transport types (`TlsTransport`, `PlainTransport`) moved from `io-driver` to `http2` crate
+- CI test matrix reduced to Linux-only (macOS removed; kompio requires io_uring / Linux 6.0+)
+
+### Fixed
+- Non-blocking segment eviction under reader pressure in cache-core
+- All clippy -D warnings across workspace (collapsible_if, redundant_closure, implicit borrow
+  patterns, io_other_error, etc.)
+- Rustdoc invalid HTML tag warnings
+
+### Removed
+- `io-driver` crate (replaced by `kompio`)
+
 ## [0.2.18] - 2026-02-09
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "axum",
@@ -531,7 +531,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-bench"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "cache-core",
  "clap",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "cache-core"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "bytes",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "http2",
@@ -1104,7 +1104,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "rustls",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "kompio"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "io-uring",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "metriken",
 ]
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "itoa",
  "memchr",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "grpc",
@@ -2138,14 +2138,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "itoa",
  "memchr",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "axum",
@@ -2475,7 +2475,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2667,7 +2667,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache-bench/Cargo.toml
+++ b/cache-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-bench"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/kompio/Cargo.toml
+++ b/io/kompio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kompio"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [features]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.19-alpha.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.3.0

This PR prepares the release of v0.3.0.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- **New `kompio` I/O framework** replacing `io-driver`: push-based io_uring event loop with `EventHandler` trait callbacks
- **Scatter-gather send** for large value responses (~1.3ms latency improvement for 4MB GETs)
- **`cache-bench`** standalone cache benchmarking tool
- Non-blocking segment eviction fix
- CI reduced to Linux-only (macOS removed)
- All clippy/doc/fmt warnings resolved

### After Merge
The release workflow will automatically:
1. Create git tag `v0.3.0`
2. Build and publish release artifacts
3. Bump to next development version (`0.3.1-alpha.0`)

---
See CHANGELOG.md for details.