### PR TITLE
fix(server): log corruption errors instead of silently dropping on SET

### DIFF
--- a/cache/core/src/error.rs
+++ b/cache/core/src/error.rs
@@ -102,6 +102,16 @@ impl fmt::Display for CacheError {
 }
 
 impl CacheError {
+    /// Returns true if this error indicates data corruption or an internal
+    /// bug that should be investigated, as opposed to expected cache-pressure
+    /// or client errors.
+    pub fn is_corruption(&self) -> bool {
+        matches!(
+            self,
+            Self::Corrupted | Self::InvalidOffset | Self::KeyMismatch
+        )
+    }
+
     /// Returns true if this error indicates a client-side issue (bad input)
     /// that should be reported back to the client, as opposed to an internal
     /// cache-pressure or transient error that can be silently dropped in
@@ -225,5 +235,20 @@ mod tests {
         assert!(!CacheError::SegmentNotAccessible.is_client_error());
         assert!(!CacheError::ItemExpired.is_client_error());
         assert!(!CacheError::ItemDeleted.is_client_error());
+    }
+
+    #[test]
+    fn test_is_corruption() {
+        // Corruption errors: indicate bugs or data integrity issues
+        assert!(CacheError::Corrupted.is_corruption());
+        assert!(CacheError::InvalidOffset.is_corruption());
+        assert!(CacheError::KeyMismatch.is_corruption());
+
+        // Everything else is not corruption
+        assert!(!CacheError::OutOfMemory.is_corruption());
+        assert!(!CacheError::HashTableFull.is_corruption());
+        assert!(!CacheError::KeyTooLong.is_corruption());
+        assert!(!CacheError::SegmentNotAccessible.is_corruption());
+        assert!(!CacheError::ItemExpired.is_corruption());
     }
 }

--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -575,6 +575,9 @@ impl Connection {
                                 self.write_buf.extend_from_slice(b"\r\n");
                             } else {
                                 // Cache-pressure: silent drop, best-effort.
+                                if e.is_corruption() {
+                                    tracing::warn!(error = %e, "streaming SET failed with corruption error");
+                                }
                                 self.write_buf.extend_from_slice(b"+OK\r\n");
                             }
 
@@ -942,6 +945,9 @@ impl Connection {
                                 self.write_buf.extend_from_slice(b"\r\n");
                             } else {
                                 // Cache-pressure: silent drop, best-effort.
+                                if e.is_corruption() {
+                                    tracing::warn!(error = %e, "memcache SET failed with corruption error");
+                                }
                                 self.write_buf.extend_from_slice(b"STORED\r\n");
                             }
 
@@ -1326,6 +1332,9 @@ impl Connection {
                                 )
                             } else {
                                 // Cache-pressure: return stored (best-effort).
+                                if e.is_corruption() {
+                                    tracing::warn!(error = %e, "binary SET failed with corruption error");
+                                }
                                 BinaryResponse::encode_stored(
                                     &mut self.write_buf[start..],
                                     opcode,

--- a/server/src/execute.rs
+++ b/server/src/execute.rs
@@ -188,6 +188,9 @@ pub fn execute_resp<C: Cache>(
                         // Cache is best-effort storage — the item would be
                         // evicted soon anyway. This matches Redis behavior with
                         // eviction enabled.
+                        if e.is_corruption() {
+                            tracing::warn!(error = %e, "SET failed with corruption error");
+                        }
                         write_buf.extend_from_slice(b"+OK\r\n");
                     }
                 }


### PR DESCRIPTION
## Summary
- Added `CacheError::is_corruption()` to distinguish data corruption errors (`Corrupted`, `InvalidOffset`, `KeyMismatch`) from expected cache-pressure errors
- SET error paths in RESP, memcache ASCII, and memcache binary protocol handlers now log a warning when a corruption error is silently dropped
- Cache-pressure errors (`OutOfMemory`, `HashTableFull`, etc.) continue to be silently dropped as intended

## Test plan
- [x] `cargo build -p cache-core -p server` compiles cleanly
- [x] `cargo test -p cache-core -p server` passes
- [x] New `test_is_corruption` test verifies correct classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)