### PR TITLE
Add NVMe io_uring passthrough implementation plan for kompio

### DIFF
--- a/io/krio/src/async_event_loop.rs
+++ b/io/krio/src/async_event_loop.rs
@@ -250,6 +250,7 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
             OpTag::RecvMsgUdp => self.handle_recv_msg_udp(ud, result),
             OpTag::SendMsgUdp => self.handle_send_msg_udp(ud, result),
             OpTag::NvmeCmd => self.handle_nvme_cmd(ud, result),
+            OpTag::DirectIo => self.handle_direct_io(ud, result),
         }
     }
 
@@ -925,6 +926,31 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
 
         // TODO: wire up NVMe async futures / waker for async API.
         let _ = (device_index, result);
+    }
+
+    fn handle_direct_io(&mut self, ud: UserData, result: i32) {
+        let slab_idx = ud.payload() as u16;
+
+        let cmd_slab = match self.driver.direct_io_cmd_slab {
+            Some(ref mut s) => s,
+            None => return,
+        };
+
+        if !cmd_slab.in_use(slab_idx) {
+            return;
+        }
+
+        let (file_index, _op) = cmd_slab.release(slab_idx);
+
+        // Decrement in-flight count.
+        if let Some(ref mut files) = self.driver.direct_io_files
+            && let Some(f) = files.get_mut(file_index)
+        {
+            f.in_flight = f.in_flight.saturating_sub(1);
+        }
+
+        // TODO: wire up direct I/O async futures / waker for async API.
+        let _ = (file_index, result);
     }
 
     /// Spawn an async task for a newly accepted connection.

--- a/io/krio/src/async_event_loop.rs
+++ b/io/krio/src/async_event_loop.rs
@@ -195,16 +195,19 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
         {
             let cq = self.driver.ring.ring.completion();
             for cqe in cq {
-                self.driver
-                    .cqe_batch
-                    .push((cqe.user_data(), cqe.result(), cqe.flags()));
+                self.driver.cqe_batch.push((
+                    cqe.user_data(),
+                    cqe.result(),
+                    cqe.flags(),
+                    *cqe.big_cqe(),
+                ));
             }
         }
 
         if let Some(interval) = self.driver.flush_interval {
             let mut last_flush = Instant::now();
             for i in 0..self.driver.cqe_batch.len() {
-                let (user_data_raw, result, flags) = self.driver.cqe_batch[i];
+                let (user_data_raw, result, flags, _big_cqe) = self.driver.cqe_batch[i];
                 self.dispatch_cqe(user_data_raw, result, flags);
                 let now = Instant::now();
                 if now.duration_since(last_flush) >= interval {
@@ -214,7 +217,7 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
             }
         } else {
             for i in 0..self.driver.cqe_batch.len() {
-                let (user_data_raw, result, flags) = self.driver.cqe_batch[i];
+                let (user_data_raw, result, flags, _big_cqe) = self.driver.cqe_batch[i];
                 self.dispatch_cqe(user_data_raw, result, flags);
             }
         }
@@ -246,6 +249,7 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
             OpTag::Timer => self.handle_timer(ud, result),
             OpTag::RecvMsgUdp => self.handle_recv_msg_udp(ud, result),
             OpTag::SendMsgUdp => self.handle_send_msg_udp(ud, result),
+            OpTag::NvmeCmd => self.handle_nvme_cmd(ud, result),
         }
     }
 
@@ -896,6 +900,31 @@ impl<A: AsyncEventHandler> AsyncEventLoop<A> {
         }
 
         let _ = result;
+    }
+
+    fn handle_nvme_cmd(&mut self, ud: UserData, result: i32) {
+        let slab_idx = ud.payload() as u16;
+
+        let nvme_cmd_slab = match self.driver.nvme_cmd_slab {
+            Some(ref mut s) => s,
+            None => return,
+        };
+
+        if !nvme_cmd_slab.in_use(slab_idx) {
+            return;
+        }
+
+        let device_index = nvme_cmd_slab.release(slab_idx);
+
+        // Decrement in-flight count.
+        if let Some(ref mut devices) = self.driver.nvme_devices
+            && let Some(dev) = devices.get_mut(device_index)
+        {
+            dev.in_flight = dev.in_flight.saturating_sub(1);
+        }
+
+        // TODO: wire up NVMe async futures / waker for async API.
+        let _ = (device_index, result);
     }
 
     /// Spawn an async task for a newly accepted connection.

--- a/io/krio/src/completion.rs
+++ b/io/krio/src/completion.rs
@@ -27,6 +27,8 @@ pub enum OpTag {
     SendMsgUdp = 14,
     /// NVMe passthrough command (read, write, flush via IORING_OP_URING_CMD).
     NvmeCmd = 15,
+    /// Direct I/O command (read, write, fsync via O_DIRECT + IORING_OP_READ/WRITE).
+    DirectIo = 16,
 }
 
 impl OpTag {
@@ -48,6 +50,7 @@ impl OpTag {
             13 => Some(OpTag::RecvMsgUdp),
             14 => Some(OpTag::SendMsgUdp),
             15 => Some(OpTag::NvmeCmd),
+            16 => Some(OpTag::DirectIo),
             _ => None,
         }
     }

--- a/io/krio/src/completion.rs
+++ b/io/krio/src/completion.rs
@@ -25,6 +25,8 @@ pub enum OpTag {
     RecvMsgUdp = 13,
     /// Copying sendmsg for UDP sockets.
     SendMsgUdp = 14,
+    /// NVMe passthrough command (read, write, flush via IORING_OP_URING_CMD).
+    NvmeCmd = 15,
 }
 
 impl OpTag {
@@ -45,6 +47,7 @@ impl OpTag {
             12 => Some(OpTag::Timer),
             13 => Some(OpTag::RecvMsgUdp),
             14 => Some(OpTag::SendMsgUdp),
+            15 => Some(OpTag::NvmeCmd),
             _ => None,
         }
     }

--- a/io/krio/src/config.rs
+++ b/io/krio/src/config.rs
@@ -88,6 +88,9 @@ pub struct Config {
     /// UDP bind addresses. Each worker creates its own socket with SO_REUSEPORT.
     /// Empty = no UDP sockets.
     pub udp_bind: Vec<SocketAddr>,
+    /// Optional NVMe passthrough configuration. When set, enables NVMe device
+    /// management and `IORING_OP_URING_CMD` submission for direct NVMe I/O.
+    pub nvme: Option<crate::nvme::NvmeConfig>,
 }
 
 impl Default for Config {
@@ -117,6 +120,7 @@ impl Default for Config {
             standalone_task_capacity: 256,
             timer_slots: 256,
             udp_bind: Vec::new(),
+            nvme: None,
         }
     }
 }

--- a/io/krio/src/config.rs
+++ b/io/krio/src/config.rs
@@ -91,6 +91,9 @@ pub struct Config {
     /// Optional NVMe passthrough configuration. When set, enables NVMe device
     /// management and `IORING_OP_URING_CMD` submission for direct NVMe I/O.
     pub nvme: Option<crate::nvme::NvmeConfig>,
+    /// Optional direct I/O configuration. When set, enables `O_DIRECT` file I/O
+    /// via io_uring `IORING_OP_READ` / `IORING_OP_WRITE`, bypassing the page cache.
+    pub direct_io: Option<crate::direct_io::DirectIoConfig>,
 }
 
 impl Default for Config {
@@ -121,6 +124,7 @@ impl Default for Config {
             timer_slots: 256,
             udp_bind: Vec::new(),
             nvme: None,
+            direct_io: None,
         }
     }
 }

--- a/io/krio/src/direct_io.rs
+++ b/io/krio/src/direct_io.rs
@@ -31,7 +31,7 @@ pub enum DirectIoOp {
 
 /// Opaque handle to an opened direct I/O file.
 ///
-/// Returned by [`DriverCtx::open_direct_io_file`] and used to identify the
+/// Returned by [`crate::DriverCtx::open_direct_io_file`] and used to identify the
 /// file in subsequent read/write/fsync/close calls. The handle includes a
 /// generation counter for stale-handle detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -170,7 +170,7 @@ impl DirectIoCmdSlab {
 
 /// Result of a direct I/O command completion.
 ///
-/// Delivered to [`EventHandler::on_direct_io_complete`].
+/// Delivered to [`crate::EventHandler::on_direct_io_complete`].
 #[derive(Debug, Clone)]
 pub struct DirectIoCompletion {
     /// The file this command was submitted to.

--- a/io/krio/src/direct_io.rs
+++ b/io/krio/src/direct_io.rs
@@ -1,0 +1,307 @@
+//! Direct I/O via io_uring (`O_DIRECT` + `IORING_OP_READ` / `IORING_OP_WRITE`).
+//!
+//! This module provides types for submitting asynchronous file I/O through
+//! io_uring using `O_DIRECT`, bypassing the page cache while still going
+//! through the kernel block layer. This is a more portable alternative to
+//! NVMe passthrough — it works on any file or block device, not just NVMe
+//! character devices.
+//!
+//! # Alignment requirements
+//!
+//! `O_DIRECT` requires that:
+//! - Buffer addresses are aligned to the logical block size (typically 512 or 4096 bytes)
+//! - I/O sizes are multiples of the logical block size
+//! - File offsets are multiples of the logical block size
+//!
+//! The caller is responsible for meeting these alignment requirements.
+//! Violating them results in `-EINVAL` from the kernel.
+//!
+//! # Kernel requirements
+//!
+//! - Linux 5.6+ for basic io_uring read/write
+//! - Linux 6.0+ already required by krio for `SendMsgZc`
+
+/// Operation type for tracking what kind of I/O was submitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectIoOp {
+    Read,
+    Write,
+    Fsync,
+}
+
+/// Opaque handle to an opened direct I/O file.
+///
+/// Returned by [`DriverCtx::open_direct_io_file`] and used to identify the
+/// file in subsequent read/write/fsync/close calls. The handle includes a
+/// generation counter for stale-handle detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirectIoFile {
+    pub(crate) index: u16,
+    pub(crate) generation: u16,
+}
+
+impl DirectIoFile {
+    /// Returns the file slot index. Useful for indexing into per-file arrays.
+    pub fn index(&self) -> usize {
+        self.index as usize
+    }
+}
+
+/// Per-file state tracked by the driver.
+pub(crate) struct DirectIoFileState {
+    /// Index in the io_uring fixed file table.
+    pub fd_index: u32,
+    /// Whether this slot is in use.
+    pub active: bool,
+    /// Generation counter for stale-handle detection.
+    pub generation: u16,
+    /// Number of commands currently in flight.
+    pub in_flight: u32,
+}
+
+impl DirectIoFileState {
+    pub fn new() -> Self {
+        DirectIoFileState {
+            fd_index: u32::MAX,
+            active: false,
+            generation: 0,
+            in_flight: 0,
+        }
+    }
+}
+
+/// Tracks direct I/O file slots with allocation/release.
+pub(crate) struct DirectIoFileTable {
+    slots: Vec<DirectIoFileState>,
+    free_list: Vec<u16>,
+}
+
+impl DirectIoFileTable {
+    pub fn new(max_files: u16) -> Self {
+        let mut slots = Vec::with_capacity(max_files as usize);
+        let mut free_list = Vec::with_capacity(max_files as usize);
+        for i in (0..max_files).rev() {
+            slots.push(DirectIoFileState::new());
+            free_list.push(i);
+        }
+        DirectIoFileTable { slots, free_list }
+    }
+
+    pub fn allocate(&mut self) -> Option<u16> {
+        let index = self.free_list.pop()?;
+        let slot = &mut self.slots[index as usize];
+        slot.active = true;
+        Some(index)
+    }
+
+    pub fn release(&mut self, index: u16) {
+        let slot = &mut self.slots[index as usize];
+        slot.active = false;
+        slot.fd_index = u32::MAX;
+        slot.in_flight = 0;
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free_list.push(index);
+    }
+
+    pub fn get(&self, index: u16) -> Option<&DirectIoFileState> {
+        self.slots.get(index as usize).filter(|s| s.active)
+    }
+
+    pub fn get_mut(&mut self, index: u16) -> Option<&mut DirectIoFileState> {
+        self.slots.get_mut(index as usize).filter(|s| s.active)
+    }
+}
+
+/// Per-command tracking entry in the command slab.
+struct DirectIoCmdEntry {
+    /// File slot index.
+    file_index: u16,
+    /// Operation type (read, write, fsync).
+    op: DirectIoOp,
+    /// Whether this slot is in use.
+    in_use: bool,
+}
+
+/// Tracks in-flight direct I/O commands for resource cleanup on completion.
+pub(crate) struct DirectIoCmdSlab {
+    entries: Vec<DirectIoCmdEntry>,
+    free_list: Vec<u16>,
+}
+
+impl DirectIoCmdSlab {
+    pub fn new(capacity: u16) -> Self {
+        let mut entries = Vec::with_capacity(capacity as usize);
+        let mut free_list = Vec::with_capacity(capacity as usize);
+        for i in (0..capacity).rev() {
+            entries.push(DirectIoCmdEntry {
+                file_index: 0,
+                op: DirectIoOp::Read,
+                in_use: false,
+            });
+            free_list.push(i);
+        }
+        DirectIoCmdSlab { entries, free_list }
+    }
+
+    /// Allocate a command slot. Returns the slab index.
+    pub fn allocate(&mut self, file_index: u16, op: DirectIoOp) -> Option<u16> {
+        let idx = self.free_list.pop()?;
+        let entry = &mut self.entries[idx as usize];
+        entry.file_index = file_index;
+        entry.op = op;
+        entry.in_use = true;
+        Some(idx)
+    }
+
+    /// Release a command slot. Returns (file_index, op).
+    pub fn release(&mut self, idx: u16) -> (u16, DirectIoOp) {
+        let entry = &mut self.entries[idx as usize];
+        let file_index = entry.file_index;
+        let op = entry.op;
+        entry.in_use = false;
+        self.free_list.push(idx);
+        (file_index, op)
+    }
+
+    pub fn in_use(&self, idx: u16) -> bool {
+        self.entries.get(idx as usize).is_some_and(|e| e.in_use)
+    }
+}
+
+/// Result of a direct I/O command completion.
+///
+/// Delivered to [`EventHandler::on_direct_io_complete`].
+#[derive(Debug, Clone)]
+pub struct DirectIoCompletion {
+    /// The file this command was submitted to.
+    pub file: DirectIoFile,
+    /// The operation type (read, write, or fsync).
+    pub op: DirectIoOp,
+    /// Command slab sequence number (from the return value of the submit method).
+    pub seq: u32,
+    /// io_uring result code. For read/write: bytes transferred on success.
+    /// Negative values are -errno.
+    pub result: i32,
+}
+
+impl DirectIoCompletion {
+    /// Whether the command completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.result >= 0
+    }
+
+    /// Returns the number of bytes transferred, if the operation succeeded.
+    pub fn bytes_transferred(&self) -> Option<u32> {
+        if self.result >= 0 {
+            Some(self.result as u32)
+        } else {
+            None
+        }
+    }
+}
+
+/// Configuration for direct I/O support.
+///
+/// When present in [`Config`](crate::config::Config), enables direct I/O file
+/// management and allocates file/command tracking structures.
+#[derive(Clone, Debug)]
+pub struct DirectIoConfig {
+    /// Maximum number of files that can be opened simultaneously.
+    pub max_files: u16,
+    /// Maximum I/O commands in flight across all files per worker.
+    pub max_commands_in_flight: u16,
+}
+
+impl Default for DirectIoConfig {
+    fn default() -> Self {
+        DirectIoConfig {
+            max_files: 8,
+            max_commands_in_flight: 256,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_table_alloc_release() {
+        let mut table = DirectIoFileTable::new(4);
+        let a = table.allocate().unwrap();
+        let b = table.allocate().unwrap();
+        assert_ne!(a, b);
+        assert!(table.get(a).is_some());
+
+        table.release(a);
+        assert!(table.get(a).is_none());
+
+        // Re-allocate reuses the slot.
+        let c = table.allocate().unwrap();
+        assert_eq!(c, a);
+        // Generation incremented.
+        assert_eq!(table.get(c).unwrap().generation, 1);
+    }
+
+    #[test]
+    fn cmd_slab_alloc_release() {
+        let mut slab = DirectIoCmdSlab::new(8);
+        let a = slab.allocate(0, DirectIoOp::Read).unwrap();
+        let b = slab.allocate(1, DirectIoOp::Write).unwrap();
+        assert!(slab.in_use(a));
+        assert!(slab.in_use(b));
+
+        let (file, op) = slab.release(a);
+        assert_eq!(file, 0);
+        assert_eq!(op, DirectIoOp::Read);
+        assert!(!slab.in_use(a));
+
+        let (file, op) = slab.release(b);
+        assert_eq!(file, 1);
+        assert_eq!(op, DirectIoOp::Write);
+    }
+
+    #[test]
+    fn cmd_slab_fsync() {
+        let mut slab = DirectIoCmdSlab::new(4);
+        let a = slab.allocate(2, DirectIoOp::Fsync).unwrap();
+        let (file, op) = slab.release(a);
+        assert_eq!(file, 2);
+        assert_eq!(op, DirectIoOp::Fsync);
+    }
+
+    #[test]
+    fn file_table_exhaustion() {
+        let mut table = DirectIoFileTable::new(2);
+        assert!(table.allocate().is_some());
+        assert!(table.allocate().is_some());
+        assert!(table.allocate().is_none());
+    }
+
+    #[test]
+    fn completion_bytes_transferred() {
+        let success = DirectIoCompletion {
+            file: DirectIoFile {
+                index: 0,
+                generation: 0,
+            },
+            op: DirectIoOp::Read,
+            seq: 0,
+            result: 4096,
+        };
+        assert!(success.is_success());
+        assert_eq!(success.bytes_transferred(), Some(4096));
+
+        let failure = DirectIoCompletion {
+            file: DirectIoFile {
+                index: 0,
+                generation: 0,
+            },
+            op: DirectIoOp::Write,
+            seq: 1,
+            result: -libc::EINVAL,
+        };
+        assert!(!failure.is_success());
+        assert_eq!(failure.bytes_transferred(), None);
+    }
+}

--- a/io/krio/src/driver.rs
+++ b/io/krio/src/driver.rs
@@ -158,6 +158,12 @@ pub(crate) struct Driver {
     /// Base offset in the fixed file table for NVMe device fds.
     /// NVMe devices are registered at `nvme_fd_base + device_index`.
     pub(crate) nvme_fd_base: u32,
+    /// Direct I/O file tracking table. `None` when direct I/O is not configured.
+    pub(crate) direct_io_files: Option<crate::direct_io::DirectIoFileTable>,
+    /// Direct I/O command slab for tracking in-flight commands. `None` when not configured.
+    pub(crate) direct_io_cmd_slab: Option<crate::direct_io::DirectIoCmdSlab>,
+    /// Base offset in the fixed file table for direct I/O file fds.
+    pub(crate) direct_io_fd_base: u32,
 }
 
 impl Driver {
@@ -184,10 +190,17 @@ impl Driver {
             .as_ref()
             .map(|n| n.max_devices as u32)
             .unwrap_or(0);
+        let direct_io_max = config
+            .direct_io
+            .as_ref()
+            .map(|d| d.max_files as u32)
+            .unwrap_or(0);
 
         // Register resources with the kernel
         ring.register_buffers(&fixed_buffers)?;
-        ring.register_files_sparse(config.max_connections + udp_count + nvme_max)?;
+        ring.register_files_sparse(
+            config.max_connections + udp_count + nvme_max + direct_io_max,
+        )?;
         ring.register_buf_ring(&provided_bufs)?;
 
         let connections = ConnectionTable::new(config.max_connections);
@@ -293,6 +306,15 @@ impl Driver {
                 .as_ref()
                 .map(|n| crate::nvme::NvmeCmdSlab::new(n.max_commands_in_flight)),
             nvme_fd_base: config.max_connections + udp_count,
+            direct_io_files: config
+                .direct_io
+                .as_ref()
+                .map(|d| crate::direct_io::DirectIoFileTable::new(d.max_files)),
+            direct_io_cmd_slab: config
+                .direct_io
+                .as_ref()
+                .map(|d| crate::direct_io::DirectIoCmdSlab::new(d.max_commands_in_flight)),
+            direct_io_fd_base: config.max_connections + udp_count + nvme_max,
         };
 
         // Submit initial recvmsg for each UDP socket.
@@ -335,6 +357,9 @@ impl Driver {
             nvme_devices: &mut self.nvme_devices,
             nvme_cmd_slab: &mut self.nvme_cmd_slab,
             nvme_fd_base: self.nvme_fd_base,
+            direct_io_files: &mut self.direct_io_files,
+            direct_io_cmd_slab: &mut self.direct_io_cmd_slab,
+            direct_io_fd_base: self.direct_io_fd_base,
         }
     }
 

--- a/io/krio/src/driver.rs
+++ b/io/krio/src/driver.rs
@@ -198,9 +198,7 @@ impl Driver {
 
         // Register resources with the kernel
         ring.register_buffers(&fixed_buffers)?;
-        ring.register_files_sparse(
-            config.max_connections + udp_count + nvme_max + direct_io_max,
-        )?;
+        ring.register_files_sparse(config.max_connections + udp_count + nvme_max + direct_io_max)?;
         ring.register_buf_ring(&provided_bufs)?;
 
         let connections = ConnectionTable::new(config.max_connections);

--- a/io/krio/src/driver.rs
+++ b/io/krio/src/driver.rs
@@ -133,7 +133,9 @@ pub(crate) struct Driver {
     /// Pre-allocated timespec storage for connect timeouts.
     pub(crate) connect_timespecs: Vec<io_uring::types::Timespec>,
     /// Pre-allocated batch buffer for draining CQEs.
-    pub(crate) cqe_batch: Vec<(u64, i32, u32)>,
+    /// Tuple: (user_data, result, flags, big_cqe). The big_cqe field
+    /// contains the extra 16 bytes from Entry32 CQEs (used by NVMe passthrough).
+    pub(crate) cqe_batch: Vec<(u64, i32, u32, [u64; 2])>,
     /// Whether to set TCP_NODELAY on connections.
     pub(crate) tcp_nodelay: bool,
     /// Per-connection send chain tracking for IOSQE_IO_LINK chains.
@@ -149,6 +151,13 @@ pub(crate) struct Driver {
     pub(crate) tick_timeout_armed: bool,
     /// Per-worker UDP socket state.
     pub(crate) udp_sockets: Vec<UdpSocketState>,
+    /// NVMe device tracking table. `None` when NVMe is not configured.
+    pub(crate) nvme_devices: Option<crate::nvme::NvmeDeviceTable>,
+    /// NVMe command slab for tracking in-flight commands. `None` when NVMe is not configured.
+    pub(crate) nvme_cmd_slab: Option<crate::nvme::NvmeCmdSlab>,
+    /// Base offset in the fixed file table for NVMe device fds.
+    /// NVMe devices are registered at `nvme_fd_base + device_index`.
+    pub(crate) nvme_fd_base: u32,
 }
 
 impl Driver {
@@ -170,10 +179,15 @@ impl Driver {
         )?;
 
         let udp_count = config.udp_bind.len() as u32;
+        let nvme_max = config
+            .nvme
+            .as_ref()
+            .map(|n| n.max_devices as u32)
+            .unwrap_or(0);
 
         // Register resources with the kernel
         ring.register_buffers(&fixed_buffers)?;
-        ring.register_files_sparse(config.max_connections + udp_count)?;
+        ring.register_files_sparse(config.max_connections + udp_count + nvme_max)?;
         ring.register_buf_ring(&provided_bufs)?;
 
         let connections = ConnectionTable::new(config.max_connections);
@@ -270,6 +284,15 @@ impl Driver {
             },
             tick_timeout_armed: false,
             udp_sockets,
+            nvme_devices: config
+                .nvme
+                .as_ref()
+                .map(|n| crate::nvme::NvmeDeviceTable::new(n.max_devices)),
+            nvme_cmd_slab: config
+                .nvme
+                .as_ref()
+                .map(|n| crate::nvme::NvmeCmdSlab::new(n.max_commands_in_flight)),
+            nvme_fd_base: config.max_connections + udp_count,
         };
 
         // Submit initial recvmsg for each UDP socket.
@@ -309,6 +332,9 @@ impl Driver {
             max_chain_length: self.max_chain_length,
             send_queues: &mut self.send_queues,
             udp_sockets: &mut self.udp_sockets,
+            nvme_devices: &mut self.nvme_devices,
+            nvme_cmd_slab: &mut self.nvme_cmd_slab,
+            nvme_fd_base: self.nvme_fd_base,
         }
     }
 
@@ -596,13 +622,17 @@ impl Driver {
             {
                 let cq = self.ring.ring.completion();
                 for cqe in cq {
-                    self.cqe_batch
-                        .push((cqe.user_data(), cqe.result(), cqe.flags()));
+                    self.cqe_batch.push((
+                        cqe.user_data(),
+                        cqe.result(),
+                        cqe.flags(),
+                        *cqe.big_cqe(),
+                    ));
                 }
             }
 
             for i in 0..self.cqe_batch.len() {
-                let (user_data_raw, _result, flags) = self.cqe_batch[i];
+                let (user_data_raw, _result, flags, _big_cqe) = self.cqe_batch[i];
                 let ud = UserData(user_data_raw);
                 let tag = match ud.tag() {
                     Some(t) => t,

--- a/io/krio/src/event_loop.rs
+++ b/io/krio/src/event_loop.rs
@@ -150,6 +150,7 @@ impl<H: EventHandler> EventLoop<H> {
             OpTag::RecvMsgUdp => self.handle_recv_msg_udp(ud, result),
             OpTag::SendMsgUdp => self.handle_send_msg_udp(ud, result),
             OpTag::NvmeCmd => self.handle_nvme_cmd(ud, result),
+            OpTag::DirectIo => self.handle_direct_io(ud, result),
         }
     }
 
@@ -194,6 +195,50 @@ impl<H: EventHandler> EventLoop<H> {
 
         let mut ctx = self.driver.make_ctx();
         self.handler.on_nvme_complete(&mut ctx, completion);
+    }
+
+    fn handle_direct_io(&mut self, ud: UserData, result: i32) {
+        let slab_idx = ud.payload() as u16;
+
+        let cmd_slab = match self.driver.direct_io_cmd_slab {
+            Some(ref mut s) => s,
+            None => return,
+        };
+
+        if !cmd_slab.in_use(slab_idx) {
+            return;
+        }
+
+        let (file_index, op) = cmd_slab.release(slab_idx);
+
+        // Decrement in-flight count.
+        if let Some(ref mut files) = self.driver.direct_io_files
+            && let Some(f) = files.get_mut(file_index)
+        {
+            f.in_flight = f.in_flight.saturating_sub(1);
+        }
+
+        // Build completion and fire callback.
+        let generation = self
+            .driver
+            .direct_io_files
+            .as_ref()
+            .and_then(|f| f.get(file_index))
+            .map(|f| f.generation)
+            .unwrap_or(0);
+
+        let completion = crate::direct_io::DirectIoCompletion {
+            file: crate::direct_io::DirectIoFile {
+                index: file_index,
+                generation,
+            },
+            op,
+            seq: slab_idx as u32,
+            result,
+        };
+
+        let mut ctx = self.driver.make_ctx();
+        self.handler.on_direct_io_complete(&mut ctx, completion);
     }
 
     fn handle_recv_multi(&mut self, ud: UserData, result: i32, flags: u32) {
@@ -966,6 +1011,9 @@ fn call_on_data<H: EventHandler>(
         nvme_devices: &mut driver.nvme_devices,
         nvme_cmd_slab: &mut driver.nvme_cmd_slab,
         nvme_fd_base: driver.nvme_fd_base,
+        direct_io_files: &mut driver.direct_io_files,
+        direct_io_cmd_slab: &mut driver.direct_io_cmd_slab,
+        direct_io_fd_base: driver.direct_io_fd_base,
     };
     let consumed = handler.on_data(&mut ctx, token, data);
     driver.accumulators.consume(conn_index, consumed);

--- a/io/krio/src/event_loop.rs
+++ b/io/krio/src/event_loop.rs
@@ -95,16 +95,19 @@ impl<H: EventHandler> EventLoop<H> {
         {
             let cq = self.driver.ring.ring.completion();
             for cqe in cq {
-                self.driver
-                    .cqe_batch
-                    .push((cqe.user_data(), cqe.result(), cqe.flags()));
+                self.driver.cqe_batch.push((
+                    cqe.user_data(),
+                    cqe.result(),
+                    cqe.flags(),
+                    *cqe.big_cqe(),
+                ));
             }
         }
 
         if let Some(interval) = self.driver.flush_interval {
             let mut last_flush = Instant::now();
             for i in 0..self.driver.cqe_batch.len() {
-                let (user_data_raw, result, flags) = self.driver.cqe_batch[i];
+                let (user_data_raw, result, flags, _big_cqe) = self.driver.cqe_batch[i];
                 self.dispatch_cqe(user_data_raw, result, flags);
                 let now = Instant::now();
                 if now.duration_since(last_flush) >= interval {
@@ -114,7 +117,7 @@ impl<H: EventHandler> EventLoop<H> {
             }
         } else {
             for i in 0..self.driver.cqe_batch.len() {
-                let (user_data_raw, result, flags) = self.driver.cqe_batch[i];
+                let (user_data_raw, result, flags, _big_cqe) = self.driver.cqe_batch[i];
                 self.dispatch_cqe(user_data_raw, result, flags);
             }
         }
@@ -146,7 +149,51 @@ impl<H: EventHandler> EventLoop<H> {
             OpTag::Timer => {} // only used in async event loop
             OpTag::RecvMsgUdp => self.handle_recv_msg_udp(ud, result),
             OpTag::SendMsgUdp => self.handle_send_msg_udp(ud, result),
+            OpTag::NvmeCmd => self.handle_nvme_cmd(ud, result),
         }
+    }
+
+    fn handle_nvme_cmd(&mut self, ud: UserData, result: i32) {
+        let slab_idx = ud.payload() as u16;
+
+        let nvme_cmd_slab = match self.driver.nvme_cmd_slab {
+            Some(ref mut s) => s,
+            None => return,
+        };
+
+        if !nvme_cmd_slab.in_use(slab_idx) {
+            return;
+        }
+
+        let device_index = nvme_cmd_slab.release(slab_idx);
+
+        // Decrement in-flight count.
+        if let Some(ref mut devices) = self.driver.nvme_devices
+            && let Some(dev) = devices.get_mut(device_index)
+        {
+            dev.in_flight = dev.in_flight.saturating_sub(1);
+        }
+
+        // Build completion and fire callback.
+        let generation = self
+            .driver
+            .nvme_devices
+            .as_ref()
+            .and_then(|d| d.get(device_index))
+            .map(|d| d.generation)
+            .unwrap_or(0);
+
+        let completion = crate::nvme::NvmeCompletion {
+            device: crate::nvme::NvmeDevice {
+                index: device_index,
+                generation,
+            },
+            seq: slab_idx as u32,
+            result,
+        };
+
+        let mut ctx = self.driver.make_ctx();
+        self.handler.on_nvme_complete(&mut ctx, completion);
     }
 
     fn handle_recv_multi(&mut self, ud: UserData, result: i32, flags: u32) {
@@ -916,6 +963,9 @@ fn call_on_data<H: EventHandler>(
         max_chain_length: driver.max_chain_length,
         send_queues: &mut driver.send_queues,
         udp_sockets: &mut driver.udp_sockets,
+        nvme_devices: &mut driver.nvme_devices,
+        nvme_cmd_slab: &mut driver.nvme_cmd_slab,
+        nvme_fd_base: driver.nvme_fd_base,
     };
     let consumed = handler.on_data(&mut ctx, token, data);
     driver.accumulators.consume(conn_index, consumed);

--- a/io/krio/src/handler.rs
+++ b/io/krio/src/handler.rs
@@ -794,10 +794,7 @@ impl<'a> DriverCtx<'a> {
     }
 
     /// Validate an NVMe device handle and return (fd_index, nsid).
-    fn validate_nvme_device(
-        &self,
-        device: crate::nvme::NvmeDevice,
-    ) -> io::Result<(u32, u32)> {
+    fn validate_nvme_device(&self, device: crate::nvme::NvmeDevice) -> io::Result<(u32, u32)> {
         let devices = self
             .nvme_devices
             .as_ref()
@@ -950,7 +947,10 @@ impl<'a> DriverCtx<'a> {
             slab_idx as u32,
         );
 
-        match unsafe { self.ring.submit_direct_write(fd_index, buf, len, offset, ud) } {
+        match unsafe {
+            self.ring
+                .submit_direct_write(fd_index, buf, len, offset, ud)
+        } {
             Ok(()) => {
                 if let Some(files) = self.direct_io_files.as_mut()
                     && let Some(f) = files.get_mut(file.index)
@@ -971,10 +971,7 @@ impl<'a> DriverCtx<'a> {
     /// Submit an fsync for a direct I/O file.
     ///
     /// Returns the command slab index (sequence number) for correlation.
-    pub fn direct_io_fsync(
-        &mut self,
-        file: crate::direct_io::DirectIoFile,
-    ) -> io::Result<u32> {
+    pub fn direct_io_fsync(&mut self, file: crate::direct_io::DirectIoFile) -> io::Result<u32> {
         let fd_index = self.validate_direct_io_file(file)?;
 
         let slab = self
@@ -1010,10 +1007,7 @@ impl<'a> DriverCtx<'a> {
     }
 
     /// Close a direct I/O file.
-    pub fn close_direct_io_file(
-        &mut self,
-        file: crate::direct_io::DirectIoFile,
-    ) -> io::Result<()> {
+    pub fn close_direct_io_file(&mut self, file: crate::direct_io::DirectIoFile) -> io::Result<()> {
         let fd_index = self.validate_direct_io_file(file)?;
 
         // Unregister from the fixed file table.
@@ -1027,10 +1021,7 @@ impl<'a> DriverCtx<'a> {
     }
 
     /// Validate a direct I/O file handle and return the fd_index.
-    fn validate_direct_io_file(
-        &self,
-        file: crate::direct_io::DirectIoFile,
-    ) -> io::Result<u32> {
+    fn validate_direct_io_file(&self, file: crate::direct_io::DirectIoFile) -> io::Result<u32> {
         let files = self
             .direct_io_files
             .as_ref()

--- a/io/krio/src/handler.rs
+++ b/io/krio/src/handler.rs
@@ -86,6 +86,12 @@ pub struct DriverCtx<'a> {
     pub(crate) send_queues: &'a mut Vec<ConnSendState>,
     /// Per-worker UDP socket state.
     pub(crate) udp_sockets: &'a mut Vec<crate::driver::UdpSocketState>,
+    /// NVMe device table. `None` when NVMe is not configured.
+    pub(crate) nvme_devices: &'a mut Option<crate::nvme::NvmeDeviceTable>,
+    /// NVMe command slab. `None` when NVMe is not configured.
+    pub(crate) nvme_cmd_slab: &'a mut Option<crate::nvme::NvmeCmdSlab>,
+    /// Base offset in the fixed file table for NVMe device fds.
+    pub(crate) nvme_fd_base: u32,
 }
 
 impl<'a> DriverCtx<'a> {
@@ -571,6 +577,232 @@ impl<'a> DriverCtx<'a> {
         let target_ud = crate::completion::UserData::encode(target_tag, conn.index, 0);
         self.ring.submit_async_cancel(target_ud.raw(), conn.index)?;
         Ok(())
+    }
+
+    // ── NVMe passthrough methods ──────────────────────────────────────────
+
+    /// Open an NVMe device for passthrough I/O.
+    ///
+    /// `path` must be an NVMe-generic character device (e.g., `/dev/ng0n1`).
+    /// `nsid` is the NVMe namespace ID (usually 1).
+    ///
+    /// The device fd is registered in the io_uring fixed file table. Returns
+    /// an [`NvmeDevice`](crate::nvme::NvmeDevice) handle for subsequent operations.
+    pub fn open_nvme_device(
+        &mut self,
+        path: &str,
+        nsid: u32,
+    ) -> io::Result<crate::nvme::NvmeDevice> {
+        let devices = self
+            .nvme_devices
+            .as_mut()
+            .ok_or_else(|| io::Error::other("NVMe not configured"))?;
+
+        let index = devices
+            .allocate()
+            .ok_or_else(|| io::Error::other("NVMe device table full"))?;
+
+        // Open the NVMe-generic character device.
+        let c_path =
+            std::ffi::CString::new(path).map_err(|_| io::Error::other("invalid device path"))?;
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDWR) };
+        if fd < 0 {
+            devices.release(index);
+            return Err(io::Error::last_os_error());
+        }
+
+        // Register in the fixed file table.
+        let fd_index = self.nvme_fd_base + index as u32;
+        if self.ring.register_files_update(fd_index, &[fd]).is_err() {
+            devices.release(index);
+            unsafe {
+                libc::close(fd);
+            }
+            return Err(io::Error::other("failed to register NVMe fd"));
+        }
+        unsafe {
+            libc::close(fd);
+        }
+
+        // Store device state.
+        if let Some(dev) = devices.get_mut(index) {
+            dev.fd_index = fd_index;
+            dev.nsid = nsid;
+        }
+
+        let generation = devices.get(index).map(|d| d.generation).unwrap_or(0);
+        Ok(crate::nvme::NvmeDevice { index, generation })
+    }
+
+    /// Submit an NVMe read command.
+    ///
+    /// Reads `num_blocks` logical blocks starting at `lba` into the buffer
+    /// at `buf_addr` with length `buf_len`. The buffer must remain valid
+    /// until [`on_nvme_complete`](EventHandler::on_nvme_complete) fires.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    pub fn nvme_read(
+        &mut self,
+        device: crate::nvme::NvmeDevice,
+        lba: u64,
+        num_blocks: u16,
+        buf_addr: u64,
+        buf_len: u32,
+    ) -> io::Result<u32> {
+        let (fd_index, nsid) = self.validate_nvme_device(device)?;
+
+        let slab = self
+            .nvme_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("NVMe not configured"))?;
+        let slab_idx = slab
+            .allocate(device.index)
+            .ok_or_else(|| io::Error::other("NVMe command slab exhausted"))?;
+
+        let cmd = crate::nvme::NvmeUringCmd::read(nsid, lba, num_blocks, buf_addr, buf_len);
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::NvmeCmd,
+            device.index as u32,
+            slab_idx as u32,
+        );
+
+        match unsafe { self.ring.submit_nvme_cmd(fd_index, &cmd, ud) } {
+            Ok(()) => {
+                if let Some(devices) = self.nvme_devices.as_mut()
+                    && let Some(dev) = devices.get_mut(device.index)
+                {
+                    dev.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.nvme_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Submit an NVMe write command.
+    ///
+    /// Writes `num_blocks` logical blocks starting at `lba` from the buffer
+    /// at `buf_addr` with length `buf_len`. The buffer must remain valid
+    /// until [`on_nvme_complete`](EventHandler::on_nvme_complete) fires.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    pub fn nvme_write(
+        &mut self,
+        device: crate::nvme::NvmeDevice,
+        lba: u64,
+        num_blocks: u16,
+        buf_addr: u64,
+        buf_len: u32,
+    ) -> io::Result<u32> {
+        let (fd_index, nsid) = self.validate_nvme_device(device)?;
+
+        let slab = self
+            .nvme_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("NVMe not configured"))?;
+        let slab_idx = slab
+            .allocate(device.index)
+            .ok_or_else(|| io::Error::other("NVMe command slab exhausted"))?;
+
+        let cmd = crate::nvme::NvmeUringCmd::write(nsid, lba, num_blocks, buf_addr, buf_len);
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::NvmeCmd,
+            device.index as u32,
+            slab_idx as u32,
+        );
+
+        match unsafe { self.ring.submit_nvme_cmd(fd_index, &cmd, ud) } {
+            Ok(()) => {
+                if let Some(devices) = self.nvme_devices.as_mut()
+                    && let Some(dev) = devices.get_mut(device.index)
+                {
+                    dev.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.nvme_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Submit an NVMe flush command.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    pub fn nvme_flush(&mut self, device: crate::nvme::NvmeDevice) -> io::Result<u32> {
+        let (fd_index, nsid) = self.validate_nvme_device(device)?;
+
+        let slab = self
+            .nvme_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("NVMe not configured"))?;
+        let slab_idx = slab
+            .allocate(device.index)
+            .ok_or_else(|| io::Error::other("NVMe command slab exhausted"))?;
+
+        let cmd = crate::nvme::NvmeUringCmd::flush(nsid);
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::NvmeCmd,
+            device.index as u32,
+            slab_idx as u32,
+        );
+
+        match unsafe { self.ring.submit_nvme_cmd(fd_index, &cmd, ud) } {
+            Ok(()) => {
+                if let Some(devices) = self.nvme_devices.as_mut()
+                    && let Some(dev) = devices.get_mut(device.index)
+                {
+                    dev.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.nvme_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Close an NVMe device.
+    pub fn close_nvme_device(&mut self, device: crate::nvme::NvmeDevice) -> io::Result<()> {
+        let (fd_index, _nsid) = self.validate_nvme_device(device)?;
+
+        // Unregister from the fixed file table.
+        let _ = self.ring.register_files_update(fd_index, &[-1i32]);
+
+        if let Some(devices) = self.nvme_devices.as_mut() {
+            devices.release(device.index);
+        }
+
+        Ok(())
+    }
+
+    /// Validate an NVMe device handle and return (fd_index, nsid).
+    fn validate_nvme_device(
+        &self,
+        device: crate::nvme::NvmeDevice,
+    ) -> io::Result<(u32, u32)> {
+        let devices = self
+            .nvme_devices
+            .as_ref()
+            .ok_or_else(|| io::Error::other("NVMe not configured"))?;
+        let dev = devices
+            .get(device.index)
+            .ok_or_else(|| io::Error::other("invalid NVMe device handle"))?;
+        if dev.generation != device.generation {
+            return Err(io::Error::other("stale NVMe device handle"));
+        }
+        Ok((dev.fd_index, dev.nsid))
     }
 
     /// Arm a connect timeout for the given connection index.
@@ -1475,6 +1707,14 @@ pub trait EventHandler: Send + 'static {
         _data: &[u8],
         _peer: SocketAddr,
     ) {
+    }
+
+    /// Called when an NVMe passthrough command completes.
+    ///
+    /// The [`NvmeCompletion`](crate::nvme::NvmeCompletion) contains the device
+    /// handle, command sequence number, and result code.
+    /// Default: no-op.
+    fn on_nvme_complete(&mut self, _ctx: &mut DriverCtx, _completion: crate::nvme::NvmeCompletion) {
     }
 
     /// Called when the worker's eventfd is signaled by an external thread.

--- a/io/krio/src/handler.rs
+++ b/io/krio/src/handler.rs
@@ -92,6 +92,12 @@ pub struct DriverCtx<'a> {
     pub(crate) nvme_cmd_slab: &'a mut Option<crate::nvme::NvmeCmdSlab>,
     /// Base offset in the fixed file table for NVMe device fds.
     pub(crate) nvme_fd_base: u32,
+    /// Direct I/O file table. `None` when direct I/O is not configured.
+    pub(crate) direct_io_files: &'a mut Option<crate::direct_io::DirectIoFileTable>,
+    /// Direct I/O command slab. `None` when direct I/O is not configured.
+    pub(crate) direct_io_cmd_slab: &'a mut Option<crate::direct_io::DirectIoCmdSlab>,
+    /// Base offset in the fixed file table for direct I/O file fds.
+    pub(crate) direct_io_fd_base: u32,
 }
 
 impl<'a> DriverCtx<'a> {
@@ -803,6 +809,239 @@ impl<'a> DriverCtx<'a> {
             return Err(io::Error::other("stale NVMe device handle"));
         }
         Ok((dev.fd_index, dev.nsid))
+    }
+
+    // ── Direct I/O methods ────────────────────────────────────────────────
+
+    /// Open a file for direct I/O (O_DIRECT).
+    ///
+    /// `path` can be any file or block device path. The file is opened with
+    /// `O_RDWR | O_DIRECT`. The fd is registered in the io_uring fixed file table.
+    ///
+    /// Returns a [`DirectIoFile`](crate::direct_io::DirectIoFile) handle for
+    /// subsequent operations.
+    pub fn open_direct_io_file(
+        &mut self,
+        path: &str,
+    ) -> io::Result<crate::direct_io::DirectIoFile> {
+        let files = self
+            .direct_io_files
+            .as_mut()
+            .ok_or_else(|| io::Error::other("direct I/O not configured"))?;
+
+        let index = files
+            .allocate()
+            .ok_or_else(|| io::Error::other("direct I/O file table full"))?;
+
+        // Open with O_DIRECT | O_RDWR.
+        let c_path =
+            std::ffi::CString::new(path).map_err(|_| io::Error::other("invalid file path"))?;
+        let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDWR | libc::O_DIRECT) };
+        if fd < 0 {
+            files.release(index);
+            return Err(io::Error::last_os_error());
+        }
+
+        // Register in the fixed file table.
+        let fd_index = self.direct_io_fd_base + index as u32;
+        if self.ring.register_files_update(fd_index, &[fd]).is_err() {
+            files.release(index);
+            unsafe {
+                libc::close(fd);
+            }
+            return Err(io::Error::other("failed to register direct I/O fd"));
+        }
+        unsafe {
+            libc::close(fd);
+        }
+
+        // Store file state.
+        if let Some(f) = files.get_mut(index) {
+            f.fd_index = fd_index;
+        }
+
+        let generation = files.get(index).map(|f| f.generation).unwrap_or(0);
+        Ok(crate::direct_io::DirectIoFile { index, generation })
+    }
+
+    /// Submit a direct I/O read.
+    ///
+    /// Reads `len` bytes from `offset` into the buffer at `buf`.
+    /// The buffer must be aligned to the logical block size and remain valid
+    /// until [`on_direct_io_complete`](EventHandler::on_direct_io_complete) fires.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    ///
+    /// # Safety
+    /// `buf` must point to valid, aligned memory of at least `len` bytes
+    /// that remains valid until the completion callback fires.
+    pub unsafe fn direct_io_read(
+        &mut self,
+        file: crate::direct_io::DirectIoFile,
+        offset: u64,
+        buf: *mut u8,
+        len: u32,
+    ) -> io::Result<u32> {
+        let fd_index = self.validate_direct_io_file(file)?;
+
+        let slab = self
+            .direct_io_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("direct I/O not configured"))?;
+        let slab_idx = slab
+            .allocate(file.index, crate::direct_io::DirectIoOp::Read)
+            .ok_or_else(|| io::Error::other("direct I/O command slab exhausted"))?;
+
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::DirectIo,
+            file.index as u32,
+            slab_idx as u32,
+        );
+
+        match unsafe { self.ring.submit_direct_read(fd_index, buf, len, offset, ud) } {
+            Ok(()) => {
+                if let Some(files) = self.direct_io_files.as_mut()
+                    && let Some(f) = files.get_mut(file.index)
+                {
+                    f.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.direct_io_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Submit a direct I/O write.
+    ///
+    /// Writes `len` bytes from the buffer at `buf` to `offset`.
+    /// The buffer must be aligned to the logical block size and remain valid
+    /// until [`on_direct_io_complete`](EventHandler::on_direct_io_complete) fires.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    ///
+    /// # Safety
+    /// `buf` must point to valid, aligned memory of at least `len` bytes
+    /// that remains valid until the completion callback fires.
+    pub unsafe fn direct_io_write(
+        &mut self,
+        file: crate::direct_io::DirectIoFile,
+        offset: u64,
+        buf: *const u8,
+        len: u32,
+    ) -> io::Result<u32> {
+        let fd_index = self.validate_direct_io_file(file)?;
+
+        let slab = self
+            .direct_io_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("direct I/O not configured"))?;
+        let slab_idx = slab
+            .allocate(file.index, crate::direct_io::DirectIoOp::Write)
+            .ok_or_else(|| io::Error::other("direct I/O command slab exhausted"))?;
+
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::DirectIo,
+            file.index as u32,
+            slab_idx as u32,
+        );
+
+        match unsafe { self.ring.submit_direct_write(fd_index, buf, len, offset, ud) } {
+            Ok(()) => {
+                if let Some(files) = self.direct_io_files.as_mut()
+                    && let Some(f) = files.get_mut(file.index)
+                {
+                    f.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.direct_io_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Submit an fsync for a direct I/O file.
+    ///
+    /// Returns the command slab index (sequence number) for correlation.
+    pub fn direct_io_fsync(
+        &mut self,
+        file: crate::direct_io::DirectIoFile,
+    ) -> io::Result<u32> {
+        let fd_index = self.validate_direct_io_file(file)?;
+
+        let slab = self
+            .direct_io_cmd_slab
+            .as_mut()
+            .ok_or_else(|| io::Error::other("direct I/O not configured"))?;
+        let slab_idx = slab
+            .allocate(file.index, crate::direct_io::DirectIoOp::Fsync)
+            .ok_or_else(|| io::Error::other("direct I/O command slab exhausted"))?;
+
+        let ud = crate::completion::UserData::encode(
+            crate::completion::OpTag::DirectIo,
+            file.index as u32,
+            slab_idx as u32,
+        );
+
+        match self.ring.submit_direct_fsync(fd_index, ud) {
+            Ok(()) => {
+                if let Some(files) = self.direct_io_files.as_mut()
+                    && let Some(f) = files.get_mut(file.index)
+                {
+                    f.in_flight += 1;
+                }
+                Ok(slab_idx as u32)
+            }
+            Err(e) => {
+                if let Some(slab) = self.direct_io_cmd_slab.as_mut() {
+                    slab.release(slab_idx);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Close a direct I/O file.
+    pub fn close_direct_io_file(
+        &mut self,
+        file: crate::direct_io::DirectIoFile,
+    ) -> io::Result<()> {
+        let fd_index = self.validate_direct_io_file(file)?;
+
+        // Unregister from the fixed file table.
+        let _ = self.ring.register_files_update(fd_index, &[-1i32]);
+
+        if let Some(files) = self.direct_io_files.as_mut() {
+            files.release(file.index);
+        }
+
+        Ok(())
+    }
+
+    /// Validate a direct I/O file handle and return the fd_index.
+    fn validate_direct_io_file(
+        &self,
+        file: crate::direct_io::DirectIoFile,
+    ) -> io::Result<u32> {
+        let files = self
+            .direct_io_files
+            .as_ref()
+            .ok_or_else(|| io::Error::other("direct I/O not configured"))?;
+        let f = files
+            .get(file.index)
+            .ok_or_else(|| io::Error::other("invalid direct I/O file handle"))?;
+        if f.generation != file.generation {
+            return Err(io::Error::other("stale direct I/O file handle"));
+        }
+        Ok(f.fd_index)
     }
 
     /// Arm a connect timeout for the given connection index.
@@ -1715,6 +1954,19 @@ pub trait EventHandler: Send + 'static {
     /// handle, command sequence number, and result code.
     /// Default: no-op.
     fn on_nvme_complete(&mut self, _ctx: &mut DriverCtx, _completion: crate::nvme::NvmeCompletion) {
+    }
+
+    /// Called when a direct I/O command completes (read, write, or fsync).
+    ///
+    /// The [`DirectIoCompletion`](crate::direct_io::DirectIoCompletion) contains
+    /// the file handle, operation type, sequence number, and result code.
+    /// For read/write, a positive result is the number of bytes transferred.
+    /// Default: no-op.
+    fn on_direct_io_complete(
+        &mut self,
+        _ctx: &mut DriverCtx,
+        _completion: crate::direct_io::DirectIoCompletion,
+    ) {
     }
 
     /// Called when the worker's eventfd is signaled by an external thread.

--- a/io/krio/src/lib.rs
+++ b/io/krio/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod connection;
 pub(crate) mod driver;
 pub(crate) mod event_loop;
 pub(crate) mod metrics;
+pub mod direct_io;
 pub mod nvme;
 pub(crate) mod ring;
 pub(crate) mod runtime;
@@ -195,6 +196,14 @@ pub use config::WorkerConfig;
 pub use error::Error;
 /// Zero-copy send guard trait.
 pub use guard::{GuardBox, SendGuard};
+/// Direct I/O completion result.
+pub use direct_io::DirectIoCompletion;
+/// Direct I/O configuration.
+pub use direct_io::DirectIoConfig;
+/// Direct I/O file handle.
+pub use direct_io::DirectIoFile;
+/// Direct I/O operation type.
+pub use direct_io::DirectIoOp;
 /// NVMe passthrough completion result.
 pub use nvme::NvmeCompletion;
 /// NVMe passthrough configuration.

--- a/io/krio/src/lib.rs
+++ b/io/krio/src/lib.rs
@@ -51,10 +51,10 @@ pub(crate) mod buffer;
 pub(crate) mod chain;
 pub(crate) mod completion;
 pub(crate) mod connection;
+pub mod direct_io;
 pub(crate) mod driver;
 pub(crate) mod event_loop;
 pub(crate) mod metrics;
-pub mod direct_io;
 pub mod nvme;
 pub(crate) mod ring;
 pub(crate) mod runtime;
@@ -192,10 +192,6 @@ pub use config::Config;
 pub use config::RecvBufferConfig;
 /// Worker thread configuration.
 pub use config::WorkerConfig;
-/// Runtime errors.
-pub use error::Error;
-/// Zero-copy send guard trait.
-pub use guard::{GuardBox, SendGuard};
 /// Direct I/O completion result.
 pub use direct_io::DirectIoCompletion;
 /// Direct I/O configuration.
@@ -204,6 +200,10 @@ pub use direct_io::DirectIoConfig;
 pub use direct_io::DirectIoFile;
 /// Direct I/O operation type.
 pub use direct_io::DirectIoOp;
+/// Runtime errors.
+pub use error::Error;
+/// Zero-copy send guard trait.
+pub use guard::{GuardBox, SendGuard};
 /// NVMe passthrough completion result.
 pub use nvme::NvmeCompletion;
 /// NVMe passthrough configuration.

--- a/io/krio/src/lib.rs
+++ b/io/krio/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod connection;
 pub(crate) mod driver;
 pub(crate) mod event_loop;
 pub(crate) mod metrics;
+pub mod nvme;
 pub(crate) mod ring;
 pub(crate) mod runtime;
 #[cfg(feature = "tls")]
@@ -194,6 +195,12 @@ pub use config::WorkerConfig;
 pub use error::Error;
 /// Zero-copy send guard trait.
 pub use guard::{GuardBox, SendGuard};
+/// NVMe passthrough completion result.
+pub use nvme::NvmeCompletion;
+/// NVMe passthrough configuration.
+pub use nvme::NvmeConfig;
+/// NVMe passthrough device handle.
+pub use nvme::NvmeDevice;
 /// Builder for launching krio workers.
 pub use worker::KrioBuilder;
 /// Handle for triggering graceful shutdown.

--- a/io/krio/src/nvme.rs
+++ b/io/krio/src/nvme.rs
@@ -178,7 +178,7 @@ impl NvmeUringCmd {
 
 /// Opaque handle to an opened NVMe device.
 ///
-/// Returned by [`DriverCtx::open_nvme_device`] and used to identify the
+/// Returned by [`crate::DriverCtx::open_nvme_device`] and used to identify the
 /// device in subsequent read/write/close calls. The handle includes a
 /// generation counter for stale-handle detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -320,7 +320,7 @@ impl NvmeCmdSlab {
 
 /// Result of an NVMe command completion.
 ///
-/// Delivered to [`EventHandler::on_nvme_complete`].
+/// Delivered to [`crate::EventHandler::on_nvme_complete`].
 #[derive(Debug, Clone)]
 pub struct NvmeCompletion {
     /// The device this command was submitted to.

--- a/io/krio/src/nvme.rs
+++ b/io/krio/src/nvme.rs
@@ -1,0 +1,449 @@
+//! NVMe io_uring passthrough types and helpers.
+//!
+//! This module provides the types needed to submit NVMe commands via
+//! `IORING_OP_URING_CMD` (io_uring passthrough). Commands are submitted
+//! on NVMe-generic character devices (`/dev/ng<X>n<Y>`), bypassing the
+//! filesystem and block layer entirely.
+//!
+//! # Kernel requirements
+//!
+//! - Linux 5.19+ for `IORING_OP_URING_CMD`
+//! - Linux 6.0+ already required by krio for `SendMsgZc`
+//! - NVMe device accessible via `/dev/ng*` (requires `CAP_SYS_ADMIN` or udev rules)
+
+/// NVMe I/O command opcodes (NVM command set).
+pub const NVME_CMD_FLUSH: u8 = 0x00;
+pub const NVME_CMD_WRITE: u8 = 0x01;
+pub const NVME_CMD_READ: u8 = 0x02;
+
+/// NVMe uring_cmd sub-opcodes passed as `cmd_op` to `IORING_OP_URING_CMD`.
+pub const NVME_URING_CMD_IO: u32 = 0;
+#[allow(dead_code)]
+pub const NVME_URING_CMD_IO_VEC: u32 = 1;
+
+/// NVMe command structure for io_uring passthrough.
+///
+/// This matches the kernel's `struct nvme_uring_cmd` (72 bytes).
+/// It is embedded in the 80-byte command area of a Big SQE (`UringCmd80`).
+///
+/// # Layout
+///
+/// The structure maps directly to NVMe command dwords, with `addr` and
+/// `data_len` specifying the data buffer for read/write commands.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct NvmeUringCmd {
+    /// NVMe command opcode (e.g., 0x02 for Read, 0x01 for Write).
+    pub opcode: u8,
+    /// Command flags.
+    pub flags: u8,
+    /// Reserved.
+    pub rsvd1: u16,
+    /// Namespace ID (usually 1).
+    pub nsid: u32,
+    /// Command dword 2.
+    pub cdw2: u32,
+    /// Command dword 3.
+    pub cdw3: u32,
+    /// Metadata buffer address (0 if unused).
+    pub metadata: u64,
+    /// Data buffer address (userspace virtual address).
+    pub addr: u64,
+    /// Metadata length in bytes.
+    pub metadata_len: u32,
+    /// Data length in bytes.
+    pub data_len: u32,
+    /// Command dword 10 (start LBA low 32 bits for read/write).
+    pub cdw10: u32,
+    /// Command dword 11 (start LBA high 32 bits for read/write).
+    pub cdw11: u32,
+    /// Command dword 12 (number of logical blocks - 1, plus flags).
+    pub cdw12: u32,
+    /// Command dword 13.
+    pub cdw13: u32,
+    /// Command dword 14.
+    pub cdw14: u32,
+    /// Command dword 15.
+    pub cdw15: u32,
+    /// Timeout in milliseconds (0 = default).
+    pub timeout_ms: u32,
+    /// Reserved.
+    pub rsvd2: u32,
+}
+
+const _: () = assert!(std::mem::size_of::<NvmeUringCmd>() == 72);
+const _: () = assert!(std::mem::size_of::<NvmeUringCmd>() <= 80);
+
+impl NvmeUringCmd {
+    /// Build an NVMe Read command.
+    ///
+    /// # Arguments
+    /// - `nsid`: Namespace ID (usually 1)
+    /// - `lba`: Starting logical block address
+    /// - `num_blocks`: Number of blocks to read (1-based; 1 = one block)
+    /// - `buf_addr`: Userspace buffer address for the read data
+    /// - `buf_len`: Buffer length in bytes
+    pub fn read(nsid: u32, lba: u64, num_blocks: u16, buf_addr: u64, buf_len: u32) -> Self {
+        NvmeUringCmd {
+            opcode: NVME_CMD_READ,
+            flags: 0,
+            rsvd1: 0,
+            nsid,
+            cdw2: 0,
+            cdw3: 0,
+            metadata: 0,
+            addr: buf_addr,
+            metadata_len: 0,
+            data_len: buf_len,
+            cdw10: lba as u32,              // SLBA low
+            cdw11: (lba >> 32) as u32,      // SLBA high
+            cdw12: (num_blocks - 1) as u32, // NLB (0-based)
+            cdw13: 0,
+            cdw14: 0,
+            cdw15: 0,
+            timeout_ms: 0,
+            rsvd2: 0,
+        }
+    }
+
+    /// Build an NVMe Write command.
+    ///
+    /// # Arguments
+    /// - `nsid`: Namespace ID (usually 1)
+    /// - `lba`: Starting logical block address
+    /// - `num_blocks`: Number of blocks to write (1-based; 1 = one block)
+    /// - `buf_addr`: Userspace buffer address containing write data
+    /// - `buf_len`: Buffer length in bytes
+    pub fn write(nsid: u32, lba: u64, num_blocks: u16, buf_addr: u64, buf_len: u32) -> Self {
+        NvmeUringCmd {
+            opcode: NVME_CMD_WRITE,
+            flags: 0,
+            rsvd1: 0,
+            nsid,
+            cdw2: 0,
+            cdw3: 0,
+            metadata: 0,
+            addr: buf_addr,
+            metadata_len: 0,
+            data_len: buf_len,
+            cdw10: lba as u32,
+            cdw11: (lba >> 32) as u32,
+            cdw12: (num_blocks - 1) as u32,
+            cdw13: 0,
+            cdw14: 0,
+            cdw15: 0,
+            timeout_ms: 0,
+            rsvd2: 0,
+        }
+    }
+
+    /// Build an NVMe Flush command.
+    pub fn flush(nsid: u32) -> Self {
+        NvmeUringCmd {
+            opcode: NVME_CMD_FLUSH,
+            flags: 0,
+            rsvd1: 0,
+            nsid,
+            cdw2: 0,
+            cdw3: 0,
+            metadata: 0,
+            addr: 0,
+            metadata_len: 0,
+            data_len: 0,
+            cdw10: 0,
+            cdw11: 0,
+            cdw12: 0,
+            cdw13: 0,
+            cdw14: 0,
+            cdw15: 0,
+            timeout_ms: 0,
+            rsvd2: 0,
+        }
+    }
+
+    /// Serialize to a byte array for embedding in `UringCmd80`.
+    pub fn to_bytes(&self) -> [u8; 80] {
+        let mut buf = [0u8; 80];
+        // Safety: NvmeUringCmd is repr(C) and 72 bytes, fits in 80.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self as *const Self as *const u8,
+                buf.as_mut_ptr(),
+                std::mem::size_of::<Self>(),
+            );
+        }
+        buf
+    }
+}
+
+/// Opaque handle to an opened NVMe device.
+///
+/// Returned by [`DriverCtx::open_nvme_device`] and used to identify the
+/// device in subsequent read/write/close calls. The handle includes a
+/// generation counter for stale-handle detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NvmeDevice {
+    pub(crate) index: u16,
+    pub(crate) generation: u16,
+}
+
+impl NvmeDevice {
+    /// Returns the device slot index. Useful for indexing into per-device arrays.
+    pub fn index(&self) -> usize {
+        self.index as usize
+    }
+}
+
+/// Per-device state tracked by the driver.
+pub(crate) struct NvmeDeviceState {
+    /// Index in the io_uring fixed file table.
+    pub fd_index: u32,
+    /// NVMe namespace ID (usually 1).
+    pub nsid: u32,
+    /// Whether this slot is in use.
+    pub active: bool,
+    /// Generation counter for stale-handle detection.
+    pub generation: u16,
+    /// Number of commands currently in flight.
+    pub in_flight: u32,
+}
+
+impl NvmeDeviceState {
+    pub fn new() -> Self {
+        NvmeDeviceState {
+            fd_index: u32::MAX,
+            nsid: 1,
+            active: false,
+            generation: 0,
+            in_flight: 0,
+        }
+    }
+}
+
+/// Tracks NVMe device slots with allocation/release.
+pub(crate) struct NvmeDeviceTable {
+    slots: Vec<NvmeDeviceState>,
+    free_list: Vec<u16>,
+}
+
+impl NvmeDeviceTable {
+    pub fn new(max_devices: u16) -> Self {
+        let mut slots = Vec::with_capacity(max_devices as usize);
+        let mut free_list = Vec::with_capacity(max_devices as usize);
+        for i in (0..max_devices).rev() {
+            slots.push(NvmeDeviceState::new());
+            free_list.push(i);
+        }
+        NvmeDeviceTable { slots, free_list }
+    }
+
+    pub fn allocate(&mut self) -> Option<u16> {
+        let index = self.free_list.pop()?;
+        let slot = &mut self.slots[index as usize];
+        slot.active = true;
+        Some(index)
+    }
+
+    pub fn release(&mut self, index: u16) {
+        let slot = &mut self.slots[index as usize];
+        slot.active = false;
+        slot.fd_index = u32::MAX;
+        slot.in_flight = 0;
+        slot.generation = slot.generation.wrapping_add(1);
+        self.free_list.push(index);
+    }
+
+    pub fn get(&self, index: u16) -> Option<&NvmeDeviceState> {
+        self.slots.get(index as usize).filter(|s| s.active)
+    }
+
+    pub fn get_mut(&mut self, index: u16) -> Option<&mut NvmeDeviceState> {
+        self.slots.get_mut(index as usize).filter(|s| s.active)
+    }
+}
+
+/// Tracks in-flight NVMe commands for resource cleanup on completion.
+pub(crate) struct NvmeCmdSlab {
+    entries: Vec<NvmeCmdEntry>,
+    free_list: Vec<u16>,
+}
+
+/// Per-command tracking entry.
+struct NvmeCmdEntry {
+    /// Device slot index.
+    device_index: u16,
+    /// Whether this slot is in use.
+    in_use: bool,
+}
+
+impl NvmeCmdSlab {
+    pub fn new(capacity: u16) -> Self {
+        let mut entries = Vec::with_capacity(capacity as usize);
+        let mut free_list = Vec::with_capacity(capacity as usize);
+        for i in (0..capacity).rev() {
+            entries.push(NvmeCmdEntry {
+                device_index: 0,
+                in_use: false,
+            });
+            free_list.push(i);
+        }
+        NvmeCmdSlab { entries, free_list }
+    }
+
+    /// Allocate a command slot. Returns the slab index.
+    pub fn allocate(&mut self, device_index: u16) -> Option<u16> {
+        let idx = self.free_list.pop()?;
+        let entry = &mut self.entries[idx as usize];
+        entry.device_index = device_index;
+        entry.in_use = true;
+        Some(idx)
+    }
+
+    /// Release a command slot. Returns the device index.
+    pub fn release(&mut self, idx: u16) -> u16 {
+        let entry = &mut self.entries[idx as usize];
+        let device_index = entry.device_index;
+        entry.in_use = false;
+        self.free_list.push(idx);
+        device_index
+    }
+
+    #[allow(dead_code)]
+    pub fn device_index(&self, idx: u16) -> u16 {
+        self.entries[idx as usize].device_index
+    }
+
+    pub fn in_use(&self, idx: u16) -> bool {
+        self.entries.get(idx as usize).is_some_and(|e| e.in_use)
+    }
+}
+
+/// Result of an NVMe command completion.
+///
+/// Delivered to [`EventHandler::on_nvme_complete`].
+#[derive(Debug, Clone)]
+pub struct NvmeCompletion {
+    /// The device this command was submitted to.
+    pub device: NvmeDevice,
+    /// Command slab sequence number (from the payload of `nvme_read`/`nvme_write`).
+    pub seq: u32,
+    /// io_uring result code. Negative values are -errno.
+    pub result: i32,
+}
+
+impl NvmeCompletion {
+    /// Whether the command completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.result >= 0
+    }
+}
+
+/// Configuration for NVMe passthrough support.
+///
+/// When present in [`Config`](crate::config::Config), enables NVMe device
+/// management and allocates device/command tracking structures.
+#[derive(Clone, Debug)]
+pub struct NvmeConfig {
+    /// Maximum number of NVMe devices that can be opened simultaneously.
+    pub max_devices: u16,
+    /// Maximum NVMe commands in flight across all devices per worker.
+    pub max_commands_in_flight: u16,
+}
+
+impl Default for NvmeConfig {
+    fn default() -> Self {
+        NvmeConfig {
+            max_devices: 4,
+            max_commands_in_flight: 256,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nvme_uring_cmd_size() {
+        assert_eq!(std::mem::size_of::<NvmeUringCmd>(), 72);
+    }
+
+    #[test]
+    fn nvme_uring_cmd_fits_in_80_bytes() {
+        assert!(std::mem::size_of::<NvmeUringCmd>() <= 80);
+    }
+
+    #[test]
+    fn read_command_fields() {
+        let cmd = NvmeUringCmd::read(1, 0x1000, 8, 0xDEAD_BEEF, 4096);
+        assert_eq!(cmd.opcode, NVME_CMD_READ);
+        assert_eq!(cmd.nsid, 1);
+        assert_eq!(cmd.cdw10, 0x1000); // LBA low
+        assert_eq!(cmd.cdw11, 0); // LBA high
+        assert_eq!(cmd.cdw12, 7); // NLB = num_blocks - 1
+        assert_eq!(cmd.addr, 0xDEAD_BEEF);
+        assert_eq!(cmd.data_len, 4096);
+    }
+
+    #[test]
+    fn write_command_fields() {
+        let cmd = NvmeUringCmd::write(1, 0x2000_0000_0000, 1, 0xCAFE, 512);
+        assert_eq!(cmd.opcode, NVME_CMD_WRITE);
+        assert_eq!(cmd.cdw10, 0); // LBA low (0x2000_0000_0000 & 0xFFFF_FFFF)
+        assert_eq!(cmd.cdw11, 0x2000); // LBA high
+        assert_eq!(cmd.cdw12, 0); // NLB = 0 (one block)
+    }
+
+    #[test]
+    fn flush_command() {
+        let cmd = NvmeUringCmd::flush(1);
+        assert_eq!(cmd.opcode, NVME_CMD_FLUSH);
+        assert_eq!(cmd.nsid, 1);
+        assert_eq!(cmd.addr, 0);
+        assert_eq!(cmd.data_len, 0);
+    }
+
+    #[test]
+    fn to_bytes_roundtrip() {
+        let cmd = NvmeUringCmd::read(1, 42, 1, 0x1234, 512);
+        let bytes = cmd.to_bytes();
+        let recovered: NvmeUringCmd = unsafe { std::ptr::read(bytes.as_ptr() as *const _) };
+        assert_eq!(recovered.opcode, NVME_CMD_READ);
+        assert_eq!(recovered.nsid, 1);
+        assert_eq!(recovered.cdw10, 42);
+        assert_eq!(recovered.addr, 0x1234);
+    }
+
+    #[test]
+    fn device_table_alloc_release() {
+        let mut table = NvmeDeviceTable::new(4);
+        let a = table.allocate().unwrap();
+        let b = table.allocate().unwrap();
+        assert_ne!(a, b);
+        assert!(table.get(a).is_some());
+
+        table.release(a);
+        assert!(table.get(a).is_none());
+
+        // Re-allocate reuses the slot.
+        let c = table.allocate().unwrap();
+        assert_eq!(c, a);
+        // Generation incremented.
+        assert_eq!(table.get(c).unwrap().generation, 1);
+    }
+
+    #[test]
+    fn cmd_slab_alloc_release() {
+        let mut slab = NvmeCmdSlab::new(8);
+        let a = slab.allocate(0).unwrap();
+        let b = slab.allocate(1).unwrap();
+        assert!(slab.in_use(a));
+        assert!(slab.in_use(b));
+        assert_eq!(slab.device_index(a), 0);
+        assert_eq!(slab.device_index(b), 1);
+
+        let dev = slab.release(a);
+        assert_eq!(dev, 0);
+        assert!(!slab.in_use(a));
+    }
+}

--- a/io/krio/src/ring.rs
+++ b/io/krio/src/ring.rs
@@ -520,11 +520,7 @@ impl Ring {
     /// Submit an fsync via `IORING_OP_FSYNC`.
     ///
     /// The `fd_index` must be a fixed file table index pointing to an opened file.
-    pub fn submit_direct_fsync(
-        &mut self,
-        fd_index: u32,
-        user_data: UserData,
-    ) -> io::Result<()> {
+    pub fn submit_direct_fsync(&mut self, fd_index: u32, user_data: UserData) -> io::Result<()> {
         let entry = opcode::Fsync::new(Fixed(fd_index))
             .build()
             .user_data(user_data.raw());

--- a/io/krio/src/ring.rs
+++ b/io/krio/src/ring.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::os::fd::RawFd;
 
+use io_uring::cqueue;
+use io_uring::squeue;
 use io_uring::types::{Fd, Fixed};
 use io_uring::{IoUring, opcode};
 
@@ -8,10 +10,20 @@ use crate::buffer::fixed::FixedBufferRegistry;
 use crate::buffer::provided::ProvidedBufRing;
 use crate::completion::{OpTag, UserData};
 use crate::config::Config;
+use crate::nvme::{NVME_URING_CMD_IO, NvmeUringCmd};
 
 /// Wrapper around IoUring providing high-level SQE submission helpers.
+///
+/// The ring uses 128-byte SQEs and 32-byte CQEs (`IoUring<Entry128, Entry32>`)
+/// to support NVMe passthrough via `IORING_OP_URING_CMD` / `UringCmd80`.
+/// Standard network opcodes produce 64-byte `Entry` values which are
+/// automatically converted to `Entry128` (zero-padded) via `Into`.
+///
+/// Memory overhead of Big SQE/CQE: +32 KB per worker with default config
+/// (256 SQ × 64B extra + 1024 CQ × 16B extra), negligible relative to the
+/// ~20 MB of buffer pools allocated per worker.
 pub struct Ring {
-    pub(crate) ring: IoUring,
+    pub(crate) ring: IoUring<squeue::Entry128, cqueue::Entry32>,
     /// Recv buffer group ID for multishot recv.
     bgid: u16,
 }
@@ -24,7 +36,7 @@ impl Ring {
             .checked_mul(4)
             .unwrap_or(config.sq_entries);
 
-        let mut builder = IoUring::builder();
+        let mut builder = IoUring::<squeue::Entry128, cqueue::Entry32>::builder();
         builder.setup_cqsize(cq_entries);
         builder.setup_coop_taskrun();
         builder.setup_single_issuer();
@@ -339,11 +351,29 @@ impl Ring {
         Ok(())
     }
 
-    /// Push an SQE to the submission queue.
+    /// Push a standard SQE to the submission queue.
+    ///
+    /// The 64-byte `Entry` is automatically converted to `Entry128` (zero-padded)
+    /// for the Big SQE ring.
     ///
     /// # Safety
     /// The SQE must reference valid memory for the lifetime of the operation.
-    pub(crate) unsafe fn push_sqe(&mut self, entry: io_uring::squeue::Entry) -> io::Result<()> {
+    pub(crate) unsafe fn push_sqe(&mut self, entry: squeue::Entry) -> io::Result<()> {
+        let entry128: squeue::Entry128 = entry.into();
+        unsafe {
+            self.push_sqe128(entry128)?;
+        }
+        Ok(())
+    }
+
+    /// Push a 128-byte SQE to the submission queue.
+    ///
+    /// Used directly for NVMe passthrough (`UringCmd80`) which produces
+    /// `Entry128` natively.
+    ///
+    /// # Safety
+    /// The SQE must reference valid memory for the lifetime of the operation.
+    pub(crate) unsafe fn push_sqe128(&mut self, entry: squeue::Entry128) -> io::Result<()> {
         // Try to push; if SQ is full, submit first to make room.
         unsafe {
             if self.ring.submission().push(&entry).is_err() {
@@ -367,7 +397,7 @@ impl Ring {
     /// All SQEs must reference valid memory for the lifetime of their operations.
     pub(crate) unsafe fn push_sqe_chain(
         &mut self,
-        entries: &mut [io_uring::squeue::Entry],
+        entries: &mut [squeue::Entry],
     ) -> io::Result<()> {
         if entries.is_empty() {
             return Ok(());
@@ -382,14 +412,17 @@ impl Ring {
             *entry = entry.clone().flags(io_uring::squeue::Flags::IO_LINK);
         }
 
+        // Convert to Entry128 for the Big SQ ring.
+        let entries128: Vec<squeue::Entry128> = entries.iter().map(|e| e.clone().into()).collect();
+
         // Ensure enough room in the SQ for the entire chain.
         {
             let sq = self.ring.submission();
-            if sq.capacity() - sq.len() < entries.len() {
+            if sq.capacity() - sq.len() < entries128.len() {
                 drop(sq);
                 self.ring.submit()?;
                 let sq = self.ring.submission();
-                if sq.capacity() - sq.len() < entries.len() {
+                if sq.capacity() - sq.len() < entries128.len() {
                     return Err(io::Error::other("SQ too small for chain"));
                 }
             }
@@ -399,8 +432,33 @@ impl Ring {
         unsafe {
             self.ring
                 .submission()
-                .push_multiple(entries)
+                .push_multiple(&entries128)
                 .map_err(|_| io::Error::other("SQ full after flush for chain"))?;
+        }
+        Ok(())
+    }
+
+    /// Submit an NVMe passthrough command via `IORING_OP_URING_CMD`.
+    ///
+    /// The `fd_index` must be a fixed file table index pointing to an opened
+    /// NVMe-generic character device (`/dev/ng<X>n<Y>`).
+    ///
+    /// # Safety
+    /// The buffer referenced by `cmd.addr` / `cmd.data_len` must remain valid
+    /// until the CQE arrives.
+    pub unsafe fn submit_nvme_cmd(
+        &mut self,
+        fd_index: u32,
+        cmd: &NvmeUringCmd,
+        user_data: UserData,
+    ) -> io::Result<()> {
+        let cmd_bytes = cmd.to_bytes();
+        let entry = opcode::UringCmd80::new(Fixed(fd_index), NVME_URING_CMD_IO)
+            .cmd(cmd_bytes)
+            .build()
+            .user_data(user_data.raw());
+        unsafe {
+            self.push_sqe128(entry)?;
         }
         Ok(())
     }

--- a/io/krio/src/ring.rs
+++ b/io/krio/src/ring.rs
@@ -462,4 +462,75 @@ impl Ring {
         }
         Ok(())
     }
+
+    /// Submit a direct I/O read via `IORING_OP_READ`.
+    ///
+    /// The `fd_index` must be a fixed file table index pointing to a file
+    /// opened with `O_DIRECT`.
+    ///
+    /// # Safety
+    /// The buffer at `buf` with length `len` must remain valid and properly
+    /// aligned until the CQE arrives. For `O_DIRECT`, the buffer address,
+    /// length, and file offset must all be aligned to the logical block size.
+    pub unsafe fn submit_direct_read(
+        &mut self,
+        fd_index: u32,
+        buf: *mut u8,
+        len: u32,
+        offset: u64,
+        user_data: UserData,
+    ) -> io::Result<()> {
+        let entry = opcode::Read::new(Fixed(fd_index), buf, len)
+            .offset(offset)
+            .build()
+            .user_data(user_data.raw());
+        unsafe {
+            self.push_sqe(entry)?;
+        }
+        Ok(())
+    }
+
+    /// Submit a direct I/O write via `IORING_OP_WRITE`.
+    ///
+    /// The `fd_index` must be a fixed file table index pointing to a file
+    /// opened with `O_DIRECT`.
+    ///
+    /// # Safety
+    /// The buffer at `buf` with length `len` must remain valid and properly
+    /// aligned until the CQE arrives. For `O_DIRECT`, the buffer address,
+    /// length, and file offset must all be aligned to the logical block size.
+    pub unsafe fn submit_direct_write(
+        &mut self,
+        fd_index: u32,
+        buf: *const u8,
+        len: u32,
+        offset: u64,
+        user_data: UserData,
+    ) -> io::Result<()> {
+        let entry = opcode::Write::new(Fixed(fd_index), buf, len)
+            .offset(offset)
+            .build()
+            .user_data(user_data.raw());
+        unsafe {
+            self.push_sqe(entry)?;
+        }
+        Ok(())
+    }
+
+    /// Submit an fsync via `IORING_OP_FSYNC`.
+    ///
+    /// The `fd_index` must be a fixed file table index pointing to an opened file.
+    pub fn submit_direct_fsync(
+        &mut self,
+        fd_index: u32,
+        user_data: UserData,
+    ) -> io::Result<()> {
+        let entry = opcode::Fsync::new(Fixed(fd_index))
+            .build()
+            .user_data(user_data.raw());
+        unsafe {
+            self.push_sqe(entry)?;
+        }
+        Ok(())
+    }
 }

--- a/io/krio/tests/direct_io.rs
+++ b/io/krio/tests/direct_io.rs
@@ -115,11 +115,7 @@ impl EventHandler for RoundtripHandler {
     fn create_for_worker(_id: usize) -> Self {
         let path = temp_file_path(".krio_direct_io_roundtrip_test");
 
-        // Pre-create the file with 4096 bytes so read doesn't hit EOF.
-        std::fs::write(&path, [0u8; 4096]).unwrap();
-
         let mut write_buf = aligned_buf(4096);
-        // Fill with a known pattern.
         for (i, byte) in write_buf.iter_mut().enumerate() {
             *byte = (i % 251) as u8; // prime modulus for non-repeating pattern
         }
@@ -138,6 +134,14 @@ impl EventHandler for RoundtripHandler {
 
     fn on_tick(&mut self, ctx: &mut DriverCtx) {
         if self.state.phase != RoundtripPhase::Init {
+            return;
+        }
+
+        // Create the file with 4096 bytes so read doesn't hit EOF.
+        if let Err(e) = std::fs::write(&self.state.path, [0u8; 4096]) {
+            let _ = ROUNDTRIP_ERR.set(format!("file create failed: {e}"));
+            ROUNDTRIP_DONE.store(true, Ordering::Release);
+            ctx.request_shutdown();
             return;
         }
 
@@ -327,7 +331,6 @@ impl EventHandler for MultiFileHandler {
         let mut bufs = Vec::new();
         for i in 0..3 {
             let path = temp_file_path(&format!(".krio_direct_io_multi_{i}"));
-            std::fs::write(&path, [0u8; 4096]).unwrap();
             paths.push(path);
 
             let mut buf = aligned_buf(4096);
@@ -353,6 +356,16 @@ impl EventHandler for MultiFileHandler {
             return;
         }
         self.state.started = true;
+
+        // Create the files.
+        for path in &self.state.paths {
+            if let Err(e) = std::fs::write(path, [0u8; 4096]) {
+                let _ = MULTI_FILE_ERR.set(format!("file create failed: {e}"));
+                MULTI_FILE_DONE.store(true, Ordering::Release);
+                ctx.request_shutdown();
+                return;
+            }
+        }
 
         // Open all files.
         for path in &self.state.paths {

--- a/io/krio/tests/direct_io.rs
+++ b/io/krio/tests/direct_io.rs
@@ -1,0 +1,448 @@
+//! Integration tests: direct I/O via krio's `O_DIRECT` support.
+//!
+//! These tests exercise the full io_uring submission path for
+//! `IORING_OP_READ`, `IORING_OP_WRITE`, and `IORING_OP_FSYNC` using
+//! `O_DIRECT` files.
+//!
+//! Requirements:
+//! - Linux 5.6+ (io_uring read/write)
+//! - A real filesystem (ext4, xfs, etc.) — O_DIRECT does not work on tmpfs
+//! - The test binary must be on a filesystem that supports O_DIRECT
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::OnceLock;
+
+use krio::{Config, ConnToken, DirectIoCompletion, DirectIoOp, DriverCtx, EventHandler, KrioBuilder};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn direct_io_test_config() -> Config {
+    let mut config = Config::default();
+    config.worker.threads = 1;
+    config.worker.pin_to_core = false;
+    config.sq_entries = 64;
+    config.recv_buffer.ring_size = 64;
+    config.recv_buffer.buffer_size = 4096;
+    config.max_connections = 8;
+    config.send_copy_count = 8;
+    config.tick_timeout_us = 1000; // 1ms tick for responsive tests
+    config.direct_io = Some(krio::DirectIoConfig {
+        max_files: 4,
+        max_commands_in_flight: 32,
+    });
+    config
+}
+
+/// Allocate a 4096-byte aligned buffer.
+fn aligned_buf(size: usize) -> Vec<u8> {
+    let layout = std::alloc::Layout::from_size_align(size, 4096).unwrap();
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    if ptr.is_null() {
+        std::alloc::handle_alloc_error(layout);
+    }
+    unsafe { Vec::from_raw_parts(ptr, size, size) }
+}
+
+/// Generate a temp file path in the current working directory.
+/// Using cwd (the repo root) ensures we're on a real filesystem, not tmpfs.
+fn temp_file_path(name: &str) -> PathBuf {
+    std::env::current_dir().unwrap().join(name)
+}
+
+/// Check if io_uring is supported on this kernel.
+fn io_uring_supported() -> bool {
+    // Try to create a minimal io_uring. ENOSYS means the syscall doesn't exist.
+    let ret = unsafe { libc::syscall(libc::SYS_io_uring_setup, 1u32, std::ptr::null_mut::<u8>()) };
+    // EFAULT (bad params pointer) means the syscall exists; ENOSYS means it doesn't.
+    ret != -1 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ENOSYS)
+}
+
+/// Check if O_DIRECT is supported by trying to open a file.
+fn o_direct_supported() -> bool {
+    let path = temp_file_path(".krio_direct_io_probe");
+    let c_path = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+    let fd = unsafe {
+        libc::open(
+            c_path.as_ptr(),
+            libc::O_CREAT | libc::O_RDWR | libc::O_DIRECT,
+            0o644,
+        )
+    };
+    if fd >= 0 {
+        unsafe {
+            libc::close(fd);
+            libc::unlink(c_path.as_ptr());
+        }
+        true
+    } else {
+        let _ = std::fs::remove_file(&path);
+        false
+    }
+}
+
+// ── Write then Read roundtrip test ──────────────────────────────────
+
+/// Test state shared across on_tick calls via static.
+static ROUNDTRIP_DONE: AtomicBool = AtomicBool::new(false);
+static ROUNDTRIP_OK: AtomicBool = AtomicBool::new(false);
+static ROUNDTRIP_ERR: OnceLock<String> = OnceLock::new();
+
+/// Per-worker state for the roundtrip test handler.
+struct RoundtripState {
+    phase: RoundtripPhase,
+    file: Option<krio::DirectIoFile>,
+    write_buf: Vec<u8>,
+    read_buf: Vec<u8>,
+    path: PathBuf,
+}
+
+#[derive(Debug, PartialEq)]
+enum RoundtripPhase {
+    Init,
+    WaitingWrite,
+    WaitingFsync,
+    WaitingRead,
+    Done,
+}
+
+struct RoundtripHandler {
+    state: RoundtripState,
+}
+
+impl EventHandler for RoundtripHandler {
+    fn create_for_worker(_id: usize) -> Self {
+        let path = temp_file_path(".krio_direct_io_roundtrip_test");
+
+        // Pre-create the file with 4096 bytes so read doesn't hit EOF.
+        std::fs::write(&path, [0u8; 4096]).unwrap();
+
+        let mut write_buf = aligned_buf(4096);
+        // Fill with a known pattern.
+        for (i, byte) in write_buf.iter_mut().enumerate() {
+            *byte = (i % 251) as u8; // prime modulus for non-repeating pattern
+        }
+        let read_buf = aligned_buf(4096);
+
+        RoundtripHandler {
+            state: RoundtripState {
+                phase: RoundtripPhase::Init,
+                file: None,
+                write_buf,
+                read_buf,
+                path,
+            },
+        }
+    }
+
+    fn on_tick(&mut self, ctx: &mut DriverCtx) {
+        if self.state.phase != RoundtripPhase::Init {
+            return;
+        }
+
+        // Open the file.
+        let path_str = self.state.path.to_str().unwrap();
+        match ctx.open_direct_io_file(path_str) {
+            Ok(file) => self.state.file = Some(file),
+            Err(e) => {
+                let _ = ROUNDTRIP_ERR.set(format!("open failed: {e}"));
+                ROUNDTRIP_DONE.store(true, Ordering::Release);
+                ctx.request_shutdown();
+                return;
+            }
+        }
+
+        let file = self.state.file.unwrap();
+
+        // Submit write.
+        match unsafe {
+            ctx.direct_io_write(
+                file,
+                0, // offset
+                self.state.write_buf.as_ptr(),
+                self.state.write_buf.len() as u32,
+            )
+        } {
+            Ok(_seq) => {
+                self.state.phase = RoundtripPhase::WaitingWrite;
+            }
+            Err(e) => {
+                let _ = ROUNDTRIP_ERR.set(format!("write submit failed: {e}"));
+                ROUNDTRIP_DONE.store(true, Ordering::Release);
+                ctx.request_shutdown();
+            }
+        }
+    }
+
+    fn on_direct_io_complete(&mut self, ctx: &mut DriverCtx, completion: DirectIoCompletion) {
+        match self.state.phase {
+            RoundtripPhase::WaitingWrite => {
+                if !completion.is_success() {
+                    let _ = ROUNDTRIP_ERR
+                        .set(format!("write failed: result={}", completion.result));
+                    ROUNDTRIP_DONE.store(true, Ordering::Release);
+                    ctx.request_shutdown();
+                    return;
+                }
+                assert_eq!(completion.op, DirectIoOp::Write);
+                assert_eq!(completion.bytes_transferred(), Some(4096));
+
+                // Submit fsync.
+                let file = self.state.file.unwrap();
+                match ctx.direct_io_fsync(file) {
+                    Ok(_) => self.state.phase = RoundtripPhase::WaitingFsync,
+                    Err(e) => {
+                        let _ = ROUNDTRIP_ERR.set(format!("fsync submit failed: {e}"));
+                        ROUNDTRIP_DONE.store(true, Ordering::Release);
+                        ctx.request_shutdown();
+                    }
+                }
+            }
+            RoundtripPhase::WaitingFsync => {
+                if !completion.is_success() {
+                    let _ = ROUNDTRIP_ERR
+                        .set(format!("fsync failed: result={}", completion.result));
+                    ROUNDTRIP_DONE.store(true, Ordering::Release);
+                    ctx.request_shutdown();
+                    return;
+                }
+                assert_eq!(completion.op, DirectIoOp::Fsync);
+
+                // Submit read.
+                let file = self.state.file.unwrap();
+                match unsafe {
+                    ctx.direct_io_read(
+                        file,
+                        0, // offset
+                        self.state.read_buf.as_mut_ptr(),
+                        self.state.read_buf.len() as u32,
+                    )
+                } {
+                    Ok(_) => self.state.phase = RoundtripPhase::WaitingRead,
+                    Err(e) => {
+                        let _ = ROUNDTRIP_ERR.set(format!("read submit failed: {e}"));
+                        ROUNDTRIP_DONE.store(true, Ordering::Release);
+                        ctx.request_shutdown();
+                    }
+                }
+            }
+            RoundtripPhase::WaitingRead => {
+                if !completion.is_success() {
+                    let _ = ROUNDTRIP_ERR
+                        .set(format!("read failed: result={}", completion.result));
+                    ROUNDTRIP_DONE.store(true, Ordering::Release);
+                    ctx.request_shutdown();
+                    return;
+                }
+                assert_eq!(completion.op, DirectIoOp::Read);
+                assert_eq!(completion.bytes_transferred(), Some(4096));
+
+                // Verify data matches.
+                if self.state.read_buf == self.state.write_buf {
+                    ROUNDTRIP_OK.store(true, Ordering::Release);
+                } else {
+                    let _ = ROUNDTRIP_ERR.set("data mismatch".to_string());
+                }
+
+                // Close the file and shut down.
+                let file = self.state.file.unwrap();
+                let _ = ctx.close_direct_io_file(file);
+                self.state.phase = RoundtripPhase::Done;
+                ROUNDTRIP_DONE.store(true, Ordering::Release);
+                ctx.request_shutdown();
+            }
+            _ => {}
+        }
+    }
+
+    fn on_accept(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
+    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize { 0 }
+    fn on_send_complete(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _r: io::Result<u32>) {}
+    fn on_close(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
+}
+
+#[test]
+fn direct_io_write_fsync_read_roundtrip() {
+    if !io_uring_supported() {
+        eprintln!("SKIP: io_uring not supported on this kernel");
+        return;
+    }
+    if !o_direct_supported() {
+        eprintln!("SKIP: O_DIRECT not supported on this filesystem");
+        return;
+    }
+
+    // Reset statics (in case test runner reuses the process).
+    ROUNDTRIP_DONE.store(false, Ordering::Release);
+    ROUNDTRIP_OK.store(false, Ordering::Release);
+
+    let (_shutdown, handles) = KrioBuilder::new(direct_io_test_config())
+        .launch::<RoundtripHandler>()
+        .expect("launch failed");
+
+    for h in handles {
+        h.join().unwrap().unwrap();
+    }
+
+    // Clean up temp file.
+    let path = temp_file_path(".krio_direct_io_roundtrip_test");
+    let _ = std::fs::remove_file(&path);
+
+    if let Some(err) = ROUNDTRIP_ERR.get() {
+        panic!("direct I/O roundtrip failed: {err}");
+    }
+    assert!(
+        ROUNDTRIP_DONE.load(Ordering::Acquire),
+        "test did not complete"
+    );
+    assert!(
+        ROUNDTRIP_OK.load(Ordering::Acquire),
+        "data verification failed"
+    );
+}
+
+// ── Multiple files test ─────────────────────────────────────────────
+
+static MULTI_FILE_DONE: AtomicBool = AtomicBool::new(false);
+static MULTI_FILE_OK: AtomicBool = AtomicBool::new(false);
+static MULTI_FILE_ERR: OnceLock<String> = OnceLock::new();
+static MULTI_FILE_COMPLETIONS: AtomicU32 = AtomicU32::new(0);
+
+struct MultiFileState {
+    started: bool,
+    files: Vec<krio::DirectIoFile>,
+    bufs: Vec<Vec<u8>>,
+    paths: Vec<PathBuf>,
+    expected_completions: u32,
+}
+
+struct MultiFileHandler {
+    state: MultiFileState,
+}
+
+impl EventHandler for MultiFileHandler {
+    fn create_for_worker(_id: usize) -> Self {
+        let mut paths = Vec::new();
+        let mut bufs = Vec::new();
+        for i in 0..3 {
+            let path = temp_file_path(&format!(".krio_direct_io_multi_{i}"));
+            std::fs::write(&path, [0u8; 4096]).unwrap();
+            paths.push(path);
+
+            let mut buf = aligned_buf(4096);
+            for (j, byte) in buf.iter_mut().enumerate() {
+                *byte = ((i * 47 + j) % 256) as u8;
+            }
+            bufs.push(buf);
+        }
+
+        MultiFileHandler {
+            state: MultiFileState {
+                started: false,
+                files: Vec::new(),
+                bufs,
+                paths,
+                expected_completions: 3, // one write per file
+            },
+        }
+    }
+
+    fn on_tick(&mut self, ctx: &mut DriverCtx) {
+        if self.state.started {
+            return;
+        }
+        self.state.started = true;
+
+        // Open all files.
+        for path in &self.state.paths {
+            let path_str = path.to_str().unwrap();
+            match ctx.open_direct_io_file(path_str) {
+                Ok(file) => self.state.files.push(file),
+                Err(e) => {
+                    let _ = MULTI_FILE_ERR.set(format!("open failed: {e}"));
+                    MULTI_FILE_DONE.store(true, Ordering::Release);
+                    ctx.request_shutdown();
+                    return;
+                }
+            }
+        }
+
+        // Submit writes to all files.
+        for (i, file) in self.state.files.iter().copied().enumerate() {
+            if let Err(e) = unsafe {
+                ctx.direct_io_write(file, 0, self.state.bufs[i].as_ptr(), 4096)
+            } {
+                let _ = MULTI_FILE_ERR.set(format!("write {i} failed: {e}"));
+                MULTI_FILE_DONE.store(true, Ordering::Release);
+                ctx.request_shutdown();
+                return;
+            }
+        }
+    }
+
+    fn on_direct_io_complete(&mut self, ctx: &mut DriverCtx, completion: DirectIoCompletion) {
+        if !completion.is_success() {
+            let _ = MULTI_FILE_ERR.set(format!(
+                "completion failed: file={} result={}",
+                completion.file.index(),
+                completion.result
+            ));
+            MULTI_FILE_DONE.store(true, Ordering::Release);
+            ctx.request_shutdown();
+            return;
+        }
+
+        let count = MULTI_FILE_COMPLETIONS.fetch_add(1, Ordering::AcqRel) + 1;
+        if count >= self.state.expected_completions {
+            // Close all files.
+            for file in &self.state.files {
+                let _ = ctx.close_direct_io_file(*file);
+            }
+            MULTI_FILE_OK.store(true, Ordering::Release);
+            MULTI_FILE_DONE.store(true, Ordering::Release);
+            ctx.request_shutdown();
+        }
+    }
+
+    fn on_accept(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
+    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize { 0 }
+    fn on_send_complete(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _r: io::Result<u32>) {}
+    fn on_close(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
+}
+
+#[test]
+fn direct_io_multiple_files() {
+    if !io_uring_supported() {
+        eprintln!("SKIP: io_uring not supported on this kernel");
+        return;
+    }
+    if !o_direct_supported() {
+        eprintln!("SKIP: O_DIRECT not supported on this filesystem");
+        return;
+    }
+
+    MULTI_FILE_DONE.store(false, Ordering::Release);
+    MULTI_FILE_OK.store(false, Ordering::Release);
+    MULTI_FILE_COMPLETIONS.store(0, Ordering::Release);
+
+    let (_shutdown, handles) = KrioBuilder::new(direct_io_test_config())
+        .launch::<MultiFileHandler>()
+        .expect("launch failed");
+
+    for h in handles {
+        h.join().unwrap().unwrap();
+    }
+
+    // Clean up.
+    for i in 0..3 {
+        let path = temp_file_path(&format!(".krio_direct_io_multi_{i}"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    if let Some(err) = MULTI_FILE_ERR.get() {
+        panic!("multi-file test failed: {err}");
+    }
+    assert!(MULTI_FILE_DONE.load(Ordering::Acquire));
+    assert!(MULTI_FILE_OK.load(Ordering::Acquire));
+}

--- a/io/krio/tests/direct_io.rs
+++ b/io/krio/tests/direct_io.rs
@@ -11,10 +11,12 @@
 
 use std::io;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-use krio::{Config, ConnToken, DirectIoCompletion, DirectIoOp, DriverCtx, EventHandler, KrioBuilder};
+use krio::{
+    Config, ConnToken, DirectIoCompletion, DirectIoOp, DriverCtx, EventHandler, KrioBuilder,
+};
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -183,8 +185,8 @@ impl EventHandler for RoundtripHandler {
         match self.state.phase {
             RoundtripPhase::WaitingWrite => {
                 if !completion.is_success() {
-                    let _ = ROUNDTRIP_ERR
-                        .set(format!("write failed: result={}", completion.result));
+                    let _ =
+                        ROUNDTRIP_ERR.set(format!("write failed: result={}", completion.result));
                     ROUNDTRIP_DONE.store(true, Ordering::Release);
                     ctx.request_shutdown();
                     return;
@@ -205,8 +207,8 @@ impl EventHandler for RoundtripHandler {
             }
             RoundtripPhase::WaitingFsync => {
                 if !completion.is_success() {
-                    let _ = ROUNDTRIP_ERR
-                        .set(format!("fsync failed: result={}", completion.result));
+                    let _ =
+                        ROUNDTRIP_ERR.set(format!("fsync failed: result={}", completion.result));
                     ROUNDTRIP_DONE.store(true, Ordering::Release);
                     ctx.request_shutdown();
                     return;
@@ -233,8 +235,7 @@ impl EventHandler for RoundtripHandler {
             }
             RoundtripPhase::WaitingRead => {
                 if !completion.is_success() {
-                    let _ = ROUNDTRIP_ERR
-                        .set(format!("read failed: result={}", completion.result));
+                    let _ = ROUNDTRIP_ERR.set(format!("read failed: result={}", completion.result));
                     ROUNDTRIP_DONE.store(true, Ordering::Release);
                     ctx.request_shutdown();
                     return;
@@ -261,7 +262,9 @@ impl EventHandler for RoundtripHandler {
     }
 
     fn on_accept(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
-    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize { 0 }
+    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize {
+        0
+    }
     fn on_send_complete(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _r: io::Result<u32>) {}
     fn on_close(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
 }
@@ -383,9 +386,9 @@ impl EventHandler for MultiFileHandler {
 
         // Submit writes to all files.
         for (i, file) in self.state.files.iter().copied().enumerate() {
-            if let Err(e) = unsafe {
-                ctx.direct_io_write(file, 0, self.state.bufs[i].as_ptr(), 4096)
-            } {
+            if let Err(e) =
+                unsafe { ctx.direct_io_write(file, 0, self.state.bufs[i].as_ptr(), 4096) }
+            {
                 let _ = MULTI_FILE_ERR.set(format!("write {i} failed: {e}"));
                 MULTI_FILE_DONE.store(true, Ordering::Release);
                 ctx.request_shutdown();
@@ -419,7 +422,9 @@ impl EventHandler for MultiFileHandler {
     }
 
     fn on_accept(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
-    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize { 0 }
+    fn on_data(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _data: &[u8]) -> usize {
+        0
+    }
     fn on_send_complete(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken, _r: io::Result<u32>) {}
     fn on_close(&mut self, _ctx: &mut DriverCtx, _conn: ConnToken) {}
 }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,338 @@
+# Plan: NVMe io_uring Passthrough Support in Kompio
+
+## Summary
+
+Add NVMe io_uring passthrough (`IORING_OP_URING_CMD`) to kompio, enabling a
+low-copy storage-to-network path: NVMe read → registered buffer → SendMsgZc.
+
+## Approach: Single Ring with Big SQE/CQE
+
+Switch kompio's ring from `IoUring<Entry, Entry>` (64B SQE, 16B CQE) to
+`IoUring<Entry128, Entry32>` (128B SQE, 32B CQE). This is the simplest
+approach because:
+
+- The io-uring 0.7.11 crate already supports `Entry128`, `Entry32`, and
+  `UringCmd80` — no dependency changes needed
+- `Entry` implements `Into<Entry128>`, so all existing network opcodes
+  (RecvMulti, Send, SendMsgZc, etc.) work unchanged on a Big ring
+- Memory cost is +32 KB per worker (256 SQ × 64B extra + 1024 CQ × 16B extra),
+  negligible vs the ~20 MB already allocated per worker for buffer pools
+- Single ring means NVMe and network ops share registered buffers natively —
+  no cross-ring coordination needed
+
+## Changes by File
+
+### 1. `io/kompio/src/ring.rs` — Ring setup and SQE submission
+
+**Ring type change:**
+- Change `ring: IoUring` to `ring: IoUring<Entry128, Entry32>`
+- In `Ring::setup()`, the `IoUring::builder()` already infers
+  `IORING_SETUP_SQE128 | IORING_SETUP_CQE32` from the type parameters
+
+**push_sqe changes:**
+- Change `push_sqe(&mut self, entry: Entry)` to accept `Entry128`
+- All existing callers build `Entry` values — wrap with `.into()` at call sites
+  (the `From<Entry> for Entry128` impl pads with zeros)
+
+**New submission method:**
+```rust
+pub(crate) unsafe fn push_sqe128(&mut self, entry: Entry128) -> io::Result<()>
+```
+For NVMe commands that produce `Entry128` directly from `UringCmd80::build()`.
+
+**New NVMe submit helpers:**
+```rust
+pub fn submit_nvme_read(
+    &mut self, fd_index: u32, nsid: u32, lba: u64,
+    num_blocks: u16, buf_index: u16, buf_addr: u64, buf_len: u32,
+    user_data: u64,
+) -> io::Result<()>
+
+pub fn submit_nvme_write(
+    &mut self, fd_index: u32, nsid: u32, lba: u64,
+    num_blocks: u16, buf_index: u16, buf_addr: u64, buf_len: u32,
+    user_data: u64,
+) -> io::Result<()>
+```
+
+These construct `nvme_uring_cmd` structs (NVMe Read = opcode 0x02,
+Write = opcode 0x01) and submit via `UringCmd80`.
+
+### 2. `io/kompio/src/completion.rs` — OpTag and UserData
+
+**New OpTag variant:**
+```rust
+NvmeCmd = 12,
+```
+
+**UserData encoding unchanged** — the existing 64-bit layout works:
+- Bits 63..56: OpTag (NvmeCmd)
+- Bits 55..32: device slot index (24 bits, reusing conn_index field)
+- Bits 31..0: command sequence / buffer index (32 bits)
+
+**CQE32 handling:**
+Big CQEs return an extra 16 bytes. For NVMe, this contains the NVMe completion
+queue entry (status, result). Add a helper to extract the NVMe-specific result
+from the extra CQE data. The completion loop needs to pass this extra data
+through for NvmeCmd completions.
+
+### 3. `io/kompio/src/event_loop.rs` — Completion dispatch
+
+**CQE iteration change:**
+When using `Entry32` CQEs, the completion iterator yields `Entry32` values.
+We need to extract both the standard fields (user_data, result, flags) and
+the extra 16 bytes for NVMe completions. For non-NVMe ops, the extra bytes
+are ignored.
+
+**New dispatch arm:**
+```rust
+OpTag::NvmeCmd => self.handle_nvme_cmd(ud, result, flags, extra),
+```
+
+**New handler method:**
+```rust
+fn handle_nvme_cmd(&mut self, ud: UserData, result: i32, flags: u32, extra: &[u8; 16]) {
+    let device_index = ud.conn_index();
+    let seq = ud.payload();
+    // Release command slot
+    // Build NvmeCompletion from extra bytes (NVMe status, result)
+    // Call handler.on_nvme_complete(ctx, device, completion)
+}
+```
+
+**New EventLoop fields:**
+```rust
+nvme_devices: Vec<NvmeDeviceState>,   // Per-device state
+nvme_cmd_slab: NvmeCmdSlab,           // In-flight command tracking
+```
+
+### 4. `io/kompio/src/handler.rs` — EventHandler trait and DriverCtx
+
+**New EventHandler callback (with default no-op):**
+```rust
+fn on_nvme_complete(
+    &mut self,
+    _ctx: &mut DriverCtx,
+    _device: NvmeDevice,
+    _completion: NvmeCompletion,
+) {}
+```
+
+**New DriverCtx methods:**
+```rust
+/// Open and register an NVMe device. Returns a device handle.
+pub fn open_nvme_device(&mut self, path: &str) -> io::Result<NvmeDevice>
+
+/// Submit an NVMe read into a registered buffer.
+pub fn nvme_read(
+    &mut self, device: NvmeDevice, lba: u64, num_blocks: u16,
+    buf_index: u16, buf_offset: usize, buf_len: u32,
+) -> io::Result<u32>  // returns command sequence number
+
+/// Submit an NVMe write from a registered buffer.
+pub fn nvme_write(
+    &mut self, device: NvmeDevice, lba: u64, num_blocks: u16,
+    buf_index: u16, buf_offset: usize, buf_len: u32,
+) -> io::Result<u32>
+
+/// Close an NVMe device.
+pub fn close_nvme_device(&mut self, device: NvmeDevice) -> io::Result<()>
+```
+
+### 5. `io/kompio/src/nvme.rs` — New module for NVMe types
+
+**NVMe command struct (matches kernel `nvme_uring_cmd`):**
+```rust
+#[repr(C)]
+pub struct NvmeUringCmd {
+    pub opcode: u8,
+    pub flags: u8,
+    pub rsvd1: u16,
+    pub nsid: u32,
+    pub cdw2: u32,
+    pub cdw3: u32,
+    pub metadata: u64,
+    pub addr: u64,
+    pub metadata_len: u32,
+    pub data_len: u32,
+    pub cdw10: u32,
+    pub cdw11: u32,
+    pub cdw12: u32,
+    pub cdw13: u32,
+    pub cdw14: u32,
+    pub cdw15: u32,
+    pub timeout_ms: u32,
+    pub rsvd2: u32,
+}
+```
+This is 72 bytes, fits in the 80-byte `UringCmd80` command field.
+
+**NVMe command opcodes:**
+```rust
+pub const NVME_CMD_READ: u8 = 0x02;
+pub const NVME_CMD_WRITE: u8 = 0x01;
+pub const NVME_CMD_FLUSH: u8 = 0x00;
+```
+
+**NVMe uring_cmd sub-opcodes:**
+```rust
+pub const NVME_URING_CMD_IO: u32 = 0;
+pub const NVME_URING_CMD_IO_VEC: u32 = 1;
+```
+
+**Device state:**
+```rust
+pub struct NvmeDevice {
+    pub(crate) index: u16,  // Slot in device table
+}
+
+pub(crate) struct NvmeDeviceState {
+    pub fd_index: u32,       // Index in io_uring fixed file table
+    pub nsid: u32,           // Namespace ID (usually 1)
+    pub block_size: u32,     // Logical block size (512 or 4096)
+    pub max_transfer: u32,   // MDTS in bytes
+    pub active: bool,
+    pub in_flight: u32,      // Commands in flight
+}
+```
+
+**Command tracking slab:**
+```rust
+pub(crate) struct NvmeCmdSlab {
+    entries: Vec<NvmeCmdEntry>,
+    free_list: Vec<u16>,
+}
+
+struct NvmeCmdEntry {
+    device_index: u16,
+    buf_index: u16,
+    in_use: bool,
+}
+```
+
+**NVMe completion result:**
+```rust
+pub struct NvmeCompletion {
+    pub seq: u32,            // Command sequence number
+    pub status: u16,         // NVMe status code
+    pub result: u64,         // Command-specific result
+    pub device: NvmeDevice,
+}
+```
+
+### 6. `io/kompio/src/config.rs` — Configuration
+
+**New config fields:**
+```rust
+pub struct NvmeConfig {
+    /// Maximum number of NVMe devices that can be opened.
+    pub max_devices: u16,
+    /// Maximum NVMe commands in flight per worker.
+    pub max_commands_in_flight: u16,
+}
+
+// In Config:
+pub nvme: Option<NvmeConfig>,
+```
+
+When `nvme` is `None` (default), no NVMe infrastructure is allocated, and the
+ring stays at standard size. When `Some`, the ring uses Big SQE/CQE.
+
+**Decision: Conditional Big ring.**
+If `config.nvme.is_some()`, create `IoUring<Entry128, Entry32>`.
+If `None`, keep `IoUring<Entry, Entry>`. This avoids any overhead for
+users who don't need NVMe. Implemented via an enum:
+
+```rust
+pub(crate) enum RingInner {
+    Standard(IoUring<Entry, Entry>),
+    Big(IoUring<Entry128, Entry32>),
+}
+```
+
+All submission helpers dispatch through this enum. The hot path (network ops)
+pays only a branch prediction cost, which is essentially free since the ring
+type is fixed for the lifetime of the worker.
+
+### 7. `io/kompio/src/lib.rs` — Module registration
+
+Add `pub mod nvme;` and re-export key types:
+- `NvmeDevice`, `NvmeCompletion`, `NvmeConfig`
+
+## Implementation Order
+
+1. **`nvme.rs`** — Types only (NvmeUringCmd, NvmeDevice, NvmeDeviceState,
+   NvmeCmdSlab, NvmeCompletion, NvmeConfig). No io_uring interaction yet.
+
+2. **`config.rs`** — Add `nvme: Option<NvmeConfig>` to Config with `None`
+   default.
+
+3. **`ring.rs`** — Add `RingInner` enum, update `Ring::setup()` to check
+   config.nvme, add `push_sqe128()`, add `submit_nvme_read/write()`. Update
+   existing `push_sqe()` to dispatch through enum.
+
+4. **`completion.rs`** — Add `OpTag::NvmeCmd`, update `from_u8()`.
+
+5. **`event_loop.rs`** — Add `nvme_devices` and `nvme_cmd_slab` fields.
+   Update CQE drain loop to handle `Entry32` extra data. Add
+   `handle_nvme_cmd()`. Wire into `dispatch_cqe()`.
+
+6. **`handler.rs`** — Add `on_nvme_complete()` to EventHandler trait (default
+   no-op). Add DriverCtx methods: `open_nvme_device()`, `nvme_read()`,
+   `nvme_write()`, `close_nvme_device()`.
+
+7. **`lib.rs`** — Module declaration and re-exports.
+
+8. **Tests** — Unit tests for NvmeUringCmd struct layout (size = 72, alignment),
+   NvmeCmdSlab alloc/release, UserData encoding with NvmeCmd tag. Integration
+   test requires an NVMe device, so gate behind `#[cfg(feature = "nvme-test")]`.
+
+## What This Does NOT Include
+
+- **Block allocator** — Managing which LBAs are free/used on the NVMe device.
+  That's a cache-core concern (analogous to segment allocation), not an I/O
+  framework concern. Kompio provides the I/O primitives; the cache server
+  decides what to read/write and where.
+
+- **Filesystem** — By design. Passthrough bypasses the filesystem entirely.
+
+- **Cache integration** — Wiring the kompio NVMe API into the server's
+  EventHandler to implement a persistent cache tier. That's a follow-up.
+
+- **Admin commands** — Only I/O commands (read/write/flush) for now. Identify
+  and other admin commands can be added later.
+
+## Buffer Sharing Design
+
+The registered buffer pool (`FixedBufferRegistry`) is ring-level. NVMe reads
+and SendMsgZc sends reference the same registered buffers by index. The
+lifecycle:
+
+```
+1. nvme_read(device, lba, blocks, buf_index=3, ...)
+   → SQE submitted, buffer 3 owned by kernel/NVMe controller
+
+2. on_nvme_complete(completion)
+   → Buffer 3 now contains data from NVMe
+   → Application can inspect/process the data
+
+3. ctx.send_parts(conn).guard_registered(buf_index=3, ptr, len).submit()
+   → SendMsgZc SQE submitted, buffer 3 owned by kernel/NIC
+
+4. on_send_complete(result)
+   → Initial send done, but buffer NOT yet safe
+
+5. [ZC notification CQE arrives]
+   → Buffer 3 is now safe to reuse for next NVMe read
+```
+
+The application (EventHandler implementation) is responsible for tracking
+buffer ownership across these phases. Kompio provides the primitives; the
+server manages the state machine.
+
+## Kernel Requirements
+
+- Existing: Linux 6.0+ (SendMsgZc)
+- NVMe passthrough: Linux 5.19+ (already covered by 6.0 requirement)
+- NVMe device permissions: `CAP_SYS_ADMIN` or appropriate udev rules on
+  `/dev/ng*`


### PR DESCRIPTION
Design plan for adding IORING_OP_URING_CMD (NVMe passthrough) support
to the kompio I/O framework, enabling a low-copy storage-to-network
data path using shared registered buffers between NVMe reads and
SendMsgZc network sends.

https://claude.ai/code/session_01E5kRxU86e9oHVFMDpra45i