### PR TITLE
fix(server): log disk read errors instead of silently converting to misses

### DIFF
--- a/server/src/async_native/handler.rs
+++ b/server/src/async_native/handler.rs
@@ -550,9 +550,10 @@ async fn submit_and_await_disk_read<C: Cache>(
     }
 
     // 3. Parse result and write response (same logic as native/handler.rs).
-    if result.is_err() {
+    if let Err(e) = &result {
         DISK_READ_ERRORS.increment();
         MISSES.increment();
+        tracing::warn!(segment_id, pool_id, "Disk read failed: {e}");
         connection.write_miss_response();
         release_read!(buffer);
         return Ok(());


### PR DESCRIPTION
## Summary
- Log the actual I/O error when disk reads fail, with segment ID and pool ID for debugging
- Previously only incremented `DISK_READ_ERRORS` counter and returned a miss — the error details were discarded

## Test plan
- [x] All server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)