### PR TITLE
feat(server): add Unix domain socket listener support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "ringline"
 version = "0.0.3-alpha.0"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=fa5cca9#fa5cca918800de925ac324e1c109686fd2a35c1c"
+source = "git+https://github.com/ringline-rs/ringline.git?rev=9c5168d#9c5168d06fdc121137379472f8a78bab694830c1"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "ringline-redis"
 version = "0.1.1"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=fa5cca9#fa5cca918800de925ac324e1c109686fd2a35c1c"
+source = "git+https://github.com/ringline-rs/ringline.git?rev=9c5168d#9c5168d06fdc121137379472f8a78bab694830c1"
 dependencies = [
  "bytes",
  "histogram 0.11.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ tracing = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crates
-ringline = { git = "https://github.com/ringline-rs/ringline.git", rev = "fa5cca9", features = ["timestamps"] }
-ringline-redis = { git = "https://github.com/ringline-rs/ringline.git", rev = "fa5cca9" }
+ringline = { git = "https://github.com/ringline-rs/ringline.git", rev = "9c5168d", features = ["timestamps"] }
+ringline-redis = { git = "https://github.com/ringline-rs/ringline.git", rev = "9c5168d" }
 http2-proto = "0.0.1"
 grpc-proto = "0.0.1"
 protocol-momento = { path = "protocol/momento" }

--- a/server/config/unix-socket.toml
+++ b/server/config/unix-socket.toml
@@ -1,0 +1,26 @@
+# Crucible Server - Unix Domain Socket Configuration
+#
+# This configuration uses a Unix domain socket instead of TCP,
+# providing lower latency for local connections by bypassing
+# the TCP/IP stack.
+#
+# Connect with: redis-cli -s /tmp/crucible.sock
+
+[workers]
+threads = 4
+
+[cache]
+backend = "segment"
+policy = "s3fifo"
+heap_size = "4GB"
+segment_size = "8MB"
+max_value_size = "1MB"
+hashtable_power = 21
+
+# Unix domain socket listener
+[[listener]]
+protocol = "resp"
+unix_socket = "/tmp/crucible.sock"
+
+[metrics]
+address = "127.0.0.1:9090"

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -165,7 +165,9 @@ mod server {
             krio_config
         };
 
-        let bind_addr = config.listener[0].address;
+        let bind_target = config.listener[0]
+            .bind_target()
+            .ok_or("listener must have 'address' or 'unix_socket'")?;
 
         let _launch_guard = launch_lock();
 
@@ -191,9 +193,13 @@ mod server {
         }
         init_config_channel(config_rx, num_workers);
 
-        let (shutdown_handle, handles) = RinglineBuilder::new(krio_config)
-            .bind(bind_addr)
-            .launch::<AsyncServerHandler<C>>()?;
+        use crate::config::BindTarget;
+        let mut builder = RinglineBuilder::new(krio_config);
+        builder = match &bind_target {
+            BindTarget::Tcp(addr) => builder.bind(*addr),
+            BindTarget::Unix(path) => builder.bind_unix(path),
+        };
+        let (shutdown_handle, handles) = builder.launch::<AsyncServerHandler<C>>()?;
 
         wait_for_workers();
         drop(_launch_guard);

--- a/server/src/banner.rs
+++ b/server/src/banner.rs
@@ -1,6 +1,6 @@
 //! Startup banner utilities.
 
-use crate::config::{CacheBackend, EvictionPolicy, Protocol, format_size};
+use crate::config::{BindTarget, CacheBackend, EvictionPolicy, Protocol, format_size};
 use std::fmt::Write;
 use std::net::SocketAddr;
 
@@ -18,8 +18,8 @@ pub struct BannerConfig<'a> {
     pub small_queue_percent: u8,
     /// Number of worker threads
     pub workers: usize,
-    /// Protocol listeners (protocol, address, tls_enabled)
-    pub listeners: &'a [(Protocol, SocketAddr, bool)],
+    /// Protocol listeners (protocol, bind_target, tls_enabled)
+    pub listeners: &'a [(Protocol, BindTarget, bool)],
     /// Metrics address
     pub metrics_address: SocketAddr,
     /// Cache heap size in bytes

--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -67,7 +67,7 @@ fn run(
     let listeners: Vec<_> = config
         .listener
         .iter()
-        .map(|l| (l.protocol, l.address, l.tls.is_some()))
+        .filter_map(|l| Some((l.protocol, l.bind_target()?, l.tls.is_some())))
         .collect();
     let cpu_affinity = config.cpu_affinity();
     let cpu_affinity_slice = cpu_affinity.as_deref();

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -392,16 +392,50 @@ pub struct ListenerConfig {
     /// Protocol to serve
     pub protocol: Protocol,
 
-    /// Address to listen on
-    pub address: SocketAddr,
+    /// TCP address to listen on (e.g. "127.0.0.1:6379").
+    /// Mutually exclusive with `unix_socket`.
+    pub address: Option<SocketAddr>,
 
-    /// TLS configuration (optional)
+    /// Unix domain socket path (e.g. "/var/run/crucible.sock").
+    /// Mutually exclusive with `address`.
+    pub unix_socket: Option<String>,
+
+    /// TLS configuration (optional, TCP only)
     pub tls: Option<TlsConfig>,
 
     /// Allow FLUSH commands (flush_all for memcache, FLUSHDB/FLUSHALL for RESP).
     /// Default: false (flush commands return error)
     #[serde(default)]
     pub allow_flush: bool,
+}
+
+/// The resolved bind target for a listener.
+#[derive(Debug, Clone)]
+pub enum BindTarget {
+    /// TCP socket address.
+    Tcp(SocketAddr),
+    /// Unix domain socket path.
+    Unix(String),
+}
+
+impl std::fmt::Display for BindTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindTarget::Tcp(addr) => write!(f, "{addr}"),
+            BindTarget::Unix(path) => write!(f, "unix:{path}"),
+        }
+    }
+}
+
+impl ListenerConfig {
+    /// Returns the resolved bind target.
+    pub fn bind_target(&self) -> Option<BindTarget> {
+        match (&self.address, &self.unix_socket) {
+            (Some(addr), None) => Some(BindTarget::Tcp(*addr)),
+            (None, Some(path)) => Some(BindTarget::Unix(path.clone())),
+            _ => None,
+        }
+    }
 }
 
 /// Supported protocols.
@@ -830,6 +864,25 @@ impl Config {
             );
         }
 
+        // Validate listener bind target
+        let listener = &self.listener[0];
+        match (&listener.address, &listener.unix_socket) {
+            (None, None) => {
+                return Err(
+                    "listener must have either 'address' or 'unix_socket' configured".into(),
+                );
+            }
+            (Some(_), Some(_)) => {
+                return Err(
+                    "listener cannot have both 'address' and 'unix_socket' configured".into(),
+                );
+            }
+            (None, Some(_)) if listener.tls.is_some() => {
+                return Err("TLS is not supported with Unix domain sockets".into());
+            }
+            _ => {}
+        }
+
         // Validate NVMe disk config fields
         if let Some(ref disk) = self.cache.disk
             && disk.enabled
@@ -994,7 +1047,8 @@ mod tests {
             cache: CacheConfig::default(),
             listener: vec![ListenerConfig {
                 protocol: Protocol::Resp,
-                address: "127.0.0.1:6379".parse().unwrap(),
+                address: Some("127.0.0.1:6379".parse().unwrap()),
+                unix_socket: None,
                 tls: None,
                 allow_flush: false,
             }],
@@ -1024,12 +1078,51 @@ mod tests {
         let mut config = minimal_config();
         config.listener.push(ListenerConfig {
             protocol: Protocol::Memcache,
-            address: "127.0.0.1:11211".parse().unwrap(),
+            address: Some("127.0.0.1:11211".parse().unwrap()),
+            unix_socket: None,
             tls: None,
             allow_flush: false,
         });
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("multiple listeners"));
+    }
+
+    #[test]
+    fn test_validate_unix_socket_listener() {
+        let mut config = minimal_config();
+        config.listener[0].address = None;
+        config.listener[0].unix_socket = Some("/tmp/crucible.sock".to_string());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_listener_missing_both() {
+        let mut config = minimal_config();
+        config.listener[0].address = None;
+        config.listener[0].unix_socket = None;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("address"));
+    }
+
+    #[test]
+    fn test_validate_listener_both_set() {
+        let mut config = minimal_config();
+        config.listener[0].unix_socket = Some("/tmp/crucible.sock".to_string());
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("both"));
+    }
+
+    #[test]
+    fn test_validate_unix_socket_no_tls() {
+        let mut config = minimal_config();
+        config.listener[0].address = None;
+        config.listener[0].unix_socket = Some("/tmp/crucible.sock".to_string());
+        config.listener[0].tls = Some(TlsConfig {
+            cert: "cert.pem".to_string(),
+            key: "key.pem".to_string(),
+        });
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("TLS"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Unix domain socket support for lower-latency local connections
- New `unix_socket` config option as alternative to `address` in `[[listener]]`
- Validation ensures exactly one of `address`/`unix_socket` is set, TLS rejected with UDS
- Update ringline to 9c5168d (adds `bind_unix`/`connect_unix`)
- Example config: `server/config/unix-socket.toml`

## Usage
```toml
[[listener]]
protocol = "resp"
unix_socket = "/tmp/crucible.sock"
```

Connect with: `redis-cli -s /tmp/crucible.sock`

## Test plan
- [x] All server tests pass
- [x] 4 new validation tests: UDS listener, missing both, both set, UDS+TLS rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)