### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-02-25
+
+### Fixed
+- **Merge eviction rewritten to SSD GC style** (cache-core): The previous implementation used
+  in-place pruning (`segment.prune()`) which marked items as deleted but never freed segments,
+  causing `ensure_space` to loop until OutOfMemory. The new implementation reserves a spare
+  segment, copies high-frequency items into it via `cas_location` (preserving frequency),
+  atomically replaces the source segments in the chain, and frees them — correctly reclaiming
+  memory. Adds `TtlBucket::replace_head_segments()` for atomically swapping N contiguous head
+  segments with a spare
+
 ## [0.4.0] - 2026-02-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-bench"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "cache-core",
  "clap",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "cache-core"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "bytes",
@@ -584,7 +584,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heap-cache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "metriken",
 ]
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-momento"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "grpc-proto",
@@ -1192,14 +1192,14 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "proxy"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "axum",
@@ -1503,7 +1503,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "segcache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "cache-core",
  "clocksource",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "bytes",
@@ -1671,7 +1671,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slab-cache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 dependencies = [
  "cache-core",
  "clocksource",

--- a/cache-bench/Cargo.toml
+++ b/cache-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-bench"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-core"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heap-cache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/segcache/Cargo.toml
+++ b/cache/segcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segcache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slab-cache"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-momento"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/protocol/ping/Cargo.toml
+++ b/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.1-alpha.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release v0.4.1

This PR prepares the release of v0.4.1.

### Changes
- Version bump across all crates
- Changelog update

### Highlights
- **Fix merge eviction**: Rewrote merge eviction from broken in-place pruning to SSD GC style (spare segment copy + free source segments), fixing OutOfMemory loops

### After Merge
The release workflow will automatically:
1. Create git tag `v0.4.1`
2. Build and publish release artifacts
3. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.