### PR TITLE
fix(server): log binary memcache parse errors instead of silently discarding

### DIFF
--- a/server/src/connection.rs
+++ b/server/src/connection.rs
@@ -1360,7 +1360,8 @@ impl Connection {
                     }
                 }
                 Ok(BinaryParseProgress::Incomplete) => break,
-                Err(_) => {
+                Err(e) => {
+                    tracing::warn!(error = %e, "binary memcache parse error");
                     PROTOCOL_ERRORS.increment();
                     self.should_close = true;
                     let len = buf.len();


### PR DESCRIPTION
## Summary
- Binary memcache protocol parse error handler used `Err(_)` which discarded the error details
- RESP and memcache ASCII handlers both log/include the error — binary was the odd one out
- Now logs the parse error at warn level before closing the connection

## Test plan
- [x] `cargo clippy -p server` clean
- [x] `cargo test -p server` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)