### PR TITLE
fix(proxy): track and log local cache SET errors instead of silently discarding

### DIFF
--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -73,7 +73,12 @@ impl SharedCache {
     #[inline]
     pub fn set(&self, key: &[u8], value: &[u8]) {
         if let Some(cache) = &self.inner {
-            let _ = cache.set(key, value, self.default_ttl);
+            if let Err(e) = cache.set(key, value, self.default_ttl) {
+                crate::metrics::CACHE_SET_ERRORS.increment();
+                if e.is_corruption() {
+                    tracing::warn!(error = %e, "local cache SET failed with corruption error");
+                }
+            }
         }
     }
 
@@ -81,7 +86,12 @@ impl SharedCache {
     #[inline]
     pub fn set_with_ttl(&self, key: &[u8], value: &[u8], ttl: Duration) {
         if let Some(cache) = &self.inner {
-            let _ = cache.set(key, value, ttl);
+            if let Err(e) = cache.set(key, value, ttl) {
+                crate::metrics::CACHE_SET_ERRORS.increment();
+                if e.is_corruption() {
+                    tracing::warn!(error = %e, "local cache SET failed with corruption error");
+                }
+            }
         }
     }
 

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -72,12 +72,12 @@ impl SharedCache {
     /// Cache a value with the default TTL.
     #[inline]
     pub fn set(&self, key: &[u8], value: &[u8]) {
-        if let Some(cache) = &self.inner {
-            if let Err(e) = cache.set(key, value, self.default_ttl) {
-                crate::metrics::CACHE_SET_ERRORS.increment();
-                if e.is_corruption() {
-                    tracing::warn!(error = %e, "local cache SET failed with corruption error");
-                }
+        if let Some(cache) = &self.inner
+            && let Err(e) = cache.set(key, value, self.default_ttl)
+        {
+            crate::metrics::CACHE_SET_ERRORS.increment();
+            if e.is_corruption() {
+                tracing::warn!(error = %e, "local cache SET failed with corruption error");
             }
         }
     }
@@ -85,12 +85,12 @@ impl SharedCache {
     /// Cache a value with a specific TTL.
     #[inline]
     pub fn set_with_ttl(&self, key: &[u8], value: &[u8], ttl: Duration) {
-        if let Some(cache) = &self.inner {
-            if let Err(e) = cache.set(key, value, ttl) {
-                crate::metrics::CACHE_SET_ERRORS.increment();
-                if e.is_corruption() {
-                    tracing::warn!(error = %e, "local cache SET failed with corruption error");
-                }
+        if let Some(cache) = &self.inner
+            && let Err(e) = cache.set(key, value, ttl)
+        {
+            crate::metrics::CACHE_SET_ERRORS.increment();
+            if e.is_corruption() {
+                tracing::warn!(error = %e, "local cache SET failed with corruption error");
             }
         }
     }

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -24,6 +24,7 @@ mod backend {
 mod cache {
     pub const HITS: usize = 0;
     pub const MISSES: usize = 1;
+    pub const SET_ERRORS: usize = 2;
 }
 
 /// Total client connections (gauge, not high-frequency).
@@ -53,3 +54,7 @@ pub static CACHE_HITS: Counter = Counter::new(&CACHE, cache::HITS);
 /// Cache misses (when caching is enabled).
 #[metric(name = "proxy_cache_misses")]
 pub static CACHE_MISSES: Counter = Counter::new(&CACHE, cache::MISSES);
+
+/// Local cache SET errors.
+#[metric(name = "proxy_cache_set_errors")]
+pub static CACHE_SET_ERRORS: Counter = Counter::new(&CACHE, cache::SET_ERRORS);


### PR DESCRIPTION
## Summary
- Replaced `let _ = cache.set(...)` with proper error handling in both `set()` and `set_with_ttl()`
- Added `proxy_cache_set_errors` counter to track all local cache write failures
- Corruption errors are logged at warn level for investigation

## Test plan
- [x] `cargo build -p proxy` compiles cleanly
- [x] `cargo test -p proxy` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)