### PR TITLE
fix(server): return error instead of process::exit on stuck workers

### DIFF
--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -250,16 +250,20 @@ mod server {
             }
         }
 
+        if let Some(handle) = diagnostics_handle {
+            let _ = handle.join();
+        }
+
         if stuck_count > 0 {
             warn!(
                 stuck_workers = stuck_count,
-                "Forcing exit due to stuck worker threads"
+                "Shutdown complete with stuck worker threads — they will be \
+                 cleaned up on process exit"
             );
-            std::process::exit(1);
-        }
-
-        if let Some(handle) = diagnostics_handle {
-            let _ = handle.join();
+            return Err(format!(
+                "{stuck_count} worker thread(s) did not stop within drain timeout"
+            )
+            .into());
         }
 
         info!("Async server shutdown complete");


### PR DESCRIPTION
## Summary
- Replace `std::process::exit(1)` with returning an error when worker threads don't stop within the drain timeout
- `process::exit` skips all destructors, which could lose unflushed disk data (`FilePool::drop` syncs to disk)
- Stuck worker threads are detached (not joined) and cleaned up when the process exits normally after `main()` returns
- Diagnostics thread is now joined before the stuck-worker check, ensuring it gets a clean shutdown

## Test plan
- [x] All server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)