### PR TITLE
fix(momento): warn when endpoint extraction fails and default is used

### DIFF
--- a/protocol/momento/src/credential.rs
+++ b/protocol/momento/src/credential.rs
@@ -30,8 +30,13 @@ impl Credential {
         // Try to extract endpoint from token
         // Momento tokens are typically: header.payload.signature (JWT-like)
         // The payload contains the endpoint info
-        let endpoint = Self::extract_endpoint(&token)
-            .unwrap_or_else(|| "cache.cell-us-east-1-1.prod.a.momentohq.com".to_string());
+        let endpoint = Self::extract_endpoint(&token).unwrap_or_else(|| {
+            eprintln!(
+                "Warning: could not extract endpoint from Momento token, \
+                 falling back to us-east-1 default"
+            );
+            "cache.cell-us-east-1-1.prod.a.momentohq.com".to_string()
+        });
 
         Ok(Self {
             token,


### PR DESCRIPTION
## Summary
- Print a warning to stderr when Momento token endpoint extraction fails and the hardcoded us-east-1 default is used
- Previously, malformed tokens or tokens for other regions silently connected to the wrong endpoint

Skipping #19 (proxy send errors) — the `let _ = client.send(...)` pattern is correct for the proxy's connection-per-task model. Failed sends mean a dead connection that will naturally close on the next recv.

## Test plan
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)