### PR TITLE
fix(server): return errors for invalid policy/backend combos instead of panic

### DIFF
--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -167,7 +167,7 @@ fn create_segment(
         EvictionPolicy::Merge => {
             builder.eviction_policy(SegEvictionPolicy::Merge(MergeConfig::default()))
         }
-        _ => unreachable!("invalid policy for segment backend"),
+        other => return Err(format!("unsupported policy '{other:?}' for segment backend").into()),
     };
 
     if let Some(node) = config.numa_node() {
@@ -250,7 +250,7 @@ fn create_slab(
         EvictionPolicy::Lrc => EvictionStrategy::SLAB_LRC,
         EvictionPolicy::Random => EvictionStrategy::RANDOM,
         EvictionPolicy::None => EvictionStrategy::NONE,
-        _ => unreachable!("invalid policy for slab backend"),
+        other => return Err(format!("unsupported policy '{other:?}' for slab backend").into()),
     };
 
     let mut builder = SlabCache::builder()
@@ -296,7 +296,7 @@ fn create_heap(
         EvictionPolicy::S3Fifo => HeapEvictionPolicy::S3Fifo,
         EvictionPolicy::Lfu => HeapEvictionPolicy::Lfu,
         EvictionPolicy::Random => HeapEvictionPolicy::Random,
-        _ => unreachable!("invalid policy for heap backend"),
+        other => return Err(format!("unsupported policy '{other:?}' for heap backend").into()),
     };
 
     let mut builder = HeapCache::builder()


### PR DESCRIPTION
## Summary
- Replace `unreachable!()` with proper error returns in `create_segment`, `create_slab`, and `create_heap`
- If a new eviction policy is added without updating all match arms, the server now shows a clear error at startup instead of panicking
- The `unreachable!()` inside the `DirectIo | Nvme` arm is kept since it's genuinely unreachable

## Test plan
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)