### PR TITLE
release: v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-02-18
+
+### Added
+- **io_uring disk tier** for segcache: Direct I/O and NVMe io_uring passthrough backends for
+  segment demotion/promotion, with block-aligned reads, lock-free disk segment pool, and
+  configurable promotion threshold
+- **krio async disk I/O API**: `open_direct_io_file()`, `direct_io_read()`, `open_nvme_device()`,
+  `nvme_read()` free functions with `DiskIoFuture` for awaitable io_uring disk operations
+- Async server integration tests (7 tests mirroring callback server test suite)
+- Disk tier integration tests for both callback and async servers with DirectIo backend
+- CI smoketest configs for async server and DirectIo disk tier
+
+### Fixed
+- Async server binary (`crucible-server-async`) now correctly uses `IoUringDiskTierConfig` for
+  DirectIo/NVMe backends instead of mmap-based `DiskTierConfig`
+- Async server disk I/O initialization moved from `on_accept()` (outside executor context) to
+  `handle_connection()` (inside executor context) to prevent "called outside executor" panic
+- `BasicHeader::from_bytes_unchecked()` calls replaced with `from_bytes()` for `--all-features`
+  compatibility (the unchecked variant is `#[cfg(not(feature = "validation"))]`)
+- `IoUringPool` unit tests gated with `#[cfg(not(feature = "loom"))]` to prevent loom scheduler
+  panics from crossbeam-deque atomics outside `loom::model`
+- Broken rustdoc link to `IoUringDiskLayer` in `server::disk_io`
+- Clippy warnings: manual `abs_diff` pattern, unused `spare_queue` field
+
 ## [0.3.5] - 2026-02-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow",
  "axum",
@@ -534,7 +534,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-bench"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cache-core",
  "clap",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "cache-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "bytes",
@@ -843,7 +843,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crucible-grpc-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-http-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-memcache-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-momento-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-resp-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "ketama",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "http2",
@@ -1195,7 +1195,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "rustls",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "http3"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "krio",
@@ -1480,11 +1480,11 @@ dependencies = [
 
 [[package]]
 name = "ketama"
-version = "0.3.5"
+version = "0.3.6"
 
 [[package]]
 name = "krio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "krio-memcache"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "ketama",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "krio-quic"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "krio",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "krio-redis"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "ketama",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "metriken",
 ]
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "itoa",
  "memchr",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "grpc",
@@ -2309,14 +2309,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bytes",
  "itoa",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "axum",
@@ -2689,7 +2689,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "axum",
  "bytes",
@@ -2882,7 +2882,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache-bench/Cargo.toml
+++ b/cache-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-bench"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-grpc-client"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true
 

--- a/client-http/Cargo.toml
+++ b/client-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-http-client"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true
 

--- a/client-memcache/Cargo.toml
+++ b/client-memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-memcache-client"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true
 

--- a/client-momento/Cargo.toml
+++ b/client-momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-momento-client"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true
 

--- a/client-resp/Cargo.toml
+++ b/client-resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-resp-client"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http3/Cargo.toml
+++ b/io/http3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http3"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-memcache/Cargo.toml
+++ b/io/krio-memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-memcache"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-quic/Cargo.toml
+++ b/io/krio-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-quic"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-redis/Cargo.toml
+++ b/io/krio-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-redis"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio/Cargo.toml
+++ b/io/krio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [features]

--- a/ketama/Cargo.toml
+++ b/ketama/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "ketama"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.3.5"
+version = "0.3.6"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.3.6

This PR prepares the release of v0.3.6.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- **io_uring disk tier** for segcache with Direct I/O and NVMe backends
- **krio async disk I/O API** with awaitable io_uring disk operations
- Async server and disk tier integration tests + CI smoketest configs
- Bug fixes for async server disk tier config, loom compatibility, and clippy/rustdoc warnings

### After Merge
The release workflow will automatically:
1. Create git tag `v0.3.6`
2. Build and publish release artifacts
3. Bump to next development version (`0.3.7-alpha.0`)

---
See CHANGELOG.md for details.