### PR TITLE
fix(heap-cache): prevent integer overflow in S3-FIFO capacity calculation

### DIFF
--- a/cache/heap/src/s3fifo_policy.rs
+++ b/cache/heap/src/s3fifo_policy.rs
@@ -38,8 +38,8 @@ impl S3FifoPolicy {
     /// - `small_percent`: Percentage of capacity for small queue (1-50, typically 10)
     /// - `demotion_threshold`: Frequency threshold for promotion (typically 1)
     pub fn new(total_capacity: u32, small_percent: u8, demotion_threshold: u8) -> Self {
-        let small_percent = small_percent.clamp(1, 50) as u32;
-        let small_capacity = (total_capacity * small_percent / 100).max(1);
+        let small_percent = small_percent.clamp(1, 50) as u64;
+        let small_capacity = (total_capacity as u64 * small_percent / 100).max(1) as u32;
         let main_capacity = total_capacity.saturating_sub(small_capacity).max(1);
 
         Self {


### PR DESCRIPTION
## Summary
- Use `u64` intermediate for `total_capacity * small_percent` to prevent overflow
- `u32 * u32` overflows when cache holds >85M items (plausible for large deployments)

Skipping issues #14 and #15 from the review — after analysis, both are correct:
- **#14**: Hashtable CAS loops are bounded by bucket size × choices, not unbounded
- **#15**: Ghost frequency CAS failure is intentionally best-effort, retry would add contention for minimal benefit

Also skipping **#16** (hugepage `eprintln!`) — `tracing` is not a dep of `cache-core` and adding it changes the library's dependency story

## Test plan
- [x] All heap-cache tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)