### PR TITLE
fix: replace eprintln! with tracing macros in production code

### DIFF
--- a/cache/core/Cargo.toml
+++ b/cache/core/Cargo.toml
@@ -23,6 +23,7 @@ libc = { workspace = true }
 memmap2 = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
+tracing = { workspace = true }
 
 # Optional loom support for concurrency testing
 loom = { workspace = true, features = ["checkpoint"], optional = true }

--- a/cache/core/src/disk/file_pool.rs
+++ b/cache/core/src/disk/file_pool.rs
@@ -250,7 +250,7 @@ impl Drop for FilePool {
     fn drop(&mut self) {
         // Sync any remaining dirty data before dropping
         if let Err(e) = self.sync() {
-            eprintln!("FilePool: failed to sync on drop, data may be lost: {e}");
+            tracing::error!(error = %e, "FilePool: failed to sync on drop, data may be lost");
         }
         // Clear segments before dropping mmap
         self.segments.clear();

--- a/cache/core/src/hugepage.rs
+++ b/cache/core/src/hugepage.rs
@@ -222,10 +222,10 @@ fn allocate_prefer_1gb(size: usize) -> Result<HugepageAllocation, std::io::Error
         // Waste is acceptable, try 1GB pages
         match try_mmap_hugepage(rounded_1gb, GB) {
             Ok(alloc) => {
-                eprintln!(
-                    "Allocated {} using 1GB hugepages ({} pages)",
-                    format_bytes(rounded_1gb),
-                    rounded_1gb / GB
+                tracing::info!(
+                    size = format_bytes(rounded_1gb),
+                    pages = rounded_1gb / GB,
+                    "Allocated using 1GB hugepages",
                 );
                 return Ok(HugepageAllocation {
                     ptr: alloc,
@@ -235,9 +235,9 @@ fn allocate_prefer_1gb(size: usize) -> Result<HugepageAllocation, std::io::Error
                 });
             }
             Err(e) => {
-                eprintln!(
-                    "1GB hugepage allocation failed ({}), falling back to regular pages",
-                    e
+                tracing::info!(
+                    error = %e,
+                    "1GB hugepage allocation failed, falling back to regular pages",
                 );
             }
         }
@@ -254,10 +254,10 @@ fn allocate_prefer_2mb(size: usize) -> Result<HugepageAllocation, std::io::Error
 
     match try_mmap_hugepage(rounded_2mb, 2 * MB) {
         Ok(alloc) => {
-            eprintln!(
-                "Allocated {} using 2MB hugepages ({} pages)",
-                format_bytes(rounded_2mb),
-                rounded_2mb / (2 * MB)
+            tracing::info!(
+                size = format_bytes(rounded_2mb),
+                pages = rounded_2mb / (2 * MB),
+                "Allocated using 2MB hugepages",
             );
             return Ok(HugepageAllocation {
                 ptr: alloc,
@@ -267,9 +267,9 @@ fn allocate_prefer_2mb(size: usize) -> Result<HugepageAllocation, std::io::Error
             });
         }
         Err(e) => {
-            eprintln!(
-                "2MB hugepage allocation failed ({}), falling back to regular pages",
-                e
+            tracing::info!(
+                error = %e,
+                "2MB hugepage allocation failed, falling back to regular pages",
             );
         }
     }
@@ -312,9 +312,9 @@ fn allocate_regular_internal(
         let _ = libc::madvise(ptr, alloc_size, 14);
     }
 
-    eprintln!(
-        "Allocated {} using regular pages (with THP hint)",
-        format_bytes(alloc_size)
+    tracing::info!(
+        size = format_bytes(alloc_size),
+        "Allocated using regular pages (with THP hint)",
     );
 
     // Pre-fault pages

--- a/protocol/momento/Cargo.toml
+++ b/protocol/momento/Cargo.toml
@@ -11,6 +11,7 @@ description = "Lightweight Momento cache protocol implementation for ringline-ba
 bytes = { workspace = true }
 grpc-proto = { workspace = true }
 http2-proto = { workspace = true }
+tracing = { workspace = true }
 
 [[bin]]
 name = "momento-cli"

--- a/protocol/momento/src/credential.rs
+++ b/protocol/momento/src/credential.rs
@@ -31,8 +31,8 @@ impl Credential {
         // Momento tokens are typically: header.payload.signature (JWT-like)
         // The payload contains the endpoint info
         let endpoint = Self::extract_endpoint(&token).unwrap_or_else(|| {
-            eprintln!(
-                "Warning: could not extract endpoint from Momento token, \
+            tracing::warn!(
+                "Could not extract endpoint from Momento token, \
                  falling back to us-east-1 default"
             );
             "cache.cell-us-east-1-1.prod.a.momentohq.com".to_string()

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -316,27 +316,19 @@ mod server {
                 let current: Vec<WorkerStatsSnapshot> =
                     stats.iter().map(|s| s.snapshot()).collect();
 
-                eprintln!(
-                    "\n[diagnostics] === Worker Stats (last {}s) ===",
-                    report_interval.as_secs()
-                );
-                eprintln!(
-                    "{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12} {:>12} {:>10}",
-                    "worker",
-                    "polls",
-                    "accepts",
-                    "closes",
-                    "recv",
-                    "send_rdy",
-                    "bytes_in",
-                    "bytes_out",
-                    "conns"
+                use std::fmt::Write;
+                let mut report = format!(
+                    "\n=== Worker Stats (last {}s) ===\n{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12} {:>12} {:>10}",
+                    report_interval.as_secs(),
+                    "worker", "polls", "accepts", "closes", "recv",
+                    "send_rdy", "bytes_in", "bytes_out", "conns"
                 );
 
                 for (i, (curr, prev)) in current.iter().zip(prev_snapshots.iter()).enumerate() {
                     let delta = curr.delta(prev);
-                    eprintln!(
-                        "{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12} {:>12} {:>10}",
+                    write!(
+                        &mut report,
+                        "\n{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12} {:>12} {:>10}",
                         i,
                         delta.poll_count,
                         delta.accepts,
@@ -346,15 +338,17 @@ mod server {
                         format_bytes(delta.bytes_received),
                         format_bytes(delta.bytes_sent),
                         curr.active_connections,
-                    );
+                    ).unwrap();
 
                     if delta.backpressure_events > 0 {
-                        eprintln!(
-                            "  ^ INFO: Worker {} hit backpressure {} times",
+                        write!(
+                            &mut report,
+                            "\n  ^ Worker {} hit backpressure {} times",
                             i, delta.backpressure_events
-                        );
+                        ).unwrap();
                     }
                 }
+                info!("{report}");
 
                 prev_snapshots = current;
                 last_report = Instant::now();


### PR DESCRIPTION
## Summary
- Converted `eprintln!` calls in production library/server code to structured `tracing` macros
- **hugepage.rs**: allocation success/fallback messages → `tracing::info!` with structured fields
- **file_pool.rs**: sync failure on drop → `tracing::error!`
- **async_native/mod.rs**: diagnostics table → single `tracing::info!` message (preserves tabular format)
- **credential.rs**: endpoint extraction fallback → `tracing::warn!`
- Adds `tracing` dependency to `cache-core` and `protocol-momento`
- CLI binaries and test files retain `eprintln!` (pre-logging or test-only output)

## Test plan
- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test -p cache-core -p server -p protocol-momento` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)