### PR TITLE
chore: use cachecannon install script instead of cargo install

### DIFF
--- a/.claude/skills/smoketest/SKILL.md
+++ b/.claude/skills/smoketest/SKILL.md
@@ -14,7 +14,7 @@ Run the cache server with the cachecannon benchmark tool to detect issues.
 
 2. **Install cachecannon** (if not already installed):
    ```bash
-   cargo install --git https://github.com/cachecannon/cachecannon
+   curl -fsSL https://cachecannon.cc/install.sh | bash
    ```
 
 3. **Kill any existing server** to avoid port conflicts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Build debug server with validation
         run: cargo build -p server --features server/validation
       - name: Install cachecannon
-        run: cargo install --git https://github.com/cachecannon/cachecannon
+        run: curl -fsSL https://cachecannon.cc/install.sh | bash
       - name: Run smoketest
         env:
           # Enable debug assertions in dependencies

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ sq_depth = 1024
 For load testing, use [cachecannon](https://github.com/cachecannon/cachecannon):
 
 ```bash
-cargo install --git https://github.com/cachecannon/cachecannon
+curl -fsSL https://cachecannon.cc/install.sh | bash
 cachecannon config/redis.toml
 ```
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -543,7 +543,7 @@ length = 64
     let mut benchmark: Option<Child> = None;
     if !no_load {
         println!("Starting benchmark...");
-        let bench_bin = which_cachecannon().map_err(|_| "cachecannon not found in PATH. Install with: cargo install --git https://github.com/cachecannon/cachecannon".to_string())?;
+        let bench_bin = which_cachecannon().map_err(|_| "cachecannon not found in PATH. Install with: curl -fsSL https://cachecannon.cc/install.sh | bash".to_string())?;
         let child = Command::new(&bench_bin)
             .arg(&benchmark_config)
             .current_dir(&workspace_root)


### PR DESCRIPTION
## Summary
- Switch from `cargo install --git` to `curl -fsSL https://cachecannon.cc/install.sh | bash` for installing cachecannon
- Installs pre-built packages via apt/yum instead of compiling from source
- Updated in CI workflow, smoketest skill, xtask error message, and README

## Test plan
- [x] xtask compiles
- [x] CI smoketest jobs install cachecannon successfully via the new script

🤖 Generated with [Claude Code](https://claude.com/claude-code)