### PR TITLE
fix(server): validate config at startup and fix drain exit code

### DIFF
--- a/server/config/disk-tier.toml
+++ b/server/config/disk-tier.toml
@@ -63,13 +63,15 @@ recover_on_startup = true
 # size = "100GB"
 # promotion_threshold = 2
 
+# Protocol listener (only one listener is supported)
 [[listener]]
 protocol = "resp"
 address = "0.0.0.0:6379"
 
-[[listener]]
-protocol = "memcache"
-address = "0.0.0.0:11211"
+# # Memcache protocol listener (swap with above to use memcache instead)
+# [[listener]]
+# protocol = "memcache"
+# address = "0.0.0.0:11211"
 
 [metrics]
 address = "0.0.0.0:9090"

--- a/server/config/example.toml
+++ b/server/config/example.toml
@@ -85,15 +85,15 @@ hashtable_power = 16
 # # nvme_device = "/dev/ng0n1"
 # # nvme_nsid = 1
 
-# RESP protocol listener (Redis-compatible)
+# Protocol listener (only one listener is supported)
 [[listener]]
 protocol = "resp"
 address = "127.0.0.1:6379"
 
-# Memcache protocol listener
-[[listener]]
-protocol = "memcache"
-address = "127.0.0.1:11211"
+# # Memcache protocol listener (swap with above to use memcache instead)
+# [[listener]]
+# protocol = "memcache"
+# address = "127.0.0.1:11211"
 
 [metrics]
 # Prometheus metrics endpoint

--- a/server/config/heap.toml
+++ b/server/config/heap.toml
@@ -42,15 +42,15 @@ hashtable_power = 24
 # sync_mode = "async"        # "sync", "async", or "none"
 # recover_on_startup = true  # Recover disk cache on restart
 
-# RESP protocol listener (Redis-compatible)
+# Protocol listener (only one listener is supported)
 [[listener]]
 protocol = "resp"
 address = "127.0.0.1:6379"
 
-# Memcache protocol listener
-[[listener]]
-protocol = "memcache"
-address = "127.0.0.1:11211"
+# # Memcache protocol listener (swap with above to use memcache instead)
+# [[listener]]
+# protocol = "memcache"
+# address = "127.0.0.1:11211"
 
 [metrics]
 address = "127.0.0.1:9090"

--- a/server/config/slab.toml
+++ b/server/config/slab.toml
@@ -49,15 +49,15 @@ hugepage = "none"
 # sync_mode = "async"        # "sync", "async", or "none"
 # recover_on_startup = true  # Recover disk cache on restart
 
-# RESP protocol listener (Redis-compatible)
+# Protocol listener (only one listener is supported)
 [[listener]]
 protocol = "resp"
 address = "127.0.0.1:6379"
 
-# Memcache protocol listener
-[[listener]]
-protocol = "memcache"
-address = "127.0.0.1:11211"
+# # Memcache protocol listener (swap with above to use memcache instead)
+# [[listener]]
+# protocol = "memcache"
+# address = "127.0.0.1:11211"
 
 [metrics]
 address = "127.0.0.1:9090"

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -235,7 +235,7 @@ mod server {
                 active_connections = active_conns,
                 "Drain timeout reached, {} connections still active — forcing exit", active_conns
             );
-            std::process::exit(0);
+            std::process::exit(1);
         }
 
         for (i, handle) in handles.into_iter().enumerate() {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -824,6 +824,25 @@ impl Config {
             return Err("at least one listener must be configured".into());
         }
 
+        if self.listener.len() > 1 {
+            return Err(
+                "multiple listeners are not yet supported; configure exactly one listener".into(),
+            );
+        }
+
+        // Validate NVMe disk config fields
+        if let Some(ref disk) = self.cache.disk
+            && disk.enabled
+            && disk.io_backend == DiskIoBackendConfig::Nvme
+        {
+            if disk.nvme_device.is_none() {
+                return Err("nvme_device is required when disk io_backend is \"nvme\"".into());
+            }
+            if disk.nvme_nsid.is_none() {
+                return Err("nvme_nsid is required when disk io_backend is \"nvme\"".into());
+            }
+        }
+
         Ok(())
     }
 
@@ -966,5 +985,120 @@ mod tests {
         assert_eq!(parse_cpu_list("0-7").unwrap(), vec![0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(parse_cpu_list("1,3,8").unwrap(), vec![1, 3, 8]);
         assert_eq!(parse_cpu_list("0-7:2").unwrap(), vec![0, 2, 4, 6]);
+    }
+
+    /// Helper to build a minimal valid Config for validation tests.
+    fn minimal_config() -> Config {
+        Config {
+            workers: WorkersConfig::default(),
+            cache: CacheConfig::default(),
+            listener: vec![ListenerConfig {
+                protocol: Protocol::Resp,
+                address: "127.0.0.1:6379".parse().unwrap(),
+                tls: None,
+                allow_flush: false,
+            }],
+            metrics: MetricsConfig::default(),
+            shutdown: ShutdownConfig::default(),
+            logging: LoggingConfig::default(),
+            uring: UringConfig::default(),
+        }
+    }
+
+    #[test]
+    fn test_validate_single_listener_ok() {
+        let config = minimal_config();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_no_listeners() {
+        let mut config = minimal_config();
+        config.listener.clear();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("at least one listener"));
+    }
+
+    #[test]
+    fn test_validate_multiple_listeners_rejected() {
+        let mut config = minimal_config();
+        config.listener.push(ListenerConfig {
+            protocol: Protocol::Memcache,
+            address: "127.0.0.1:11211".parse().unwrap(),
+            tls: None,
+            allow_flush: false,
+        });
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("multiple listeners"));
+    }
+
+    #[test]
+    fn test_validate_nvme_missing_device() {
+        let mut config = minimal_config();
+        config.cache.disk = Some(DiskConfig {
+            enabled: true,
+            io_backend: DiskIoBackendConfig::Nvme,
+            nvme_device: None,
+            nvme_nsid: Some(1),
+            path: default_disk_path(),
+            size: default_disk_size(),
+            promotion_threshold: default_promotion_threshold(),
+            sync_mode: DiskSyncMode::default(),
+            recover_on_startup: true,
+        });
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("nvme_device is required"));
+    }
+
+    #[test]
+    fn test_validate_nvme_missing_nsid() {
+        let mut config = minimal_config();
+        config.cache.disk = Some(DiskConfig {
+            enabled: true,
+            io_backend: DiskIoBackendConfig::Nvme,
+            nvme_device: Some("/dev/ng0n1".to_string()),
+            nvme_nsid: None,
+            path: default_disk_path(),
+            size: default_disk_size(),
+            promotion_threshold: default_promotion_threshold(),
+            sync_mode: DiskSyncMode::default(),
+            recover_on_startup: true,
+        });
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("nvme_nsid is required"));
+    }
+
+    #[test]
+    fn test_validate_nvme_complete_config_ok() {
+        let mut config = minimal_config();
+        config.cache.disk = Some(DiskConfig {
+            enabled: true,
+            io_backend: DiskIoBackendConfig::Nvme,
+            nvme_device: Some("/dev/ng0n1".to_string()),
+            nvme_nsid: Some(1),
+            path: default_disk_path(),
+            size: default_disk_size(),
+            promotion_threshold: default_promotion_threshold(),
+            sync_mode: DiskSyncMode::default(),
+            recover_on_startup: true,
+        });
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_nvme_disabled_skips_check() {
+        let mut config = minimal_config();
+        config.cache.disk = Some(DiskConfig {
+            enabled: false,
+            io_backend: DiskIoBackendConfig::Nvme,
+            nvme_device: None,
+            nvme_nsid: None,
+            path: default_disk_path(),
+            size: default_disk_size(),
+            promotion_threshold: default_promotion_threshold(),
+            sync_mode: DiskSyncMode::default(),
+            recover_on_startup: true,
+        });
+        assert!(config.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- **Reject multiple listeners at config load time** — the server only binds `listener[0]`, so extra listeners were silently ignored. Now `Config::validate()` returns a clear error instead.
- **Validate NVMe disk config fields at startup** — when `io_backend = "nvme"`, missing `nvme_device` or `nvme_nsid` now fails at config load instead of panicking at runtime.
- **Fix drain timeout exit code** — changed `process::exit(0)` to `process::exit(1)` so monitoring systems correctly detect a non-clean shutdown.
- Updated 4 example configs to comment out the second listener.
- Added 7 unit tests covering all new validation paths.

## Test plan

- [ ] Verify `cargo test -p server --lib config::tests` passes on Linux
- [ ] Verify server rejects config with multiple `[[listener]]` entries
- [ ] Verify server rejects NVMe config missing `nvme_device` or `nvme_nsid`
- [ ] Verify drain timeout logs warning and exits with code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)