### PR TITLE
release: v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-02-19
+
+### Fixed
+- **S3-FIFO promotion path**: `evict_from_layer()` now uses each layer's configured `next_layer`
+  for demotion instead of always targeting the disk layer. Layer 0 correctly demotes to Layer 1
+  (main queue), Layer 1 demotes to disk, fixing empty main queue segments.
+- **Cascading eviction**: `ensure_space()` ensures downstream layers have free segments before
+  demoting (bottom-up: disk → Layer 1 → Layer 0), preventing demotion failures from full targets.
+- **Disk segment eviction**: Disk layer segments can now be evicted and recycled when full,
+  preventing `OutOfMemory` after all disk segments are allocated.
+- **Write buffer leaks**: `process_evicted_segment()` and `release_read()` now properly return
+  write buffers to the pool when evicting unflushed segments or releasing condemned segments.
+- **Write buffer pool ownership**: `AlignedBufferPool` moved into `IoUringDiskLayer` struct so
+  all code paths (eviction, condemned cleanup, flush completion) can return buffers. Previously
+  broke `--all-features` builds.
+
+### Changed
+- `IoUringDiskLayer::write_item()` now works via the `Layer` trait (was returning `Unsupported`)
+- `IoUringDiskLayer::complete_flush()` no longer takes a `buffer_pool` parameter
+- `IoUringDiskLayer::write_item_with_buffers()` no longer takes a `buffer_pool` parameter
+
+### Added
+- `write_buffer_count` config for `IoUringDiskLayerBuilder` and `IoUringDiskTierConfig`
+  (default: 16). Controls RAM usage for disk write staging buffers. Under pressure, demotion
+  degrades gracefully to discard.
+
 ## [0.3.6] - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "benchmark"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "arrow",
  "axum",
@@ -534,7 +534,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-bench"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cache-core",
  "clap",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "cache-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ahash",
  "bytes",
@@ -843,7 +843,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crucible-grpc-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-http-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-memcache-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-momento-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-resp-client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "ketama",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "http2",
@@ -1195,7 +1195,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "http2"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "rustls",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "http3"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "krio",
@@ -1480,11 +1480,11 @@ dependencies = [
 
 [[package]]
 name = "ketama"
-version = "0.3.6"
+version = "0.3.7"
 
 [[package]]
 name = "krio"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "krio-memcache"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "ketama",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "krio-quic"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "krio",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "krio-redis"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "ketama",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "metriken",
 ]
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "grpc",
@@ -2309,14 +2309,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bytes",
  "itoa",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "ahash",
  "axum",
@@ -2689,7 +2689,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "axum",
  "bytes",
@@ -2882,7 +2882,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache-bench/Cargo.toml
+++ b/cache-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-bench"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/src/disk/io_uring_layer.rs
+++ b/cache/core/src/disk/io_uring_layer.rs
@@ -421,11 +421,7 @@ impl IoUringDiskLayer {
     }
 
     /// Allocate a new segment and add it to the specified bucket.
-    fn allocate_segment_for_bucket(
-        &self,
-        bucket_index: usize,
-        ttl: Duration,
-    ) -> CacheResult<u32> {
+    fn allocate_segment_for_bucket(&self, bucket_index: usize, ttl: Duration) -> CacheResult<u32> {
         let segment_id = self.pool.reserve().ok_or(CacheError::OutOfMemory)?;
 
         let segment = self.pool.get(segment_id).ok_or(CacheError::OutOfMemory)?;

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-grpc-client"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 

--- a/client-http/Cargo.toml
+++ b/client-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-http-client"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 

--- a/client-memcache/Cargo.toml
+++ b/client-memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-memcache-client"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 

--- a/client-momento/Cargo.toml
+++ b/client-momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-momento-client"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true
 

--- a/client-resp/Cargo.toml
+++ b/client-resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-resp-client"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 

--- a/io/grpc/Cargo.toml
+++ b/io/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http2/Cargo.toml
+++ b/io/http2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http2"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/io/http3/Cargo.toml
+++ b/io/http3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http3"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-memcache/Cargo.toml
+++ b/io/krio-memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-memcache"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-quic/Cargo.toml
+++ b/io/krio-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-quic"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio-redis/Cargo.toml
+++ b/io/krio-redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio-redis"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 

--- a/io/krio/Cargo.toml
+++ b/io/krio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krio"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [features]

--- a/ketama/Cargo.toml
+++ b/ketama/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "ketama"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/memcache/Cargo.toml
+++ b/protocol/memcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-memcache"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/resp/Cargo.toml
+++ b/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/tests/async_server_integration.rs
+++ b/server/tests/async_server_integration.rs
@@ -24,10 +24,11 @@ fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
             stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
             if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
                 let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n >= 5 && &buf[..5] == b"+PONG" {
-                        return true;
-                    }
+                if let Ok(n) = stream.read(&mut buf)
+                    && n >= 5
+                    && &buf[..5] == b"+PONG"
+                {
+                    return true;
                 }
             }
         }

--- a/server/tests/async_server_integration.rs
+++ b/server/tests/async_server_integration.rs
@@ -20,8 +20,16 @@ fn get_available_port() -> u16 {
 fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
-            return true;
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n >= 5 && &buf[..5] == b"+PONG" {
+                        return true;
+                    }
+                }
+            }
         }
         thread::sleep(Duration::from_millis(10));
     }

--- a/server/tests/disk_tier_integration.rs
+++ b/server/tests/disk_tier_integration.rs
@@ -24,10 +24,11 @@ fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
             stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
             if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
                 let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n >= 5 && &buf[..5] == b"+PONG" {
-                        return true;
-                    }
+                if let Ok(n) = stream.read(&mut buf)
+                    && n >= 5
+                    && &buf[..5] == b"+PONG"
+                {
+                    return true;
                 }
             }
         }

--- a/server/tests/disk_tier_integration.rs
+++ b/server/tests/disk_tier_integration.rs
@@ -20,8 +20,16 @@ fn get_available_port() -> u16 {
 fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
-            return true;
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n >= 5 && &buf[..5] == b"+PONG" {
+                        return true;
+                    }
+                }
+            }
         }
         thread::sleep(Duration::from_millis(10));
     }

--- a/server/tests/e2e_resp.rs
+++ b/server/tests/e2e_resp.rs
@@ -19,8 +19,16 @@ fn get_available_port() -> u16 {
 fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(50)).is_ok() {
-            return true;
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(50)) {
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n >= 5 && &buf[..5] == b"+PONG" {
+                        return true;
+                    }
+                }
+            }
         }
         thread::sleep(Duration::from_millis(50));
     }

--- a/server/tests/e2e_resp.rs
+++ b/server/tests/e2e_resp.rs
@@ -23,10 +23,11 @@ fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
             stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
             if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
                 let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n >= 5 && &buf[..5] == b"+PONG" {
-                        return true;
-                    }
+                if let Ok(n) = stream.read(&mut buf)
+                    && n >= 5
+                    && &buf[..5] == b"+PONG"
+                {
+                    return true;
                 }
             }
         }

--- a/server/tests/io_engine_integration.rs
+++ b/server/tests/io_engine_integration.rs
@@ -47,10 +47,11 @@ fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
             stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
             if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
                 let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n >= 5 && &buf[..5] == b"+PONG" {
-                        return true;
-                    }
+                if let Ok(n) = stream.read(&mut buf)
+                    && n >= 5
+                    && &buf[..5] == b"+PONG"
+                {
+                    return true;
                 }
             }
         }

--- a/server/tests/io_engine_integration.rs
+++ b/server/tests/io_engine_integration.rs
@@ -43,8 +43,16 @@ fn get_available_port() -> u16 {
 fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
-            return true;
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n >= 5 && &buf[..5] == b"+PONG" {
+                        return true;
+                    }
+                }
+            }
         }
         thread::sleep(Duration::from_millis(10));
     }

--- a/server/tests/large_value_io_tests.rs
+++ b/server/tests/large_value_io_tests.rs
@@ -52,10 +52,11 @@ fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
             stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
             if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
                 let mut buf = [0u8; 32];
-                if let Ok(n) = stream.read(&mut buf) {
-                    if n >= 5 && &buf[..5] == b"+PONG" {
-                        return true;
-                    }
+                if let Ok(n) = stream.read(&mut buf)
+                    && n >= 5
+                    && &buf[..5] == b"+PONG"
+                {
+                    return true;
                 }
             }
         }

--- a/server/tests/large_value_io_tests.rs
+++ b/server/tests/large_value_io_tests.rs
@@ -47,8 +47,17 @@ fn get_available_port() -> u16 {
 fn wait_for_server(addr: SocketAddr, timeout: Duration) -> bool {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok() {
-            return true;
+        if let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(100)) {
+            // Send PING and wait for PONG to confirm a worker is processing
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            if stream.write_all(b"*1\r\n$4\r\nPING\r\n").is_ok() {
+                let mut buf = [0u8; 32];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n >= 5 && &buf[..5] == b"+PONG" {
+                        return true;
+                    }
+                }
+            }
         }
         thread::sleep(Duration::from_millis(10));
     }


### PR DESCRIPTION
## Release v0.3.7

This PR prepares the release of v0.3.7.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- **S3-FIFO promotion fix**: Layer 0 now correctly demotes to Layer 1 (main queue) instead of skipping straight to disk
- **Cascading eviction**: `ensure_space()` frees downstream layers bottom-up before demoting
- **Disk segment recycling**: Disk segments can now be evicted when full
- **Write buffer pool**: Moved into `IoUringDiskLayer` with configurable `write_buffer_count` (default 16)

### After Merge
The release workflow will automatically:
1. Create git tag `v0.3.7`
2. Build and publish release artifacts
3. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.