### PR TITLE
fix: resolve rustfmt formatting and clippy lint warnings

### DIFF
--- a/benchmark/src/client/momento.rs
+++ b/benchmark/src/client/momento.rs
@@ -144,7 +144,10 @@ impl MomentoConn {
             return None;
         }
 
-        match self.client.set_with_ttl(&self.cache_name, key, value, self.ttl) {
+        match self
+            .client
+            .set_with_ttl(&self.cache_name, key, value, self.ttl)
+        {
             Ok(_pending) => {
                 let id = self.next_id;
                 self.next_id += 1;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -193,8 +193,7 @@ fn run_benchmark(
                 let start = if eid < key_remainder {
                     eid * (keys_per_worker + 1)
                 } else {
-                    key_remainder * (keys_per_worker + 1)
-                        + (eid - key_remainder) * keys_per_worker
+                    key_remainder * (keys_per_worker + 1) + (eid - key_remainder) * keys_per_worker
                 };
                 let count = if eid < key_remainder {
                     keys_per_worker + 1

--- a/client/src/command.rs
+++ b/client/src/command.rs
@@ -86,12 +86,7 @@ impl Command {
 /// Encode the RESP header for a SET command (everything before the value body).
 ///
 /// Writes: `*<argc>\r\n$3\r\nSET\r\n$<keylen>\r\n<key>\r\n$<vallen>\r\n`
-pub(crate) fn encode_set_header(
-    buf: &mut Vec<u8>,
-    key: &[u8],
-    value_len: usize,
-    has_ttl: bool,
-) {
+pub(crate) fn encode_set_header(buf: &mut Vec<u8>, key: &[u8], value_len: usize, has_ttl: bool) {
     let argc: u8 = if has_ttl { 5 } else { 3 };
     buf.push(b'*');
     push_decimal(buf, argc as u64);
@@ -188,9 +183,9 @@ impl PendingResponse {
                         Ok(Some(Bytes::from(data)))
                     }
                     protocol_resp::Value::Null => Ok(None),
-                    protocol_resp::Value::Error(msg) => {
-                        Err(ClientError::Redis(String::from_utf8_lossy(&msg).into_owned()))
-                    }
+                    protocol_resp::Value::Error(msg) => Err(ClientError::Redis(
+                        String::from_utf8_lossy(&msg).into_owned(),
+                    )),
                     other => Err(ClientError::Protocol(format!(
                         "unexpected GET response: {other:?}",
                     ))),
@@ -200,9 +195,9 @@ impl PendingResponse {
             ResponseKind::Set(tx) => {
                 let result = match value {
                     protocol_resp::Value::SimpleString(ref s) if s == b"OK" => Ok(()),
-                    protocol_resp::Value::Error(msg) => {
-                        Err(ClientError::Redis(String::from_utf8_lossy(&msg).into_owned()))
-                    }
+                    protocol_resp::Value::Error(msg) => Err(ClientError::Redis(
+                        String::from_utf8_lossy(&msg).into_owned(),
+                    )),
                     other => Err(ClientError::Protocol(format!(
                         "unexpected SET response: {other:?}",
                     ))),
@@ -212,9 +207,9 @@ impl PendingResponse {
             ResponseKind::Del(tx) => {
                 let result = match value {
                     protocol_resp::Value::Integer(n) => Ok(n as u64),
-                    protocol_resp::Value::Error(msg) => {
-                        Err(ClientError::Redis(String::from_utf8_lossy(&msg).into_owned()))
-                    }
+                    protocol_resp::Value::Error(msg) => Err(ClientError::Redis(
+                        String::from_utf8_lossy(&msg).into_owned(),
+                    )),
                     other => Err(ClientError::Protocol(format!(
                         "unexpected DEL response: {other:?}",
                     ))),
@@ -224,9 +219,9 @@ impl PendingResponse {
             ResponseKind::Ping(tx) => {
                 let result = match value {
                     protocol_resp::Value::SimpleString(ref s) if s == b"PONG" => Ok(()),
-                    protocol_resp::Value::Error(msg) => {
-                        Err(ClientError::Redis(String::from_utf8_lossy(&msg).into_owned()))
-                    }
+                    protocol_resp::Value::Error(msg) => Err(ClientError::Redis(
+                        String::from_utf8_lossy(&msg).into_owned(),
+                    )),
                     other => Err(ClientError::Protocol(format!(
                         "unexpected PING response: {other:?}",
                     ))),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -38,8 +38,8 @@ pub use error::ClientError;
 pub use latency::ClientLatency;
 
 use std::net::ToSocketAddrs;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::thread;
 
 use bytes::Bytes;
@@ -71,7 +71,11 @@ impl Client {
     /// This is synchronous — it spawns kompio background threads and returns
     /// immediately. Connections are established asynchronously by the workers.
     pub fn connect(config: ClientConfig) -> Result<Self, ClientError> {
-        let num_workers = if config.workers == 0 { 1 } else { config.workers };
+        let num_workers = if config.workers == 0 {
+            1
+        } else {
+            config.workers
+        };
 
         // Resolve server addresses
         let mut server_addrs = Vec::with_capacity(config.servers.len());
@@ -129,8 +133,8 @@ impl Client {
         kompio_config.tick_timeout_us = 10_000; // 10ms tick for reconnects
 
         // Launch without bind (client-only mode)
-        let (shutdown, threads) = kompio::KompioBuilder::new(kompio_config)
-            .launch::<ClientHandler>()?;
+        let (shutdown, threads) =
+            kompio::KompioBuilder::new(kompio_config).launch::<ClientHandler>()?;
 
         // Build WorkerHandle for each worker
         let eventfds = shutdown.worker_eventfds();
@@ -175,11 +179,7 @@ impl Client {
     ///
     /// Accepts any type that converts to `Bytes` — pass `Bytes` directly for
     /// zero-copy, or `&[u8]` / `Vec<u8>` for convenience (copies once).
-    pub async fn set(
-        &self,
-        key: &[u8],
-        value: impl Into<Bytes>,
-    ) -> Result<(), ClientError> {
+    pub async fn set(&self, key: &[u8], value: impl Into<Bytes>) -> Result<(), ClientError> {
         let (tx, rx) = oneshot::channel();
         let cmd = Command::Set {
             key: Bytes::copy_from_slice(key),

--- a/client/src/worker.rs
+++ b/client/src/worker.rs
@@ -200,7 +200,8 @@ impl ClientHandler {
     /// Send a single command on a specific connection.
     fn send_command(&mut self, ctx: &mut DriverCtx, cmd: Command, conn_token: ConnToken) {
         // Check if this is a SET with a value large enough for zero-copy
-        let is_large_set = matches!(&cmd, Command::Set { value, .. } if value.len() >= ZC_THRESHOLD);
+        let is_large_set =
+            matches!(&cmd, Command::Set { value, .. } if value.len() >= ZC_THRESHOLD);
 
         if is_large_set {
             let Command::Set {

--- a/io/kompio/src/chain.rs
+++ b/io/kompio/src/chain.rs
@@ -13,10 +13,7 @@ pub(crate) enum ChainEvent {
     /// All operation CQEs received, but ZC notifications still pending.
     AllOpsComplete,
     /// Chain fully complete (all operation CQEs + all ZC notifications).
-    Complete {
-        bytes_sent: u32,
-        error: Option<i32>,
-    },
+    Complete { bytes_sent: u32, error: Option<i32> },
 }
 
 /// State for a single in-flight send chain on a connection.

--- a/io/kompio/src/event_loop.rs
+++ b/io/kompio/src/event_loop.rs
@@ -1393,7 +1393,12 @@ impl<H: EventHandler> EventLoop<H> {
         send_copy_pool: &mut SendCopyPool,
     ) {
         for built in queue.drain(..) {
-            Self::release_built_resources(send_slab, send_copy_pool, built.pool_slot, built.slab_idx);
+            Self::release_built_resources(
+                send_slab,
+                send_copy_pool,
+                built.pool_slot,
+                built.slab_idx,
+            );
         }
     }
 

--- a/io/kompio/src/handler.rs
+++ b/io/kompio/src/handler.rs
@@ -147,13 +147,9 @@ impl<'a> DriverCtx<'a> {
             conn.index,
             slot as u32,
         );
-        let entry = io_uring::opcode::Send::new(
-            io_uring::types::Fixed(conn.index),
-            ptr,
-            len,
-        )
-        .build()
-        .user_data(user_data.raw());
+        let entry = io_uring::opcode::Send::new(io_uring::types::Fixed(conn.index), ptr, len)
+            .build()
+            .user_data(user_data.raw());
 
         let built = BuiltSend {
             entry,
@@ -741,13 +737,9 @@ impl<'b, 'a> SendBuilder<'b, 'a> {
             self.conn.index,
             slot as u32,
         );
-        let entry = io_uring::opcode::Send::new(
-            io_uring::types::Fixed(self.conn.index),
-            ptr,
-            len,
-        )
-        .build()
-        .user_data(user_data.raw());
+        let entry = io_uring::opcode::Send::new(io_uring::types::Fixed(self.conn.index), ptr, len)
+            .build()
+            .user_data(user_data.raw());
 
         Ok(BuiltSend {
             entry,
@@ -1001,13 +993,9 @@ impl<'b, 'a> SendChainBuilder<'b, 'a> {
             self.conn.index,
             slot as u32,
         );
-        let entry = io_uring::opcode::Send::new(
-            io_uring::types::Fixed(self.conn.index),
-            ptr,
-            len,
-        )
-        .build()
-        .user_data(user_data.raw());
+        let entry = io_uring::opcode::Send::new(io_uring::types::Fixed(self.conn.index), ptr, len)
+            .build()
+            .user_data(user_data.raw());
 
         self.total_bytes += data.len() as u32;
         self.built.push(BuiltSend {
@@ -1060,9 +1048,7 @@ impl<'b, 'a> SendChainBuilder<'b, 'a> {
             // Single SQE — no IO_LINK needed, but register chain state for
             // consistent CQE handling.
             let built = self.built.pop().unwrap();
-            self.ctx
-                .chain_table
-                .start(conn_index, 1, total_bytes);
+            self.ctx.chain_table.start(conn_index, 1, total_bytes);
             unsafe {
                 self.ctx.ring.push_sqe(built.entry)?;
             }
@@ -1206,13 +1192,10 @@ impl<'b, 'a> ChainPartsBuilder<'b, 'a> {
                         conn_index,
                         slot as u32,
                     );
-                    let entry = io_uring::opcode::Send::new(
-                        io_uring::types::Fixed(conn_index),
-                        ptr,
-                        len,
-                    )
-                    .build()
-                    .user_data(user_data.raw());
+                    let entry =
+                        io_uring::opcode::Send::new(io_uring::types::Fixed(conn_index), ptr, len)
+                            .build()
+                            .user_data(user_data.raw());
 
                     BuiltSend {
                         entry,
@@ -1307,8 +1290,7 @@ impl<'b, 'a> ChainPartsBuilder<'b, 'a> {
                             }
                             None => {
                                 self.chain.ctx.send_copy_pool.release(slot);
-                                self.chain.error =
-                                    Some(io::Error::other("send slab exhausted"));
+                                self.chain.error = Some(io::Error::other("send slab exhausted"));
                                 return self.chain;
                             }
                         }

--- a/io/kompio/src/lib.rs
+++ b/io/kompio/src/lib.rs
@@ -26,7 +26,9 @@ pub use config::{Config, RecvBufferConfig, WorkerConfig};
 pub use error::Error;
 pub use event_loop::EventLoop;
 pub use guard::{GuardBox, SendGuard};
-pub use handler::{ConnToken, DriverCtx, EventHandler, SendBuilder, SendChainBuilder, ChainPartsBuilder};
+pub use handler::{
+    ChainPartsBuilder, ConnToken, DriverCtx, EventHandler, SendBuilder, SendChainBuilder,
+};
 #[cfg(feature = "tls")]
 pub use tls::TlsInfo;
 pub use worker::{KompioBuilder, ShutdownHandle, launch};

--- a/io/kompio/src/ring.rs
+++ b/io/kompio/src/ring.rs
@@ -293,10 +293,7 @@ impl Ring {
     ///
     /// # Safety
     /// The SQE must reference valid memory for the lifetime of the operation.
-    pub(crate) unsafe fn push_sqe(
-        &mut self,
-        entry: io_uring::squeue::Entry,
-    ) -> io::Result<()> {
+    pub(crate) unsafe fn push_sqe(&mut self, entry: io_uring::squeue::Entry) -> io::Result<()> {
         // Try to push; if SQ is full, submit first to make room.
         unsafe {
             if self.ring.submission().push(&entry).is_err() {

--- a/server/src/native/handler.rs
+++ b/server/src/native/handler.rs
@@ -313,5 +313,3 @@ fn send_pending(
         }
     }
 }
-
-


### PR DESCRIPTION
Apply rustfmt across the workspace and fix clippy len_zero warning
in benchmark/src/worker.rs (data.len() > 0 -> !data.is_empty()).

https://claude.ai/code/session_015LN1dp2CgYTPx8n2i883os