### PR TITLE
fix(server): report client validation errors on SET instead of silent OK

### DIFF
--- a/cache/core/src/error.rs
+++ b/cache/core/src/error.rs
@@ -101,6 +101,26 @@ impl fmt::Display for CacheError {
     }
 }
 
+impl CacheError {
+    /// Returns true if this error indicates a client-side issue (bad input)
+    /// that should be reported back to the client, as opposed to an internal
+    /// cache-pressure or transient error that can be silently dropped in
+    /// best-effort mode.
+    pub fn is_client_error(&self) -> bool {
+        matches!(
+            self,
+            Self::KeyTooLong
+                | Self::ValueTooLong
+                | Self::OptionalTooLong
+                | Self::InvalidTtl
+                | Self::WrongType
+                | Self::Unsupported
+                | Self::NotNumeric
+                | Self::Overflow
+        )
+    }
+}
+
 impl std::error::Error for CacheError {}
 
 /// Result type for cache operations.
@@ -182,5 +202,28 @@ mod tests {
         let result: CacheResult<i32> = Err(CacheError::KeyNotFound);
         assert!(result.is_err());
         assert!(matches!(result, Err(CacheError::KeyNotFound)));
+    }
+
+    #[test]
+    fn test_is_client_error() {
+        // Client errors: should be reported back to the caller
+        assert!(CacheError::KeyTooLong.is_client_error());
+        assert!(CacheError::ValueTooLong.is_client_error());
+        assert!(CacheError::OptionalTooLong.is_client_error());
+        assert!(CacheError::InvalidTtl.is_client_error());
+        assert!(CacheError::WrongType.is_client_error());
+        assert!(CacheError::Unsupported.is_client_error());
+        assert!(CacheError::NotNumeric.is_client_error());
+        assert!(CacheError::Overflow.is_client_error());
+
+        // Internal/cache-pressure errors: safe to silently drop
+        assert!(!CacheError::OutOfMemory.is_client_error());
+        assert!(!CacheError::HashTableFull.is_client_error());
+        assert!(!CacheError::KeyExists.is_client_error());
+        assert!(!CacheError::KeyNotFound.is_client_error());
+        assert!(!CacheError::Corrupted.is_client_error());
+        assert!(!CacheError::SegmentNotAccessible.is_client_error());
+        assert!(!CacheError::ItemExpired.is_client_error());
+        assert!(!CacheError::ItemDeleted.is_client_error());
     }
 }

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -290,20 +290,35 @@ impl Connection {
             Err(cache_core::CacheError::OutOfMemory | cache_core::CacheError::HashTableFull) => {
                 false
             }
-            Err(_) => {
+            Err(e) => {
                 // Non-retryable error, give up
-                self.abandon_retry();
+                self.abandon_retry_with_error(e);
                 true
             }
         }
     }
 
-    /// Abandon a pending SET retry: write a success response (silent drop)
-    /// and increment SET_ERRORS.
+    /// Abandon a pending SET retry due to timeout (cache pressure).
+    /// Writes a success response (silent drop) since the original error
+    /// was OutOfMemory/HashTableFull.
     pub fn abandon_retry(&mut self) {
         use crate::metrics::SET_ERRORS;
         SET_ERRORS.increment();
         self.write_set_success_response();
+        self.pending_retry = None;
+    }
+
+    /// Abandon a pending SET retry due to a non-retryable error.
+    /// Reports client errors back to the caller; silently drops for
+    /// cache-internal errors.
+    fn abandon_retry_with_error(&mut self, error: cache_core::CacheError) {
+        use crate::metrics::SET_ERRORS;
+        SET_ERRORS.increment();
+        if error.is_client_error() {
+            self.write_set_error_response(&error);
+        } else {
+            self.write_set_success_response();
+        }
         self.pending_retry = None;
     }
 
@@ -331,6 +346,40 @@ impl Connection {
                         Opcode::Set,
                         retry.opaque,
                         0,
+                    );
+                    self.write_buf.truncate(start + len);
+                }
+            }
+        }
+    }
+
+    /// Write the protocol-appropriate error response for a SET operation.
+    fn write_set_error_response(&mut self, error: &cache_core::CacheError) {
+        match self.protocol {
+            DetectedProtocol::Resp | DetectedProtocol::Unknown => {
+                self.write_buf.extend_from_slice(b"-ERR ");
+                self.write_buf
+                    .extend_from_slice(error.to_string().as_bytes());
+                self.write_buf.extend_from_slice(b"\r\n");
+            }
+            DetectedProtocol::MemcacheAscii => {
+                self.write_buf.extend_from_slice(b"CLIENT_ERROR ");
+                self.write_buf
+                    .extend_from_slice(error.to_string().as_bytes());
+                self.write_buf.extend_from_slice(b"\r\n");
+            }
+            DetectedProtocol::MemcacheBinary => {
+                if let Some(retry) = &self.pending_retry {
+                    use memcache_proto::binary::{BinaryResponse, Opcode};
+                    let start = self.write_buf.len();
+                    self.write_buf.reserve(24);
+                    unsafe {
+                        self.write_buf.set_len(start + 24);
+                    }
+                    let len = BinaryResponse::encode_invalid_arguments(
+                        &mut self.write_buf[start..],
+                        Opcode::Set,
+                        retry.opaque,
                     );
                     self.write_buf.truncate(start + len);
                 }

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -2503,6 +2503,144 @@ mod tests {
         assert!(!conn.has_pending_write());
     }
 
+    // --- SET error response tests ---
+
+    /// A mock cache that returns a configurable error from set().
+    struct FailingSetCache {
+        error: cache_core::CacheError,
+    }
+
+    impl Cache for FailingSetCache {
+        fn get(&self, _key: &[u8]) -> Option<cache_core::OwnedGuard> {
+            None
+        }
+
+        fn with_value<F, R>(&self, _key: &[u8], _f: F) -> Option<R>
+        where
+            F: FnOnce(&[u8]) -> R,
+        {
+            None
+        }
+
+        fn get_value_ref(&self, _key: &[u8]) -> Option<cache_core::ValueRef> {
+            None
+        }
+
+        fn set(
+            &self,
+            _key: &[u8],
+            _value: &[u8],
+            _ttl: Option<std::time::Duration>,
+        ) -> Result<(), cache_core::CacheError> {
+            Err(self.error)
+        }
+
+        fn delete(&self, _key: &[u8]) -> bool {
+            false
+        }
+
+        fn contains(&self, _key: &[u8]) -> bool {
+            false
+        }
+
+        fn flush(&self) {}
+    }
+
+    #[test]
+    fn test_resp_set_key_too_long_returns_error() {
+        let cache = FailingSetCache {
+            error: cache_core::CacheError::KeyTooLong,
+        };
+        let mut conn = Connection::default();
+
+        let mut buf = TestRecvBuf::new(&build_resp_set(b"foo", b"bar"));
+        conn.process_from(&mut buf, &cache);
+
+        let response = conn.pending_write_data();
+        assert_eq!(
+            response,
+            b"-ERR key too long (max 255 bytes)\r\n",
+            "Expected RESP error for KeyTooLong, got: {:?}",
+            String::from_utf8_lossy(response)
+        );
+    }
+
+    #[test]
+    fn test_resp_set_value_too_long_returns_error() {
+        let cache = FailingSetCache {
+            error: cache_core::CacheError::ValueTooLong,
+        };
+        let mut conn = Connection::default();
+
+        let mut buf = TestRecvBuf::new(&build_resp_set(b"foo", b"bar"));
+        conn.process_from(&mut buf, &cache);
+
+        let response = conn.pending_write_data();
+        assert_eq!(
+            response,
+            b"-ERR value too long (max 16MB)\r\n",
+            "Expected RESP error for ValueTooLong, got: {:?}",
+            String::from_utf8_lossy(response)
+        );
+    }
+
+    #[test]
+    fn test_resp_set_out_of_memory_returns_ok() {
+        let cache = FailingSetCache {
+            error: cache_core::CacheError::OutOfMemory,
+        };
+        let mut conn = Connection::default();
+
+        let mut buf = TestRecvBuf::new(&build_resp_set(b"foo", b"bar"));
+        conn.process_from(&mut buf, &cache);
+
+        let response = conn.pending_write_data();
+        assert_eq!(
+            response,
+            b"+OK\r\n",
+            "Expected silent OK for OutOfMemory, got: {:?}",
+            String::from_utf8_lossy(response)
+        );
+    }
+
+    #[test]
+    fn test_memcache_ascii_set_key_too_long_returns_error() {
+        let cache = FailingSetCache {
+            error: cache_core::CacheError::KeyTooLong,
+        };
+        let mut conn = Connection::default();
+
+        let mut buf = TestRecvBuf::new(b"set foo 0 0 3\r\nbar\r\n");
+        conn.process_from(&mut buf, &cache);
+
+        let response = conn.pending_write_data();
+        assert_eq!(
+            response,
+            b"CLIENT_ERROR key too long (max 255 bytes)\r\n",
+            "Expected CLIENT_ERROR for KeyTooLong, got: {:?}",
+            String::from_utf8_lossy(response)
+        );
+    }
+
+    #[test]
+    fn test_memcache_ascii_set_out_of_memory_returns_stored() {
+        let cache = FailingSetCache {
+            error: cache_core::CacheError::OutOfMemory,
+        };
+        let mut conn = Connection::default();
+
+        let mut buf = TestRecvBuf::new(b"set foo 0 0 3\r\nbar\r\n");
+        conn.process_from(&mut buf, &cache);
+
+        let response = conn.pending_write_data();
+        assert_eq!(
+            response,
+            b"STORED\r\n",
+            "Expected silent STORED for OutOfMemory, got: {:?}",
+            String::from_utf8_lossy(response)
+        );
+    }
+
     // --- Memcache ASCII zero-copy tests ---
 
     #[test]

--- a/server/src/execute.rs
+++ b/server/src/execute.rs
@@ -1696,11 +1696,8 @@ pub fn execute_memcache_binary<C: Cache>(
                     }
                     SET_ERRORS.increment();
                     if e.is_client_error() {
-                        let len = BinaryResponse::encode_invalid_arguments(
-                            buf,
-                            Opcode::Set,
-                            *opaque,
-                        );
+                        let len =
+                            BinaryResponse::encode_invalid_arguments(buf, Opcode::Set, *opaque);
                         unsafe { write_buf.set_len(write_buf.len() + len) };
                     }
                 }

--- a/server/src/execute.rs
+++ b/server/src/execute.rs
@@ -176,12 +176,20 @@ pub fn execute_resp<C: Cache>(
                             quiet: false,
                         });
                     }
-                    // Silent drop: cache is best-effort storage. Return OK even
-                    // when the cache is full — the item would be evicted soon
-                    // anyway. This matches Redis behavior with eviction enabled
-                    // and avoids breaking clients like valkey-benchmark.
                     SET_ERRORS.increment();
-                    write_buf.extend_from_slice(b"+OK\r\n");
+                    if e.is_client_error() {
+                        // Client validation errors should be reported so the
+                        // caller can fix the request.
+                        write_buf.extend_from_slice(b"-ERR ");
+                        write_buf.extend_from_slice(e.to_string().as_bytes());
+                        write_buf.extend_from_slice(b"\r\n");
+                    } else {
+                        // Cache-pressure / transient errors: silent drop.
+                        // Cache is best-effort storage — the item would be
+                        // evicted soon anyway. This matches Redis behavior with
+                        // eviction enabled.
+                        write_buf.extend_from_slice(b"+OK\r\n");
+                    }
                 }
             }
         }
@@ -1294,7 +1302,9 @@ pub fn execute_memcache<C: Cache>(
             };
 
             match cache.set(key, data, ttl) {
-                Ok(()) => {}
+                Ok(()) => {
+                    write_buf.extend_from_slice(b"STORED\r\n");
+                }
                 Err(e) => {
                     if retry_on_eviction
                         && matches!(
@@ -1315,9 +1325,15 @@ pub fn execute_memcache<C: Cache>(
                         );
                     }
                     SET_ERRORS.increment();
+                    if e.is_client_error() {
+                        write_buf.extend_from_slice(b"CLIENT_ERROR ");
+                        write_buf.extend_from_slice(e.to_string().as_bytes());
+                        write_buf.extend_from_slice(b"\r\n");
+                    } else {
+                        write_buf.extend_from_slice(b"STORED\r\n");
+                    }
                 }
             }
-            write_buf.extend_from_slice(b"STORED\r\n");
             false
         }
         MemcacheCommand::Add {
@@ -1609,7 +1625,10 @@ pub fn execute_memcache_binary<C: Cache>(
             };
 
             match cache.set(key, value, ttl) {
-                Ok(()) => {}
+                Ok(()) => {
+                    let len = BinaryResponse::encode_stored(buf, Opcode::Set, *opaque, 0);
+                    unsafe { write_buf.set_len(write_buf.len() + len) };
+                }
                 Err(e) => {
                     if retry_on_eviction
                         && matches!(
@@ -1630,10 +1649,14 @@ pub fn execute_memcache_binary<C: Cache>(
                         );
                     }
                     SET_ERRORS.increment();
+                    let len = if e.is_client_error() {
+                        BinaryResponse::encode_invalid_arguments(buf, Opcode::Set, *opaque)
+                    } else {
+                        BinaryResponse::encode_stored(buf, Opcode::Set, *opaque, 0)
+                    };
+                    unsafe { write_buf.set_len(write_buf.len() + len) };
                 }
             }
-            let len = BinaryResponse::encode_stored(buf, Opcode::Set, *opaque, 0);
-            unsafe { write_buf.set_len(write_buf.len() + len) };
             return (false, None);
         }
         BinaryCommand::SetQ {
@@ -1672,6 +1695,14 @@ pub fn execute_memcache_binary<C: Cache>(
                         );
                     }
                     SET_ERRORS.increment();
+                    if e.is_client_error() {
+                        let len = BinaryResponse::encode_invalid_arguments(
+                            buf,
+                            Opcode::Set,
+                            *opaque,
+                        );
+                        unsafe { write_buf.set_len(write_buf.len() + len) };
+                    }
                 }
             }
             return (false, None);


### PR DESCRIPTION
## Summary
- SET commands that fail with client validation errors (`KeyTooLong`, `ValueTooLong`, `InvalidTtl`, `WrongType`, etc.) now return proper error responses instead of silently returning success
- Adds `CacheError::is_client_error()` to distinguish client-side validation errors from cache-pressure/internal errors
- Cache-pressure errors (`OutOfMemory`, `HashTableFull`) continue to silently return success, preserving best-effort semantics
- Covers all three protocol paths: RESP (`-ERR`), Memcache ASCII (`CLIENT_ERROR`), and Memcache Binary (`InvalidArguments` status)
- Also fixes `retry_set` / `abandon_retry` to report client errors on the retry path

## Test plan
- [x] Existing server tests pass
- [x] New `test_is_client_error` unit test verifies classification of all `CacheError` variants
- [ ] Manual: send SET with key > 255 bytes via redis-cli, verify `-ERR key too long` response
- [ ] Manual: send SET with value > max_value_size, verify error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)