### PR TITLE
Fix CAS and increment/decrement lost-update races in cache-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/cache/core/src/cache.rs
+++ b/cache/core/src/cache.rs
@@ -976,18 +976,32 @@ impl<H: Hashtable> TieredCache<H> {
         let write_layer = self.layers.first().ok_or(CacheError::OutOfMemory)?;
         let new_location = write_layer.write_item(key, value, optional, ttl)?;
 
-        // Update in hashtable
-        match self
-            .hashtable
-            .update_if_present(key, new_location.to_location(), &verifier)
-        {
-            Ok(old_location) => {
-                self.mark_deleted_at(old_location);
-                Ok(true)
+        // Publish by swapping the slot only if it still holds the location we
+        // checked the token against — this is the linearization point. A
+        // plain replace (update_if_present) would overwrite whatever entry is
+        // current, silently losing a write that raced in between the token
+        // check and the publish.
+        loop {
+            if self
+                .hashtable
+                .cas_location(key, current_location, new_location.to_location(), true)
+            {
+                self.mark_deleted_at(current_location);
+                return Ok(true);
             }
-            Err(e) => {
+
+            // cas_location can fail spuriously: the slot exchange covers the
+            // full packed word, so a concurrent reader bumping the frequency
+            // bits fails it even though the location is unchanged. Retry
+            // while the key still maps to the checked location; otherwise the
+            // entry really changed and the CAS fails.
+            if self
+                .hashtable
+                .get_item_frequency(key, current_location)
+                .is_none()
+            {
                 write_layer.mark_deleted(new_location);
-                Err(e)
+                return Ok(false);
             }
         }
     }
@@ -2292,5 +2306,36 @@ mod tests {
         let layer = cache.layer(0).unwrap();
         // Segment 0 should exist after writing
         let _segment = layer.get_segment(0);
+    }
+
+    #[test]
+    fn test_cas_token_lifecycle() {
+        let cache = create_test_cache();
+        let ttl = Duration::from_secs(3600);
+
+        // Missing key fails with KeyNotFound
+        assert_eq!(
+            cache.cas(b"counter", b"v1", b"", ttl, CasToken::from_raw(0)),
+            Err(CacheError::KeyNotFound)
+        );
+
+        cache.set(b"counter", b"v1", b"", ttl).unwrap();
+        let (value, token) = cache.get_with_cas(b"counter").unwrap();
+        assert_eq!(value, b"v1");
+
+        // A fresh token round-trips
+        assert_eq!(cache.cas(b"counter", b"v2", b"", ttl, token), Ok(true));
+        assert_eq!(cache.get(b"counter").unwrap(), b"v2");
+
+        // The consumed token is now stale and must not match
+        assert_eq!(cache.cas(b"counter", b"v3", b"", ttl, token), Ok(false));
+        assert_eq!(cache.get(b"counter").unwrap(), b"v2");
+
+        // A token invalidated by an intervening set fails and leaves the
+        // newer value in place
+        let (_, token) = cache.get_with_cas(b"counter").unwrap();
+        cache.set(b"counter", b"v4", b"", ttl).unwrap();
+        assert_eq!(cache.cas(b"counter", b"v5", b"", ttl, token), Ok(false));
+        assert_eq!(cache.get(b"counter").unwrap(), b"v4");
     }
 }

--- a/cache/core/src/cache.rs
+++ b/cache/core/src/cache.rs
@@ -1078,8 +1078,14 @@ impl<H: Hashtable> TieredCache<H> {
 
     /// Atomically increment a numeric value stored as ASCII decimal.
     ///
+    /// Reads the current value with its CAS token and publishes the new
+    /// value via [`Self::cas`], retrying if a concurrent write lands in
+    /// between — concurrent increments cannot lose updates. Each retry
+    /// re-reads the value (and counts as a hit for frequency purposes).
+    ///
     /// If the key doesn't exist and `initial` is provided, creates the key
-    /// with `initial + delta`. If `initial` is `None` and the key doesn't exist,
+    /// with `initial + delta` (insert-if-absent; a concurrent creation
+    /// triggers a retry). If `initial` is `None` and the key doesn't exist,
     /// returns `Err(CacheError::KeyNotFound)`.
     ///
     /// # Returns
@@ -1094,38 +1100,48 @@ impl<H: Hashtable> TieredCache<H> {
         initial: Option<u64>,
         ttl: Duration,
     ) -> CacheResult<u64> {
-        // Try to get the current value
-        let current_value = self.get(key);
+        loop {
+            // Read the current value and its CAS token in one step,
+            // parsing as ASCII decimal under the item guard.
+            let current = self.with_value_cas(key, |v| {
+                std::str::from_utf8(v)
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+            });
 
-        match current_value {
-            Some(data) => {
-                // Parse existing value as ASCII decimal
-                let value_str = std::str::from_utf8(&data).map_err(|_| CacheError::NotNumeric)?;
-                let current: u64 = value_str
-                    .trim()
-                    .parse()
-                    .map_err(|_| CacheError::NotNumeric)?;
-
-                // Compute new value with overflow check
-                let new_value = current.checked_add(delta).ok_or(CacheError::Overflow)?;
-
-                // Store the new value
-                let new_str = new_value.to_string();
-                self.set(key, new_str.as_bytes(), &[], ttl)?;
-
-                Ok(new_value)
-            }
-            None => {
-                // Key doesn't exist
-                match initial {
-                    Some(init) => {
-                        // Create with initial + delta
-                        let new_value = init.checked_add(delta).ok_or(CacheError::Overflow)?;
-                        let new_str = new_value.to_string();
-                        self.set(key, new_str.as_bytes(), &[], ttl)?;
-                        Ok(new_value)
+            match current {
+                Some((Some(current), token)) => {
+                    let new_value = current.checked_add(delta).ok_or(CacheError::Overflow)?;
+                    match self.cas(key, new_value.to_string().as_bytes(), &[], ttl, token) {
+                        Ok(true) => return Ok(new_value),
+                        // Raced with another writer, or the key was deleted
+                        // in between; re-read and retry.
+                        Ok(false) | Err(CacheError::KeyNotFound) => continue,
+                        Err(e) => return Err(e),
                     }
-                    None => Err(CacheError::KeyNotFound),
+                }
+                Some((None, _)) => return Err(CacheError::NotNumeric),
+                None => {
+                    // with_value_cas returns None both when the key is absent
+                    // and when the item is transiently unreadable (e.g. its
+                    // segment is mid-migration). Only treat the key as absent
+                    // if the hashtable agrees; otherwise retry.
+                    let verifier = self.create_key_verifier();
+                    if self.hashtable.contains(key, &verifier) {
+                        continue;
+                    }
+                    match initial {
+                        Some(init) => {
+                            let new_value = init.checked_add(delta).ok_or(CacheError::Overflow)?;
+                            match self.add(key, new_value.to_string().as_bytes(), &[], ttl) {
+                                Ok(()) => return Ok(new_value),
+                                // Lost the creation race; re-read and retry.
+                                Err(CacheError::KeyExists) => continue,
+                                Err(e) => return Err(e),
+                            }
+                        }
+                        None => return Err(CacheError::KeyNotFound),
+                    }
                 }
             }
         }
@@ -1133,8 +1149,14 @@ impl<H: Hashtable> TieredCache<H> {
 
     /// Atomically decrement a numeric value stored as ASCII decimal.
     ///
+    /// Reads the current value with its CAS token and publishes the new
+    /// value via [`Self::cas`], retrying if a concurrent write lands in
+    /// between — concurrent decrements cannot lose updates. Each retry
+    /// re-reads the value (and counts as a hit for frequency purposes).
+    ///
     /// If the key doesn't exist and `initial` is provided, creates the key
-    /// with `initial.saturating_sub(delta)`. If `initial` is `None` and the key
+    /// with `initial.saturating_sub(delta)` (insert-if-absent; a concurrent
+    /// creation triggers a retry). If `initial` is `None` and the key
     /// doesn't exist, returns `Err(CacheError::KeyNotFound)`.
     ///
     /// Underflow clamps to 0 (saturating subtraction) per memcache semantics.
@@ -1150,38 +1172,49 @@ impl<H: Hashtable> TieredCache<H> {
         initial: Option<u64>,
         ttl: Duration,
     ) -> CacheResult<u64> {
-        // Try to get the current value
-        let current_value = self.get(key);
+        loop {
+            // Read the current value and its CAS token in one step,
+            // parsing as ASCII decimal under the item guard.
+            let current = self.with_value_cas(key, |v| {
+                std::str::from_utf8(v)
+                    .ok()
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+            });
 
-        match current_value {
-            Some(data) => {
-                // Parse existing value as ASCII decimal
-                let value_str = std::str::from_utf8(&data).map_err(|_| CacheError::NotNumeric)?;
-                let current: u64 = value_str
-                    .trim()
-                    .parse()
-                    .map_err(|_| CacheError::NotNumeric)?;
-
-                // Compute new value with saturating subtraction (clamp to 0)
-                let new_value = current.saturating_sub(delta);
-
-                // Store the new value
-                let new_str = new_value.to_string();
-                self.set(key, new_str.as_bytes(), &[], ttl)?;
-
-                Ok(new_value)
-            }
-            None => {
-                // Key doesn't exist
-                match initial {
-                    Some(init) => {
-                        // Create with initial - delta (saturating)
-                        let new_value = init.saturating_sub(delta);
-                        let new_str = new_value.to_string();
-                        self.set(key, new_str.as_bytes(), &[], ttl)?;
-                        Ok(new_value)
+            match current {
+                Some((Some(current), token)) => {
+                    // Saturating subtraction (clamp to 0)
+                    let new_value = current.saturating_sub(delta);
+                    match self.cas(key, new_value.to_string().as_bytes(), &[], ttl, token) {
+                        Ok(true) => return Ok(new_value),
+                        // Raced with another writer, or the key was deleted
+                        // in between; re-read and retry.
+                        Ok(false) | Err(CacheError::KeyNotFound) => continue,
+                        Err(e) => return Err(e),
                     }
-                    None => Err(CacheError::KeyNotFound),
+                }
+                Some((None, _)) => return Err(CacheError::NotNumeric),
+                None => {
+                    // with_value_cas returns None both when the key is absent
+                    // and when the item is transiently unreadable (e.g. its
+                    // segment is mid-migration). Only treat the key as absent
+                    // if the hashtable agrees; otherwise retry.
+                    let verifier = self.create_key_verifier();
+                    if self.hashtable.contains(key, &verifier) {
+                        continue;
+                    }
+                    match initial {
+                        Some(init) => {
+                            let new_value = init.saturating_sub(delta);
+                            match self.add(key, new_value.to_string().as_bytes(), &[], ttl) {
+                                Ok(()) => return Ok(new_value),
+                                // Lost the creation race; re-read and retry.
+                                Err(CacheError::KeyExists) => continue,
+                                Err(e) => return Err(e),
+                            }
+                        }
+                        None => return Err(CacheError::KeyNotFound),
+                    }
                 }
             }
         }
@@ -2337,5 +2370,89 @@ mod tests {
         cache.set(b"counter", b"v4", b"", ttl).unwrap();
         assert_eq!(cache.cas(b"counter", b"v5", b"", ttl, token), Ok(false));
         assert_eq!(cache.get(b"counter").unwrap(), b"v4");
+    }
+
+    #[test]
+    fn test_increment_decrement_semantics() {
+        let cache = create_test_cache();
+        let ttl = Duration::from_secs(3600);
+
+        // Missing key, no initial
+        assert_eq!(
+            cache.increment(b"n", 1, None, ttl),
+            Err(CacheError::KeyNotFound)
+        );
+        assert_eq!(
+            cache.decrement(b"n", 1, None, ttl),
+            Err(CacheError::KeyNotFound)
+        );
+
+        // Missing key, initial provided: created with initial + delta
+        assert_eq!(cache.increment(b"n", 2, Some(10), ttl), Ok(12));
+        assert_eq!(cache.get(b"n").unwrap(), b"12");
+
+        // Existing key: initial is ignored
+        assert_eq!(cache.increment(b"n", 3, Some(100), ttl), Ok(15));
+
+        // Decrement, including saturation at zero
+        assert_eq!(cache.decrement(b"n", 5, None, ttl), Ok(10));
+        assert_eq!(cache.decrement(b"n", 100, None, ttl), Ok(0));
+        assert_eq!(cache.get(b"n").unwrap(), b"0");
+
+        // Decrement creation saturates too
+        assert_eq!(cache.decrement(b"m", 5, Some(3), ttl), Ok(0));
+
+        // Non-numeric value
+        cache.set(b"s", b"not a number", b"", ttl).unwrap();
+        assert_eq!(
+            cache.increment(b"s", 1, None, ttl),
+            Err(CacheError::NotNumeric)
+        );
+
+        // Overflow
+        cache
+            .set(b"max", u64::MAX.to_string().as_bytes(), b"", ttl)
+            .unwrap();
+        assert_eq!(
+            cache.increment(b"max", 1, None, ttl),
+            Err(CacheError::Overflow)
+        );
+    }
+
+    // Concurrent increments must not lose updates. This exercises both the
+    // increment retry loop and the cas() publish linearization: with the
+    // old get-then-set increment, or with cas() publishing via a plain
+    // replace, concurrent updates are lost and the final count comes up
+    // short (measured ~30-45% of updates surviving before the fix).
+    #[test]
+    fn test_increment_concurrent_no_lost_updates() {
+        use std::sync::Arc as StdArc;
+
+        const THREADS: usize = 4;
+        const PER_THREAD: u64 = 250;
+
+        let cache = StdArc::new(create_test_cache());
+        let ttl = Duration::from_secs(3600);
+
+        cache.set(b"counter", b"0", b"", ttl).unwrap();
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let cache = StdArc::clone(&cache);
+                std::thread::spawn(move || {
+                    for _ in 0..PER_THREAD {
+                        cache.increment(b"counter", 1, None, ttl).unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let value = cache.get(b"counter").unwrap();
+        let value: u64 = std::str::from_utf8(&value).unwrap().parse().unwrap();
+        assert_eq!(value, THREADS as u64 * PER_THREAD);
     }
 }

--- a/cache/core/src/disk/config.rs
+++ b/cache/core/src/disk/config.rs
@@ -98,11 +98,7 @@ impl DiskConfig {
     /// Calculate the number of segments based on size and segment_size.
     pub fn segment_count(&self, default_segment_size: usize) -> usize {
         let segment_size = self.segment_size.unwrap_or(default_segment_size);
-        if segment_size == 0 {
-            0
-        } else {
-            self.size / segment_size
-        }
+        self.size.checked_div(segment_size).unwrap_or(0)
     }
 }
 

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -1534,6 +1534,28 @@ mod tests {
         }
     }
 
+    // Every Free -> Reserved transition must bump the generation counter:
+    // CasToken ABA protection depends on a recycled segment never serving
+    // items under a generation that outstanding tokens were issued against.
+    #[test]
+    fn test_segment_generation_bumps_on_recycle() {
+        let (segment, ptr, layout) = create_test_segment(0, false, 0, 1024);
+        assert_eq!(segment.generation(), 0);
+
+        // First allocation
+        assert!(segment.try_reserve());
+        assert_eq!(segment.generation(), 1);
+
+        // Recycle: back to Free, then reserved again
+        assert!(segment.try_release());
+        assert!(segment.try_reserve());
+        assert_eq!(segment.generation(), 2);
+
+        unsafe {
+            free_test_segment(ptr, layout);
+        }
+    }
+
     #[test]
     fn test_segment_append_basic() {
         let (segment, ptr, layout) = create_test_segment(0, false, 0, 4096);


### PR DESCRIPTION
## Summary

Two lost-update races in `TieredCache`, found while porting the CasToken design to pelikan-io/cache-rs (pelikan-io/cache-rs#24):

- **`cas()` published via `update_if_present`**, which compare-exchanges against a re-read slot word rather than the location the token was validated against. A concurrent set or cas landing between the token check and the publish was silently overwritten — the exact race CAS exists to prevent. Now publishes via `cas_location(key, checked_location, new_location)`, making the slot exchange the linearization point; any concurrent write, relocation, or delete fails the CAS closed with `Ok(false)`. Spurious exchange failures from concurrent readers bumping the frequency bits are retried while the key still maps to the checked location (freq-neutral `get_item_frequency`).
- **`increment()`/`decrement()` were get → parse → set**: two concurrent operations could both read N and write N+delta. Both are now `with_value_cas` + `cas()` retry loops, with `add()` (insert-if-absent) for the `initial` case. `with_value_cas` returning `None` is only treated as key-absent when the hashtable agrees, since it's also the transient mid-migration result. Semantics preserved: trim/parse, overflow checks, saturation at zero, initial handling, error variants.

Also adds a regression test pinning that `try_reserve` bumps the segment generation on every recycle — the property CasToken's ABA protection depends on (the bump already existed; it just wasn't pinned).

## Testing

- New `test_increment_concurrent_no_lost_updates` (4 threads × 250 increments): against the old code it loses **55–70% of updates** (observed 314/1000, 439/1000); with the fix it lands exactly at 1000, repeatedly.
- New `test_cas_token_lifecycle` and `test_increment_decrement_semantics` pin single-threaded behavior; `test_segment_generation_bumps_on_recycle` pins the recycle bump.
- `cargo test -p cache-core` (413 tests), `--features loom` (44 models), and segcache/heap-cache/slab-cache suites all green. `cargo fmt --check` clean. (One pre-existing clippy `manual_checked_ops` hit in `disk/config.rs` from a newer toolchain lint, present on main; workspace io_uring crates don't build on macOS as usual.)

## Follow-up

`HeapCache::cas` (cache/heap/src/lib.rs) has the same check-then-act publish shape on its slot storage and needs an analogous fix. Full race-freedom of `cas()` against the (astronomically narrow) recycle-during-publish window would additionally need a segment read guard held from the generation check through the slot exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)