### PR TITLE
fix(cache-core): use saturating_add for TTL expiration calculations

### DIFF
--- a/cache/core/src/disk/disk_layer.rs
+++ b/cache/core/src/disk/disk_layer.rs
@@ -118,7 +118,7 @@ impl DiskLayer {
         let segment = self.pool.get(segment_id).ok_or(CacheError::OutOfMemory)?;
 
         // Set segment expiration time
-        let expire_at = Self::now_secs() + ttl.as_secs() as u32;
+        let expire_at = Self::now_secs().saturating_add(ttl.as_secs() as u32);
         segment.set_expire_at(expire_at);
 
         // Add to bucket

--- a/cache/core/src/disk/io_uring_layer.rs
+++ b/cache/core/src/disk/io_uring_layer.rs
@@ -439,7 +439,7 @@ impl IoUringDiskLayer {
         segment.attach_write_buffer(buf);
 
         // Set segment expiration time
-        let expire_at = Self::now_secs() + ttl.as_secs() as u32;
+        let expire_at = Self::now_secs().saturating_add(ttl.as_secs() as u32);
         segment.set_expire_at(expire_at);
 
         // Add to bucket

--- a/cache/core/src/layer/fifo_layer.rs
+++ b/cache/core/src/layer/fifo_layer.rs
@@ -577,7 +577,7 @@ impl Layer for FifoLayer {
 
             if let Some(segment) = self.pool.get(segment_id) {
                 // Calculate expiration
-                let expire_at = Self::now_secs() + ttl.as_secs() as u32;
+                let expire_at = Self::now_secs().saturating_add(ttl.as_secs() as u32);
 
                 // Try to append with per-item TTL
                 if let Some(offset) = segment.append_item_with_ttl(key, value, optional, expire_at)
@@ -714,7 +714,7 @@ impl Layer for FifoLayer {
 
             if let Some(segment) = self.pool.get(segment_id) {
                 // Calculate expiration
-                let expire_at = Self::now_secs() + ttl.as_secs() as u32;
+                let expire_at = Self::now_secs().saturating_add(ttl.as_secs() as u32);
 
                 // Try to reserve space for the item
                 if let Some((offset, item_size, value_ptr)) =

--- a/cache/core/src/layer/ttl_layer.rs
+++ b/cache/core/src/layer/ttl_layer.rs
@@ -105,7 +105,7 @@ impl TtlLayer {
         let segment = self.pool.get(segment_id).ok_or(CacheError::OutOfMemory)?;
 
         // Set segment expiration time
-        let expire_at = Self::now_secs() + ttl.as_secs() as u32;
+        let expire_at = Self::now_secs().saturating_add(ttl.as_secs() as u32);
         segment.set_expire_at(expire_at);
 
         // Track which bucket this segment belongs to


### PR DESCRIPTION
## Summary
- Replaced `now_secs() + ttl.as_secs() as u32` with `now_secs().saturating_add(ttl.as_secs() as u32)` in all 5 sites across cache-core (fifo_layer, ttl_layer, disk_layer, io_uring_layer)
- Prevents u32 overflow that could cause items to expire immediately or at incorrect times
- Matches the pattern already used in the slab cache (`cache/slab/src/item.rs:132`)

## Test plan
- [x] `cargo build -p cache-core` compiles cleanly
- [x] `cargo test -p cache-core -p segcache` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)