### PR TITLE
release: v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.3.3] - 2026-02-13
+
+### Fixed
+- Pipelined large-value response stall (kompio): when `process_from` hit write backpressure
+  (pending > 256KB), remaining commands sat in the recv accumulator with no mechanism to resume.
+  Added `replay_accumulated()` to re-invoke `on_data` after send completions drain write capacity
+- Streaming recv CRLF livelock (server): when a large SET value's trailing `\r\n` was split across
+  recv buffers, `continue_streaming_recv()` returned true without consuming data, causing an
+  infinite processing loop. Fixed for RESP, memcache ASCII, and memcache binary protocols
+
 ## [0.3.2] - 2026-02-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "arrow",
  "axum",
@@ -531,7 +531,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-bench"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "cache-core",
  "clap",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "cache-core"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "bytes",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "http2",
@@ -1104,7 +1104,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "rustls",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "kompio"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "crossbeam-channel",
  "io-uring",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "metriken",
 ]
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "bytes",
  "grpc",
@@ -2138,14 +2138,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "axum",
@@ -2475,7 +2475,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "axum",
  "bytes",
@@ -2667,7 +2667,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache-bench/Cargo.toml
+++ b/cache-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-bench"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/kompio/Cargo.toml
+++ b/io/kompio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kompio"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 edition = "2024"
 
 [features]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.3.3-alpha.0"
+version = "0.3.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.3.3

This PR prepares the release of v0.3.3.

### Fixed
- Pipelined large-value response stall (kompio): when `process_from` hit write backpressure (pending > 256KB), remaining commands sat in the recv accumulator with no mechanism to resume. Added `replay_accumulated()` to re-invoke `on_data` after send completions drain write capacity
- Streaming recv CRLF livelock (server): when a large SET value's trailing `\r\n` was split across recv buffers, `continue_streaming_recv()` returned true without consuming data, causing an infinite processing loop. Fixed for RESP, memcache ASCII, and memcache binary protocols

### After Merge
The release workflow will automatically:
1. Create git tag `v0.3.3`
2. Build and publish release artifacts
3. Bump to next development version (`0.3.4-alpha.0`)

---
See CHANGELOG.md for details.