### PR TITLE
fix(cache-core): add yield fallback to eviction spin loops

### DIFF
--- a/cache/core/src/layer/fifo_layer.rs
+++ b/cache/core/src/layer/fifo_layer.rs
@@ -258,9 +258,7 @@ impl FifoLayer {
         };
 
         // Wait for readers to finish
-        while segment.ref_count() > 0 {
-            std::hint::spin_loop();
-        }
+        super::wait_for_readers(segment);
 
         // Transition to Locked for clearing
         segment.cas_metadata(State::Draining, State::Locked, None, None);
@@ -346,9 +344,7 @@ impl FifoLayer {
         };
 
         // Wait for readers to finish
-        while segment.ref_count() > 0 {
-            std::hint::spin_loop();
-        }
+        super::wait_for_readers(segment);
 
         // Transition to Locked for clearing
         segment.cas_metadata(State::Draining, State::Locked, None, None);

--- a/cache/core/src/layer/mod.rs
+++ b/cache/core/src/layer/mod.rs
@@ -30,3 +30,22 @@ mod ttl_layer;
 pub use fifo_layer::{EvictResult, FifoLayer, FifoLayerBuilder};
 pub use traits::Layer;
 pub use ttl_layer::{TtlLayer, TtlLayerBuilder};
+
+use crate::segment::Segment;
+
+/// Wait for all readers to release a segment.
+///
+/// Spins briefly using `spin_loop` hints for low-latency cases, then
+/// falls back to `thread::yield_now()` to avoid starving other work
+/// on the core.
+pub(crate) fn wait_for_readers<S: Segment>(segment: &S) {
+    let mut spins = 0u32;
+    while segment.ref_count() > 0 {
+        if spins < 64 {
+            std::hint::spin_loop();
+        } else {
+            std::thread::yield_now();
+        }
+        spins = spins.saturating_add(1);
+    }
+}

--- a/cache/core/src/layer/ttl_layer.rs
+++ b/cache/core/src/layer/ttl_layer.rs
@@ -423,9 +423,7 @@ impl TtlLayer {
         };
 
         // Wait for readers to finish
-        while segment.ref_count() > 0 {
-            std::hint::spin_loop();
-        }
+        super::wait_for_readers(segment);
 
         // Transition to Locked for clearing
         segment.cas_metadata(State::Draining, State::Locked, None, None);
@@ -764,9 +762,7 @@ impl TtlLayer {
         };
 
         // Wait for readers to finish
-        while segment.ref_count() > 0 {
-            std::hint::spin_loop();
-        }
+        super::wait_for_readers(segment);
 
         // Transition to Locked for clearing
         segment.cas_metadata(State::Draining, State::Locked, None, None);


### PR DESCRIPTION
## Summary
- Replace unbounded `spin_loop()` in eviction with `wait_for_readers()` helper
- Spins for 64 iterations with `spin_loop` hints, then falls back to `thread::yield_now()`
- Prevents CPU starvation when readers hold `ValueRef` for extended periods (e.g. slow zero-copy network sends)
- Applied to all 4 spin-on-refcount sites in `fifo_layer` and `ttl_layer`

Also skipping issue #6 (segment orphaning in AwaitingRelease) — after thorough analysis, the existing "race fix" at line 176 correctly handles all interleavings. The review agent's claim was incorrect.

## Test plan
- [x] All cache-core and server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)