### PR TITLE
refactor(proxy): migrate from ctrlc to ringline::signal for signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -1216,6 +1217,7 @@ dependencies = [
  "grpc-proto",
  "http2-proto",
  "serial_test",
+ "tracing",
 ]
 
 [[package]]
@@ -1234,7 +1236,6 @@ dependencies = [
  "bytes",
  "clap",
  "crossbeam-channel",
- "ctrlc",
  "ketama",
  "libc",
  "metrics",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -44,9 +44,6 @@ clap = { workspace = true, features = ["derive"] }
 metrics = { workspace = true }
 metriken = { workspace = true }
 
-# Signal handling
-ctrlc = { version = "3", features = ["termination"] }
-
 # Structured logging
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/proxy/src/signal.rs
+++ b/proxy/src/signal.rs
@@ -4,14 +4,21 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Install signal handlers and return a shutdown flag.
+///
+/// Spawns a dedicated thread that blocks on `ringline::signal::wait()`
+/// and sets the shutdown flag when SIGINT or SIGTERM is received.
 pub fn install_signal_handler() -> Arc<AtomicBool> {
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_clone = shutdown.clone();
 
-    ctrlc::set_handler(move || {
-        shutdown_clone.store(true, Ordering::SeqCst);
-    })
-    .expect("failed to set signal handler");
+    std::thread::Builder::new()
+        .name("signal".to_string())
+        .spawn(move || {
+            let signal = ringline::signal::wait();
+            tracing::info!(%signal, "Received signal, initiating shutdown...");
+            shutdown_clone.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to spawn signal thread");
 
     shutdown
 }


### PR DESCRIPTION
## Summary
- Replaced `ctrlc` crate with `ringline::signal::wait()` for signal handling, matching the server's pattern
- Spawns a dedicated "signal" thread instead of using ctrlc's callback-based handler
- Now logs which signal was received (SIGINT vs SIGTERM) via tracing
- Removes the `ctrlc` dependency from the proxy

## Test plan
- [x] `cargo fmt` applied
- [x] `cargo clippy -p proxy --all-targets` clean
- [x] `cargo test -p proxy` — all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)