### PR TITLE
refactor: use From impls for DiskSyncMode and HugepageConfig conversions

### DIFF
--- a/cache-bench/src/config.rs
+++ b/cache-bench/src/config.rs
@@ -130,6 +130,16 @@ pub enum DiskSyncMode {
     None,
 }
 
+impl From<DiskSyncMode> for cache_core::SyncMode {
+    fn from(mode: DiskSyncMode) -> Self {
+        match mode {
+            DiskSyncMode::Sync => Self::Sync,
+            DiskSyncMode::Async => Self::Async,
+            DiskSyncMode::None => Self::None,
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct DiskConfig {
     #[serde(default)]

--- a/cache-bench/src/main.rs
+++ b/cache-bench/src/main.rs
@@ -9,7 +9,7 @@ mod metrics;
 mod ratelimit;
 mod worker;
 
-use crate::config::{CacheBackend, Config, DiskSyncMode, EvictionPolicy};
+use crate::config::{CacheBackend, Config, EvictionPolicy};
 use crate::ratelimit::DynamicRateLimiter;
 use crate::worker::{Phase, SharedState};
 
@@ -396,9 +396,7 @@ fn print_latency_summary(label: &str, hist: &AtomicHistogram) {
 // --- Cache constructors ---
 
 fn create_segment(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>> {
-    use segcache::{
-        DiskTierConfig, EvictionPolicy as SegEvictionPolicy, MergeConfig, SegCache, SyncMode,
-    };
+    use segcache::{DiskTierConfig, EvictionPolicy as SegEvictionPolicy, MergeConfig, SegCache};
 
     let mut builder = SegCache::builder()
         .heap_size(config.cache.heap_size)
@@ -419,14 +417,9 @@ fn create_segment(config: &Config) -> Result<impl Cache, Box<dyn std::error::Err
     if let Some(ref disk_config) = config.cache.disk
         && disk_config.enabled
     {
-        let sync_mode = match disk_config.sync_mode {
-            DiskSyncMode::Sync => SyncMode::Sync,
-            DiskSyncMode::Async => SyncMode::Async,
-            DiskSyncMode::None => SyncMode::None,
-        };
         let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
             .promotion_threshold(disk_config.promotion_threshold)
-            .sync_mode(sync_mode)
+            .sync_mode(disk_config.sync_mode.into())
             .recover_on_startup(disk_config.recover_on_startup);
         builder = builder.disk_tier(disk_tier);
     }
@@ -436,7 +429,7 @@ fn create_segment(config: &Config) -> Result<impl Cache, Box<dyn std::error::Err
 }
 
 fn create_slab(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>> {
-    use slab_cache::{DiskTierConfig, EvictionStrategy, SlabCache, SyncMode};
+    use slab_cache::{DiskTierConfig, EvictionStrategy, SlabCache};
 
     let eviction_strategy = match config.cache.policy {
         EvictionPolicy::Lra => EvictionStrategy::SLAB_LRA,
@@ -455,14 +448,9 @@ fn create_slab(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>
     if let Some(ref disk_config) = config.cache.disk
         && disk_config.enabled
     {
-        let sync_mode = match disk_config.sync_mode {
-            DiskSyncMode::Sync => SyncMode::Sync,
-            DiskSyncMode::Async => SyncMode::Async,
-            DiskSyncMode::None => SyncMode::None,
-        };
         let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
             .promotion_threshold(disk_config.promotion_threshold)
-            .sync_mode(sync_mode)
+            .sync_mode(disk_config.sync_mode.into())
             .recover_on_startup(disk_config.recover_on_startup);
         builder = builder.disk_tier(disk_tier);
     }
@@ -473,7 +461,7 @@ fn create_slab(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>
 }
 
 fn create_heap(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>> {
-    use heap_cache::{DiskTierConfig, EvictionPolicy as HeapEvictionPolicy, HeapCache, SyncMode};
+    use heap_cache::{DiskTierConfig, EvictionPolicy as HeapEvictionPolicy, HeapCache};
 
     let heap_policy = match config.cache.policy {
         EvictionPolicy::S3Fifo => HeapEvictionPolicy::S3Fifo,
@@ -490,14 +478,9 @@ fn create_heap(config: &Config) -> Result<impl Cache, Box<dyn std::error::Error>
     if let Some(ref disk_config) = config.cache.disk
         && disk_config.enabled
     {
-        let sync_mode = match disk_config.sync_mode {
-            DiskSyncMode::Sync => SyncMode::Sync,
-            DiskSyncMode::Async => SyncMode::Async,
-            DiskSyncMode::None => SyncMode::None,
-        };
         let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
             .promotion_threshold(disk_config.promotion_threshold)
-            .sync_mode(sync_mode)
+            .sync_mode(disk_config.sync_mode.into())
             .recover_on_startup(disk_config.recover_on_startup);
         builder = builder.disk_tier(disk_tier);
     }

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -320,8 +320,15 @@ mod server {
                 let mut report = format!(
                     "\n=== Worker Stats (last {}s) ===\n{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>12} {:>12} {:>10}",
                     report_interval.as_secs(),
-                    "worker", "polls", "accepts", "closes", "recv",
-                    "send_rdy", "bytes_in", "bytes_out", "conns"
+                    "worker",
+                    "polls",
+                    "accepts",
+                    "closes",
+                    "recv",
+                    "send_rdy",
+                    "bytes_in",
+                    "bytes_out",
+                    "conns"
                 );
 
                 for (i, (curr, prev)) in current.iter().zip(prev_snapshots.iter()).enumerate() {
@@ -338,14 +345,16 @@ mod server {
                         format_bytes(delta.bytes_received),
                         format_bytes(delta.bytes_sent),
                         curr.active_connections,
-                    ).unwrap();
+                    )
+                    .unwrap();
 
                     if delta.backpressure_events > 0 {
                         write!(
                             &mut report,
                             "\n  ^ Worker {} hit backpressure {} times",
                             i, delta.backpressure_events
-                        ).unwrap();
+                        )
+                        .unwrap();
                     }
                 }
                 info!("{report}");

--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -10,7 +10,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use clap::Parser;
 use server::admin::{self, AdminConfig};
 use server::banner::{BannerConfig, print_banner};
-use server::config::{CacheBackend, Config, DiskIoBackendConfig, EvictionPolicy, HugepageConfig};
+use server::config::{CacheBackend, Config, DiskIoBackendConfig, EvictionPolicy};
 use server::logging;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -140,15 +140,11 @@ fn create_segment(
 ) -> Result<impl cache_core::Cache, Box<dyn std::error::Error>> {
     use segcache::{
         DiskTierConfig, EvictionPolicy as SegEvictionPolicy, HugepageSize, IoUringDiskTierConfig,
-        MergeConfig, SegCache, SyncMode,
+        MergeConfig, SegCache,
     };
     use server::config::format_size;
 
-    let hugepage_size = match config.cache.hugepage {
-        HugepageConfig::None => HugepageSize::None,
-        HugepageConfig::TwoMegabyte => HugepageSize::TwoMegabyte,
-        HugepageConfig::OneGigabyte => HugepageSize::OneGigabyte,
-    };
+    let hugepage_size: HugepageSize = config.cache.hugepage.into();
 
     let mut builder = SegCache::builder()
         .heap_size(config.cache.heap_size)
@@ -205,15 +201,9 @@ fn create_segment(
                 builder = builder.io_uring_disk_tier(io_uring_tier);
             }
             DiskIoBackendConfig::Mmap => {
-                let sync_mode = match disk_config.sync_mode {
-                    server::config::DiskSyncMode::Sync => SyncMode::Sync,
-                    server::config::DiskSyncMode::Async => SyncMode::Async,
-                    server::config::DiskSyncMode::None => SyncMode::None,
-                };
-
                 let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
                     .promotion_threshold(disk_config.promotion_threshold)
-                    .sync_mode(sync_mode)
+                    .sync_mode(disk_config.sync_mode.into())
                     .recover_on_startup(disk_config.recover_on_startup);
 
                 eprintln!(
@@ -237,13 +227,9 @@ fn create_slab(
     config: &Config,
     policy: EvictionPolicy,
 ) -> Result<impl cache_core::Cache, Box<dyn std::error::Error>> {
-    use slab_cache::{DiskTierConfig, EvictionStrategy, HugepageSize, SlabCache, SyncMode};
+    use slab_cache::{DiskTierConfig, EvictionStrategy, HugepageSize, SlabCache};
 
-    let hugepage_size = match config.cache.hugepage {
-        HugepageConfig::None => HugepageSize::None,
-        HugepageConfig::TwoMegabyte => HugepageSize::TwoMegabyte,
-        HugepageConfig::OneGigabyte => HugepageSize::OneGigabyte,
-    };
+    let hugepage_size: HugepageSize = config.cache.hugepage.into();
 
     let eviction_strategy = match policy {
         EvictionPolicy::Lra => EvictionStrategy::SLAB_LRA,
@@ -267,15 +253,9 @@ fn create_slab(
     if let Some(ref disk_config) = config.cache.disk
         && disk_config.enabled
     {
-        let sync_mode = match disk_config.sync_mode {
-            server::config::DiskSyncMode::Sync => SyncMode::Sync,
-            server::config::DiskSyncMode::Async => SyncMode::Async,
-            server::config::DiskSyncMode::None => SyncMode::None,
-        };
-
         let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
             .promotion_threshold(disk_config.promotion_threshold)
-            .sync_mode(sync_mode)
+            .sync_mode(disk_config.sync_mode.into())
             .recover_on_startup(disk_config.recover_on_startup);
 
         builder = builder.disk_tier(disk_tier);
@@ -290,7 +270,7 @@ fn create_heap(
     config: &Config,
     policy: EvictionPolicy,
 ) -> Result<impl cache_core::Cache, Box<dyn std::error::Error>> {
-    use heap_cache::{DiskTierConfig, EvictionPolicy as HeapEvictionPolicy, HeapCache, SyncMode};
+    use heap_cache::{DiskTierConfig, EvictionPolicy as HeapEvictionPolicy, HeapCache};
 
     let heap_policy = match policy {
         EvictionPolicy::S3Fifo => HeapEvictionPolicy::S3Fifo,
@@ -308,15 +288,9 @@ fn create_heap(
     if let Some(ref disk_config) = config.cache.disk
         && disk_config.enabled
     {
-        let sync_mode = match disk_config.sync_mode {
-            server::config::DiskSyncMode::Sync => SyncMode::Sync,
-            server::config::DiskSyncMode::Async => SyncMode::Async,
-            server::config::DiskSyncMode::None => SyncMode::None,
-        };
-
         let disk_tier = DiskTierConfig::new(&disk_config.path, disk_config.size)
             .promotion_threshold(disk_config.promotion_threshold)
-            .sync_mode(sync_mode)
+            .sync_mode(disk_config.sync_mode.into())
             .recover_on_startup(disk_config.recover_on_startup);
 
         builder = builder.disk_tier(disk_tier);

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -385,6 +385,16 @@ impl<'de> Deserialize<'de> for HugepageConfig {
     }
 }
 
+impl From<HugepageConfig> for cache_core::HugepageSize {
+    fn from(config: HugepageConfig) -> Self {
+        match config {
+            HugepageConfig::None => Self::None,
+            HugepageConfig::TwoMegabyte => Self::TwoMegabyte,
+            HugepageConfig::OneGigabyte => Self::OneGigabyte,
+        }
+    }
+}
+
 /// Protocol listener configuration.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
## Summary
- Replaced 6 duplicated `DiskSyncMode → SyncMode` match conversions with `.into()` (3 in server, 3 in cache-bench)
- Replaced 2 duplicated `HugepageConfig → HugepageSize` match conversions with `.into()` in server
- Added `From<HugepageConfig>` impl in server config and `From<DiskSyncMode>` impl in cache-bench config
- Server already had a `From<DiskSyncMode>` impl that wasn't being used — now it is
- Removed 8 unused `SyncMode`/`HugepageConfig` imports

## Test plan
- [x] `cargo fmt` applied
- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test -p server -p cache-bench` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)