### PR TITLE
fix(server): replace unwrap() with expect() in async handler disk I/O paths

### DIFF
--- a/server/src/async_native/handler.rs
+++ b/server/src/async_native/handler.rs
@@ -395,7 +395,10 @@ async fn handle_connection<C: Cache>(
         if connection.pending_disk_read.is_some() {
             let has_disk_io = disk_io.lock().is_some();
             if has_disk_io {
-                let pending_info = connection.pending_disk_read.take().unwrap();
+                let pending_info = connection
+                    .pending_disk_read
+                    .take()
+                    .expect("pending_disk_read must be Some (guarded by is_some check)");
                 match submit_and_await_disk_read(
                     &disk_io,
                     &*cache,
@@ -487,7 +490,9 @@ async fn submit_and_await_disk_read<C: Cache>(
     // 1. Allocate aligned read buffer.
     let mut buffer: cache_core::disk::AlignedBuffer = {
         let mut dio = disk_io.lock();
-        let dio = dio.as_mut().unwrap();
+        let dio = dio
+            .as_mut()
+            .expect("disk_io must be Some when submit_and_await_disk_read is called");
         match dio.read_buffer_pool.allocate() {
             Some(buf) => buf,
             None => {
@@ -505,7 +510,9 @@ async fn submit_and_await_disk_read<C: Cache>(
     // before awaiting (the future spans a suspend point).
     let future = {
         let dio = disk_io.lock();
-        let dio = dio.as_ref().unwrap();
+        let dio = dio
+            .as_ref()
+            .expect("disk_io must be Some when submit_and_await_disk_read is called");
         match &dio.backend {
             DiskBackend::DirectIo { file, .. } => unsafe {
                 ringline::direct_io_read(
@@ -542,7 +549,7 @@ async fn submit_and_await_disk_read<C: Cache>(
             disk_io
                 .lock()
                 .as_mut()
-                .unwrap()
+                .expect("disk_io must be Some during read cleanup")
                 .read_buffer_pool
                 .release($buf);
             cache.release_disk_read(segment_id, pool_id);

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -79,7 +79,11 @@ mod server {
 
         // Pre-create disk file before ringline launch (workers need it for O_DIRECT open)
         if disk_io_backend == Some(DiskIoBackendConfig::DirectIo) {
-            let disk_config = config.cache.disk.as_ref().unwrap();
+            let disk_config = config
+                .cache
+                .disk
+                .as_ref()
+                .expect("disk config must be present when io_backend is DirectIo");
             if let Err(e) = ensure_disk_file(&disk_config.path, disk_config.size) {
                 return Err(format!("Failed to create disk file: {e}").into());
             }
@@ -126,7 +130,11 @@ mod server {
         // Build disk I/O worker config
         let disk_io_worker_config: Option<DiskIoWorkerConfig> = match disk_io_backend {
             Some(DiskIoBackendConfig::DirectIo) => {
-                let disk_config = config.cache.disk.as_ref().unwrap();
+                let disk_config = config
+                    .cache
+                    .disk
+                    .as_ref()
+                    .expect("disk config must be present when io_backend is DirectIo");
                 Some(DiskIoWorkerConfig {
                     backend: cache_core::DiskIoBackend::DirectIo,
                     path: disk_config.path.to_string_lossy().into_owned(),
@@ -136,7 +144,11 @@ mod server {
                 })
             }
             Some(DiskIoBackendConfig::Nvme) => {
-                let disk_config = config.cache.disk.as_ref().unwrap();
+                let disk_config = config
+                    .cache
+                    .disk
+                    .as_ref()
+                    .expect("disk config must be present when io_backend is Nvme");
                 let device_path = disk_config
                     .nvme_device
                     .clone()


### PR DESCRIPTION
## Summary
- Replaced 7 `unwrap()` calls on `Option` types in async handler disk I/O paths with `expect()` providing descriptive context
- Covers `handler.rs` (pending_disk_read, disk_io lock, release_read macro) and `mod.rs` (disk config access in DirectIo/Nvme branches)
- If these invariants are ever violated, the panic message now indicates exactly which assumption failed

## Test plan
- [x] `cargo build -p server` compiles cleanly
- [x] `cargo test -p server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)