### PR TITLE
fix(server): add bounds check to advance_streaming_recv

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1738,13 +1738,44 @@ impl Connection {
     /// Advance the streaming receive position by `n` bytes (written via recv sink).
     pub fn advance_streaming_recv(&mut self, n: usize) {
         match &mut self.streaming_state {
-            StreamingState::ReceivingSegment { received, .. }
-            | StreamingState::ReceivingVec { received, .. }
-            | StreamingState::MemcacheAsciiSegment { received, .. }
-            | StreamingState::MemcacheAsciiVec { received, .. }
-            | StreamingState::MemcacheBinarySegment { received, .. }
-            | StreamingState::MemcacheBinaryVec { received, .. } => {
-                *received += n;
+            StreamingState::ReceivingSegment {
+                reservation,
+                received,
+                ..
+            } => {
+                debug_assert!(*received + n <= reservation.value_len());
+                *received = (*received + n).min(reservation.value_len());
+            }
+            StreamingState::ReceivingVec {
+                reservation,
+                received,
+                ..
+            }
+            | StreamingState::MemcacheAsciiVec {
+                reservation,
+                received,
+                ..
+            }
+            | StreamingState::MemcacheBinaryVec {
+                reservation,
+                received,
+                ..
+            } => {
+                debug_assert!(*received + n <= reservation.value_len());
+                *received = (*received + n).min(reservation.value_len());
+            }
+            StreamingState::MemcacheAsciiSegment {
+                reservation,
+                received,
+                ..
+            }
+            | StreamingState::MemcacheBinarySegment {
+                reservation,
+                received,
+                ..
+            } => {
+                debug_assert!(*received + n <= reservation.value_len());
+                *received = (*received + n).min(reservation.value_len());
             }
             StreamingState::None | StreamingState::Draining { .. } => {}
         }


### PR DESCRIPTION
## Summary
- Cap `received` counter at `value_len` in `advance_streaming_recv()` to prevent overflow
- Adds `debug_assert!` to catch violations in development, `.min()` clamp for safety in release
- The recv sink capacity already prevents overruns in practice, but this is defense-in-depth

## Test plan
- [x] All server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)