### PR TITLE
fix(cache-core): log sync failure in FilePool::drop

### DIFF
--- a/cache/core/src/disk/file_pool.rs
+++ b/cache/core/src/disk/file_pool.rs
@@ -249,7 +249,9 @@ impl FilePool {
 impl Drop for FilePool {
     fn drop(&mut self) {
         // Sync any remaining dirty data before dropping
-        let _ = self.sync();
+        if let Err(e) = self.sync() {
+            eprintln!("FilePool: failed to sync on drop, data may be lost: {e}");
+        }
         // Clear segments before dropping mmap
         self.segments.clear();
     }


### PR DESCRIPTION
## Summary
- Log to stderr when `FilePool::sync()` fails during drop, instead of silently discarding the error
- Uses `eprintln!` since tracing may not be available during drop

## Test plan
- [x] All cache-core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)