### PR TITLE
fix(server): fix e2e_resp test reliability and remove process::exit

### DIFF
--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -229,16 +229,10 @@ mod server {
             std::thread::sleep(Duration::from_millis(100));
         }
 
-        let active_conns = crate::metrics::CONNECTIONS_ACTIVE.value();
-        if active_conns > 0 {
-            warn!(
-                active_connections = active_conns,
-                "Drain timeout reached, {} connections still active — forcing exit", active_conns
-            );
-            std::process::exit(1);
-        }
-
         for (i, handle) in handles.into_iter().enumerate() {
+            if !workers_stopped[i] {
+                debug!(worker_id = i, "Worker did not stop within drain timeout");
+            }
             match handle.join() {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => warn!(worker_id = i, error = %e, "worker thread returned error"),

--- a/server/tests/e2e_resp.rs
+++ b/server/tests/e2e_resp.rs
@@ -80,13 +80,27 @@ fn start_test_server(cache_port: u16) -> (thread::JoinHandle<()>, Arc<AtomicBool
     (handle, shutdown)
 }
 
-/// Stop the test server - closes connections first, then signals shutdown.
+/// Stop the test server and wait for it to fully shut down.
+///
+/// This MUST join the server thread to ensure global statics (CONFIG_CHANNEL,
+/// WORKERS_INITIALIZED, CONNECTIONS_ACTIVE) are in a clean state before the
+/// next `#[serial]` test starts.
 fn stop_test_server(handle: thread::JoinHandle<()>, shutdown: Arc<AtomicBool>) {
     shutdown.store(true, Ordering::SeqCst);
-    // Wait a bit for server to shut down, but don't block forever
+
+    // Wait for the server thread to actually finish. The drain timeout in the
+    // test config is 500ms, so the server should stop within ~1s.
+    let start = std::time::Instant::now();
+    while !handle.is_finished() && start.elapsed() < Duration::from_secs(5) {
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    if handle.is_finished() {
+        let _ = handle.join();
+    }
+
+    // Brief pause for kernel to release the listening socket (TIME_WAIT).
     thread::sleep(Duration::from_millis(100));
-    // Drop the handle - the server thread will be cleaned up when the test exits
-    drop(handle);
 }
 
 /// Send a RESP command and read the response.


### PR DESCRIPTION
## Summary

- **Fix `stop_test_server()` to join the server thread** — was calling `drop(handle)` which detaches the thread, leaving global statics (`CONFIG_CHANNEL`, `WORKERS_INITIALIZED`, `CONNECTIONS_ACTIVE`) dirty when the next `#[serial]` test starts. Now polls `is_finished()` with a 5s timeout and joins properly.
- **Remove `process::exit(1)` from drain timeout path** — `process::exit()` kills the entire test process, not just the server thread. If any stale `CONNECTIONS_ACTIVE` count existed from a previous detached server thread, the next test's shutdown would terminate all tests. Workers are joined normally after drain timeout since ringline's `shutdown()` signal already causes them to exit.

## Root cause

The combination of these two bugs created a cascading failure:
1. Test A's `stop_test_server` detaches the server thread (doesn't join)
2. Test B starts, runs its server, completes, signals shutdown
3. Test B's server enters drain, `CONNECTIONS_ACTIVE` has a stale non-zero value from the still-running Test A server
4. `process::exit(1)` kills the entire test harness → "5 tests, exit status: 1"

## Test plan

- [ ] CI: `cargo test -p server --test e2e_resp` passes reliably
- [ ] CI: all other `#[serial]` integration tests still pass
- [ ] Server still shuts down cleanly in production (drain timeout → join workers → return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)