### PR TITLE
Post-v0.3.1 fixes: zero-copy benchmark SETs, HTTP/2 frame clamping, docs

### DIFF
--- a/benchmark/src/config/mod.rs
+++ b/benchmark/src/config/mod.rs
@@ -166,6 +166,10 @@ pub struct Workload {
     /// before the warmup phase begins.
     #[serde(default)]
     pub prefill: bool,
+    /// Maximum time to wait for prefill to complete before aborting.
+    /// Set to "0s" to disable the timeout. Default: 300s.
+    #[serde(default = "default_prefill_timeout", with = "humantime_serde")]
+    pub prefill_timeout: Duration,
     #[serde(default)]
     pub keyspace: Keyspace,
     #[serde(default)]
@@ -250,6 +254,10 @@ fn default_max_rate() -> u64 {
 
 fn default_min_throughput_ratio() -> f64 {
     0.9
+}
+
+fn default_prefill_timeout() -> Duration {
+    Duration::from_secs(300)
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -13,8 +13,8 @@ pub mod worker;
 pub use admin::{AdminHandle, AdminServer};
 pub use config::{Config, parse_cpu_list};
 pub use output::{
-    ColorMode, LatencyStats, OutputFormat, OutputFormatter, Results, Sample, SaturationResults,
-    SaturationStep, create_formatter,
+    ColorMode, LatencyStats, OutputFormat, OutputFormatter, PrefillDiagnostics, PrefillStallCause,
+    Results, Sample, SaturationResults, SaturationStep, create_formatter,
 };
 pub use ratelimit::DynamicRateLimiter;
 pub use saturation::SaturationSearchState;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -4,6 +4,7 @@ use benchmark::ratelimit::DynamicRateLimiter;
 use benchmark::saturation::SaturationSearchState;
 use benchmark::viewer;
 use benchmark::worker::{BenchWorkerConfig, Phase, init_config_channel};
+use benchmark::output::{PrefillDiagnostics, PrefillStallCause};
 use benchmark::{
     AdminServer, LatencyStats, OutputFormatter, Results, Sample, SharedState, create_formatter,
     parse_cpu_list,
@@ -288,6 +289,16 @@ fn run_benchmark(
     // Track when warmup actually starts (after prefill completes)
     let mut warmup_start: Option<Instant> = if prefill_enabled { None } else { Some(start) };
 
+    // Prefill progress tracking
+    let prefill_start = Instant::now();
+    let mut last_prefill_confirmed: usize = 0;
+    let mut last_prefill_progress_time = Instant::now();
+    let mut last_prefill_progress_report = Instant::now();
+    let prefill_timeout = config.workload.prefill_timeout;
+    let prefill_stall_threshold = Duration::from_secs(30);
+    let prefill_progress_interval = Duration::from_secs(5);
+    let mut prefill_timeout_diag: Option<PrefillDiagnostics> = None;
+
     loop {
         std::thread::sleep(Duration::from_millis(100));
 
@@ -315,7 +326,71 @@ fn run_benchmark(
                 current_phase = Phase::Warmup;
                 warmup_start = Some(Instant::now());
                 formatter.print_warmup(warmup);
+                continue;
             }
+
+            let confirmed = shared.prefill_keys_confirmed();
+            let total = shared.prefill_keys_total();
+            let elapsed = prefill_start.elapsed();
+
+            // Progress reporting
+            if last_prefill_progress_report.elapsed() >= prefill_progress_interval && total > 0 {
+                formatter.print_prefill_progress(confirmed, total, elapsed);
+                last_prefill_progress_report = Instant::now();
+            }
+
+            // Track progress for stall detection
+            if confirmed > last_prefill_confirmed {
+                last_prefill_confirmed = confirmed;
+                last_prefill_progress_time = Instant::now();
+            }
+
+            // Stall detection: no progress for 30s after some progress was made
+            let stalled = last_prefill_confirmed > 0
+                && last_prefill_progress_time.elapsed() >= prefill_stall_threshold;
+
+            // Timeout detection (skip if timeout is zero = disabled)
+            let timed_out = !prefill_timeout.is_zero() && elapsed >= prefill_timeout;
+
+            if stalled || timed_out {
+                let conns_active = metrics::CONNECTIONS_ACTIVE.value();
+                let bytes_rx = metrics::BYTES_RX.value();
+                let requests_sent = metrics::REQUESTS_SENT.value();
+
+                let likely_cause = if conns_active == 0 {
+                    PrefillStallCause::NoConnections
+                } else if bytes_rx == 0 {
+                    PrefillStallCause::NoResponses
+                } else if stalled {
+                    PrefillStallCause::Stalled
+                } else if confirmed > 0 && total > confirmed {
+                    // Still progressing but hit timeout - estimate remaining time
+                    let rate = confirmed as f64 / elapsed.as_secs_f64();
+                    let remaining_keys = (total - confirmed) as f64;
+                    let estimated_remaining = if rate > 0.0 {
+                        Duration::from_secs_f64(remaining_keys / rate)
+                    } else {
+                        Duration::from_secs(0)
+                    };
+                    PrefillStallCause::TooSlow { estimated_remaining }
+                } else {
+                    PrefillStallCause::Unknown
+                };
+
+                prefill_timeout_diag = Some(PrefillDiagnostics {
+                    workers_complete: prefill_complete,
+                    workers_total: num_threads,
+                    keys_confirmed: confirmed,
+                    keys_total: total,
+                    elapsed,
+                    conns_active,
+                    bytes_rx,
+                    requests_sent,
+                    likely_cause,
+                });
+                break;
+            }
+
             continue;
         }
 
@@ -451,6 +526,26 @@ fn run_benchmark(
 
             last_report = Instant::now();
         }
+    }
+
+    // Handle prefill timeout/stall
+    if let Some(ref diag) = prefill_timeout_diag {
+        shared.set_phase(Phase::Stop);
+        formatter.print_prefill_timeout(diag);
+
+        // Still shutdown workers cleanly
+        shutdown_handle.shutdown();
+
+        let shutdown_start = Instant::now();
+        for handle in handles {
+            let remaining = WORKER_SHUTDOWN_TIMEOUT.saturating_sub(shutdown_start.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            let _ = handle.join();
+        }
+
+        return Err("prefill failed: timed out or stalled".into());
     }
 
     // Shutdown kompio workers

--- a/benchmark/src/protocol/memcache.rs
+++ b/benchmark/src/protocol/memcache.rs
@@ -117,6 +117,12 @@ impl MemcacheCodec {
         self.pending_responses
     }
 
+    /// Notify the codec that a request was sent (for guard-based send path).
+    /// Increments the pending response counter without encoding anything.
+    pub fn notify_request_sent(&mut self) {
+        self.pending_responses += 1;
+    }
+
     /// Attempts to decode a response from the buffer.
     ///
     /// Returns:

--- a/benchmark/src/protocol/memcache_binary.rs
+++ b/benchmark/src/protocol/memcache_binary.rs
@@ -136,6 +136,15 @@ impl MemcacheBinaryCodec {
         self.pending_responses
     }
 
+    /// Allocate the next opaque value and increment pending responses
+    /// (for guard-based send path where encoding is done externally).
+    pub fn allocate_opaque(&mut self) -> u32 {
+        let opaque = self.next_opaque;
+        self.next_opaque = self.next_opaque.wrapping_add(1);
+        self.pending_responses += 1;
+        opaque
+    }
+
     /// Attempts to decode a response from the buffer.
     ///
     /// Returns:

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -9,7 +9,7 @@ use crate::config::{Config, Protocol as CacheProtocol};
 use crate::metrics;
 use crate::ratelimit::DynamicRateLimiter;
 
-use kompio::{ConnToken, DriverCtx, EventHandler};
+use kompio::{ConnToken, DriverCtx, EventHandler, GuardBox, RegionId, SendGuard};
 
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -166,6 +166,8 @@ pub struct BenchWorkerConfig {
     pub prefill_range: Option<std::ops::Range<usize>>,
     /// CPU IDs for pinning (if configured).
     pub cpu_ids: Option<Vec<usize>>,
+    /// Shared 1GB random value pool (all workers share the same Arc).
+    pub value_pool: Arc<Vec<u8>>,
 }
 
 // ── Config channel (same pattern as server) ──────────────────────────────
@@ -224,6 +226,33 @@ impl RecvBuf for DataSlice<'_> {
     }
 }
 
+// ── ValuePoolGuard ────────────────────────────────────────────────────────
+
+/// Zero-copy send guard referencing a slice of the shared value pool.
+///
+/// When used with `ctx.send_parts().guard()`, the kernel sends directly from
+/// the pool memory via SendMsgZc. The `Arc<Vec<u8>>` keeps the pool alive
+/// until the kernel signals completion.
+///
+/// Size: 8 (Arc ptr) + 4 + 4 = 16 bytes, well within GuardBox's 64-byte limit.
+struct ValuePoolGuard {
+    pool: Arc<Vec<u8>>,
+    offset: u32,
+    len: u32,
+}
+
+impl SendGuard for ValuePoolGuard {
+    fn as_ptr_len(&self) -> (*const u8, u32) {
+        // SAFETY: offset + len is always within the pool bounds (enforced at construction).
+        let ptr = unsafe { self.pool.as_ptr().add(self.offset as usize) };
+        (ptr, self.len)
+    }
+
+    fn region(&self) -> RegionId {
+        RegionId::UNREGISTERED
+    }
+}
+
 // ── BenchHandler ─────────────────────────────────────────────────────────
 
 /// Benchmark worker event handler for kompio.
@@ -250,7 +279,12 @@ pub struct BenchHandler {
     /// Workload generation
     rng: Xoshiro256PlusPlus,
     key_buf: Vec<u8>,
+    /// Value buffer for Momento sessions (they use their own TLS transport, not kompio)
     value_buf: Vec<u8>,
+    /// Shared 1GB random value pool for zero-copy SET sends via send_parts()
+    value_pool: Arc<Vec<u8>>,
+    /// Reusable buffer for SET protocol framing (prefix bytes)
+    set_prefix_buf: Vec<u8>,
 
     /// Results buffer (reused)
     results: Vec<RequestResult>,
@@ -515,14 +549,19 @@ impl BenchHandler {
         let get_ratio = self.config.workload.commands.get;
         let delete_ratio = self.config.workload.commands.delete;
         let recording = self.recording;
+        let value_len = self.config.workload.values.length;
+        let pool_len = self.value_pool.len();
 
         for idx in 0..self.sessions.len() {
-            let session = &mut self.sessions[idx];
-            if !session.is_connected() {
+            if !self.sessions[idx].is_connected() {
                 continue;
             }
 
-            while session.can_send() {
+            loop {
+                if !self.sessions[idx].can_send() {
+                    break;
+                }
+
                 if let Some(ref rl) = self.ratelimiter
                     && !rl.try_acquire()
                 {
@@ -533,59 +572,87 @@ impl BenchHandler {
                 write_key(&mut self.key_buf, key_id);
 
                 let roll = self.rng.random_range(0..100);
-                let sent = if roll < get_ratio {
-                    session.get(&self.key_buf, now).is_some()
+                if roll < get_ratio {
+                    // GET: encode into session buffer, batch-flush later
+                    if self.sessions[idx].get(&self.key_buf, now).is_none() {
+                        break;
+                    }
                 } else if roll < get_ratio + delete_ratio {
-                    session.delete(&self.key_buf, now).is_some()
+                    // DELETE: encode into session buffer, batch-flush later
+                    if self.sessions[idx].delete(&self.key_buf, now).is_none() {
+                        break;
+                    }
                 } else {
-                    self.rng.fill_bytes(&mut self.value_buf);
-                    session.set(&self.key_buf, &self.value_buf, now).is_some()
-                };
+                    // SET: flush any pending GET/DELETE data first, then send via guard
+                    self.flush_session(ctx, idx);
 
-                if sent {
-                    self.requests_driven += 1;
-                    if recording {
-                        metrics::REQUESTS_SENT.increment();
+                    if let Some((_id, suffix)) =
+                        self.sessions[idx].encode_set_guard(&mut self.set_prefix_buf, &self.key_buf, value_len, now)
+                    {
+                        if let Err(e) = self.send_set_parts(ctx, idx, value_len, pool_len, suffix) {
+                            self.send_failures += 1;
+                            if e.kind() != io::ErrorKind::Other {
+                                tracing::debug!(worker = self.id, error = %e, "send_parts error (closing)");
+                                self.close_session(ctx, idx, DisconnectReason::SendError);
+                            }
+                            break;
+                        }
+                    } else {
+                        break;
                     }
                 }
 
-                if !sent {
-                    break;
+                self.requests_driven += 1;
+                if recording {
+                    metrics::REQUESTS_SENT.increment();
                 }
             }
 
-            // Flush send buffer
+            // Flush any remaining GET/DELETE data in the send buffer
             self.flush_session(ctx, idx);
         }
     }
 
     /// Drive prefill requests (sequential SET commands).
     fn drive_prefill_requests(&mut self, ctx: &mut DriverCtx, now: std::time::Instant) {
+        let value_len = self.config.workload.values.length;
+        let pool_len = self.value_pool.len();
+
         for idx in 0..self.sessions.len() {
-            let session = &mut self.sessions[idx];
-            if !session.is_connected() {
+            if !self.sessions[idx].is_connected() {
                 continue;
             }
 
-            while session.can_send() {
+            loop {
+                if !self.sessions[idx].can_send() {
+                    break;
+                }
+
                 let key_id = match self.prefill_pending.pop_front() {
                     Some(id) => id,
                     None => break,
                 };
 
                 write_key(&mut self.key_buf, key_id);
-                self.rng.fill_bytes(&mut self.value_buf);
 
-                if session.set(&self.key_buf, &self.value_buf, now).is_some() {
+                if let Some((_id, suffix)) =
+                    self.sessions[idx].encode_set_guard(&mut self.set_prefix_buf, &self.key_buf, value_len, now)
+                {
+                    if let Err(e) = self.send_set_parts(ctx, idx, value_len, pool_len, suffix) {
+                        self.send_failures += 1;
+                        self.prefill_pending.push_front(key_id);
+                        if e.kind() != io::ErrorKind::Other {
+                            tracing::debug!(worker = self.id, error = %e, "prefill send_parts error (closing)");
+                            self.close_session(ctx, idx, DisconnectReason::SendError);
+                        }
+                        break;
+                    }
                     self.prefill_in_flight[idx].push_back(key_id);
                 } else {
                     self.prefill_pending.push_front(key_id);
                     break;
                 }
             }
-
-            // Flush send buffer
-            self.flush_session(ctx, idx);
         }
     }
 
@@ -605,9 +672,9 @@ impl BenchHandler {
             Some(t) => t,
             None => return,
         };
-        let n = send_buf.len();
 
-        match ctx.send(token, send_buf) {
+        let n = send_buf.len();
+        match ctx.send(token, &send_buf[..n]) {
             Ok(()) => {
                 self.sessions[idx].bytes_sent(n);
             }
@@ -615,7 +682,6 @@ impl BenchHandler {
                 self.send_failures += 1;
                 if e.kind() != io::ErrorKind::Other {
                     tracing::debug!(worker = self.id, error = %e, "send submit error (closing)");
-                    // Real error - close session
                     self.close_session(ctx, idx, DisconnectReason::SendError);
                 } else {
                     tracing::debug!(worker = self.id, error = %e, "send submit pool exhausted");
@@ -623,6 +689,53 @@ impl BenchHandler {
                 // Pool exhausted - wait for on_send_complete
             }
         }
+    }
+
+    /// Submit a guard-based SET send via send_parts().
+    fn send_set_parts(
+        &mut self,
+        ctx: &mut DriverCtx,
+        idx: usize,
+        value_len: usize,
+        pool_len: usize,
+        suffix: &'static [u8],
+    ) -> io::Result<()> {
+        let conn_id = match self.sessions[idx].conn_id() {
+            Some(id) => id,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "session not connected",
+                ));
+            }
+        };
+
+        let token = match self.get_token(conn_id) {
+            Some(t) => t,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "no token for connection",
+                ));
+            }
+        };
+
+        // Pick a random offset into the value pool
+        let max_offset = pool_len - value_len;
+        let offset = self.rng.random_range(0..=max_offset);
+
+        let guard = ValuePoolGuard {
+            pool: Arc::clone(&self.value_pool),
+            offset: offset as u32,
+            len: value_len as u32,
+        };
+
+        let mut builder = ctx.send_parts(token).copy(&self.set_prefix_buf);
+        builder = builder.guard(GuardBox::new(guard));
+        if !suffix.is_empty() {
+            builder = builder.copy(suffix);
+        }
+        builder.submit()
     }
 
     /// Try to reconnect disconnected sessions.
@@ -770,8 +883,9 @@ impl EventHandler for BenchHandler {
         let key_buf = vec![0u8; cfg.config.workload.keyspace.length];
         let mut value_buf = vec![0u8; cfg.config.workload.values.length];
         let pipeline_depth = cfg.config.connection.pipeline_depth;
+        let value_pool = cfg.value_pool;
 
-        // Fill value buffer with random data
+        // Fill value buffer with random data (used only for Momento sessions)
         let mut init_rng = Xoshiro256PlusPlus::seed_from_u64(42);
         init_rng.fill_bytes(&mut value_buf);
 
@@ -823,6 +937,8 @@ impl EventHandler for BenchHandler {
             rng,
             key_buf,
             value_buf,
+            value_pool,
+            set_prefix_buf: Vec::with_capacity(256),
             results: Vec::with_capacity(pipeline_depth),
             ratelimiter: cfg.ratelimiter,
             recording: cfg.recording,

--- a/io/http2/src/connection/mod.rs
+++ b/io/http2/src/connection/mod.rs
@@ -521,7 +521,8 @@ impl<T: Transport> Connection<T> {
                 self.flow_control.available() as usize,
                 stream.send_window() as usize,
             );
-            let to_send = std::cmp::min(available, data.len());
+            let max_frame = self.frame_encoder.max_frame_size() as usize;
+            let to_send = data.len().min(available).min(max_frame);
             let is_end = end_stream && to_send == data.len();
 
             (to_send, is_end)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,7 +1,7 @@
 //! Crucible cache server.
 //!
 //! A high-performance cache server supporting multiple protocols (RESP, Memcache, Momento)
-//! with native io_uring/mio runtime.
+//! with native io_uring runtime via kompio.
 
 pub mod admin;
 pub mod affinity;


### PR DESCRIPTION
## Summary

Cherry-picks post-release fixes from `release/v0.3.1` back to `main`:

- **feat(benchmark): zero-copy SET sends via `send_parts()` + `ValuePoolGuard`** — Fixes benchmark deadlock when `value_size >= 16384` by using kompio's scatter-gather API with a shared 1GB random value pool instead of copying values through the 16KB send pool slots
- **fix(http2): clamp DATA frames to `max_frame_size`** — Prevents HTTP/2 protocol violations when sending large payloads
- **docs: update I/O documentation for factual accuracy** — Corrects architecture docs
- **feat(benchmark): add prefill timeout detection and diagnostics** — Adds stall detection and progress reporting during prefill phase

## Test plan

- [x] `cargo build` — full workspace compiles
- [x] `cargo test -p benchmark` — all 47 tests pass
- [x] `cargo clippy -p benchmark` — no warnings
- [ ] Manual: run benchmark with `value_size = 16384` to verify non-zero throughput
- [ ] Manual: run benchmark with default `value_size = 64` to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)