### PR TITLE
fix(heap-cache): subtract bytes_used on typed slot insertion rollback

### DIFF
--- a/cache/heap/src/lib.rs
+++ b/cache/heap/src/lib.rs
@@ -1227,7 +1227,8 @@ impl HeapCache {
                 Ok((idx, generation, true))
             }
             Err(e) => {
-                // Rollback: deallocate the slot we just created
+                // Rollback: deallocate the slot and undo bytes_used tracking
+                self.bytes_used.fetch_sub(base_size, Ordering::Relaxed);
                 match value_type {
                     ValueType::Hash => self.hash_storage.deallocate(idx),
                     ValueType::List => self.list_storage.deallocate(idx),


### PR DESCRIPTION
## Summary
- Fix memory accounting leak in `get_or_create_typed()` when hashtable insertion fails
- `base_size` was added to `bytes_used` before the insert, but the error path never subtracted it
- Over time, `bytes_used` diverges from actual memory, causing premature evictions

## Test plan
- [x] All existing heap-cache tests pass (including memory tracking tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)