### PR TITLE
deps: upgrade to ringline 0.6 / ringline-redis 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Upgraded to published ringline releases**: `ringline` 0.6 and `ringline-redis` 0.7 from
+  crates.io, replacing the pinned git revision. Picks up the io_uring send/close correctness
+  fixes, segmented zero-copy recv, and the 1 GiB `recv_accumulator_max` default. Adapting to the
+  breaking API changes:
+  - `ringline::Config` is built through `ConfigBuilder` (server, proxy, ping, proxy tests);
+    `WorkerConfig` / `RecvBufferConfig` are no longer exported and `Config::validate()` now
+    always runs at build time
+  - `ringline::TlsConfig` is constructed with `TlsConfig::new()` instead of a struct literal
+  - `nvme_read` / `nvme_write` are `unsafe fn`; the disk-tier read and flush paths wrap them with
+    the buffer-lifetime safety argument
+  - `AsyncSendBuilder::submit_batch_await` was removed upstream; the scatter-gather drain path
+    submits with `submit_batch` and yields explicitly on the backpressure path. `MAX_IOVECS` /
+    `MAX_GUARDS` are no longer exported, so the handler defines its own batch caps
+- **Bumped protocol crates**: `resp-proto` 0.0.2, `memcache-proto` 0.0.5, `http2-proto` 0.0.2,
+  `grpc-proto` 0.0.2, `ketama` 0.0.2 — matching what ringline 0.6 builds against (line-framing,
+  ring-routing, and parser-overflow fixes)
+- **Bumped `metriken` to 0.9**, which is what ringline 0.6 registers its metrics with. Crucible
+  and ringline now share one metriken registry, so ringline's I/O metrics are exposed on
+  `/metrics` again; histogram exposition moved from the deprecated `percentiles()` to
+  `quantiles()`
+
 ## [0.4.1] - 2026-02-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,8 +182,8 @@ dependencies = [
  "humantime",
  "libc",
  "metrics",
- "metriken 0.8.0",
- "rand 0.9.2",
+ "metriken",
+ "rand",
  "rand_xoshiro",
  "segcache",
  "serde",
@@ -205,7 +205,7 @@ dependencies = [
  "loom",
  "memmap2",
  "parking_lot",
- "rand 0.9.2",
+ "rand",
  "tempfile",
  "tracing",
 ]
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "grpc-proto"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251e77f35a022f2ec42a80b004042570e6585506ddd7927d2f66c942edce6557"
+checksum = "bce390c89186df80d4795a4c130ccf145dd5cab4b2841abcb1dddfeb7be3274d"
 dependencies = [
  "bytes",
  "http2-proto",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "1.2.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2b5fe6dcc3f27467d78bebc976c7ffb20fc693ad53627ceb0bc58dc6871513"
+checksum = "8ebb5d42df947561c11a73414c53d14c4a0e3193e761a4cdca16ca3d941a2302"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "http2-proto"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346ea9f18bd84e3c02dc9321afea9cec87576061357027c19ecfc707b2d4cc91"
+checksum = "fa57f5eb3b9b11f30d7ec1a5672b861d374bad6617c52b03954a9ade4570fb29"
 dependencies = [
  "bytes",
  "rustls",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "ketama"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc28a770b7d738684c2b53fff2e68614edfa874c865b6592a7d72fc3c3ac2be"
+checksum = "02477b4e4b5454c404fa7ef505c85cacb89fee3987793f9a3a2bd9ab556c4e3b"
 
 [[package]]
 name = "lazy_static"
@@ -883,10 +883,11 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memcache-proto"
-version = "0.0.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9ce3407f1cea26c7596fbdc759cd7f5ad6e325f58c08b51f912f5fca2b49d4"
+checksum = "1bc235782fb39adfbf6629e80cd16bb5fe09c88081a6d7b3ffe8487c6ddbde5d"
 dependencies = [
+ "bytes",
  "itoa",
  "memchr",
  "thiserror 2.0.18",
@@ -911,29 +912,16 @@ dependencies = [
 name = "metrics"
 version = "0.4.2-alpha.0"
 dependencies = [
- "metriken 0.8.0",
+ "metriken",
 ]
 
 [[package]]
 name = "metriken"
-version = "0.7.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc160a09cad0d921ac6d6a6fe45a31f7f709b5c312afa97d58c637c7add0be9"
+checksum = "d34d88b3f3ec8c532945831eeea8170f9410a37f444feb1322b8e124f3a4a3b9"
 dependencies = [
- "histogram 0.11.4",
- "metriken-core",
- "metriken-derive",
- "once_cell",
- "parking_lot",
-]
-
-[[package]]
-name = "metriken"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625cf66223be6d306db71b8bec24e8ae6b18bce095d41b8b696fe7b87ccdfd1a"
-dependencies = [
- "histogram 1.2.0",
+ "histogram 1.5.0",
  "metriken-core",
  "metriken-derive",
  "once_cell",
@@ -942,10 +930,11 @@ dependencies = [
 
 [[package]]
 name = "metriken-core"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51491c61573eefe01aff38c3ab258f182c596e29362caffb108c10585fdf6cc"
+checksum = "bab27bd3058a12219267acc9a86c68c9a55ab456825582758f5c0376a1267e31"
 dependencies = [
+ "histogram 1.5.0",
  "linkme",
  "parking_lot",
  "phf",
@@ -976,6 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1096,29 +1086,30 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.6",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1129,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -1239,7 +1230,7 @@ dependencies = [
  "ketama",
  "libc",
  "metrics",
- "metriken 0.8.0",
+ "metriken",
  "num_cpus",
  "resp-proto",
  "ringline",
@@ -1271,21 +1262,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1295,14 +1277,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1319,7 +1295,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1382,9 +1358,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "resp-proto"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1169c78518f0fc00e1b679cd2663cd50c6d05918362bf6a03edf5a15fbe3bac3"
+checksum = "d01e2c53b92515b23532298e01e98af3c6e1b22330411a4b661eab456d78aabc"
 dependencies = [
  "bytes",
  "itoa",
@@ -1409,15 +1385,17 @@ dependencies = [
 
 [[package]]
 name = "ringline"
-version = "0.0.3-alpha.0"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=6e373ef#6e373ef4da8db5f0d6027921e588455d005ccea0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceff25c27887a057239c350c4165fbcfdd8c37ba4ebb12439b0154ff2ad3bd05"
 dependencies = [
  "bytes",
  "crossbeam-channel",
  "futures-io",
  "io-uring",
  "libc",
- "metriken 0.7.0",
+ "metriken",
+ "mio",
  "pin-project-lite",
  "rustls",
  "thiserror 2.0.18",
@@ -1425,11 +1403,13 @@ dependencies = [
 
 [[package]]
 name = "ringline-redis"
-version = "0.1.1"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=6e373ef#6e373ef4da8db5f0d6027921e588455d005ccea0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c556a8440503cbf9c1c06c0395ab61980acde31805549caf8989983c4f1f18e5"
 dependencies = [
  "bytes",
  "histogram 0.11.4",
+ "itoa",
  "ketama",
  "resp-proto",
  "ringline",
@@ -1655,7 +1635,7 @@ dependencies = [
  "libc",
  "memcache-proto",
  "metrics",
- "metriken 0.8.0",
+ "metriken",
  "num_cpus",
  "parking_lot",
  "protocol-ping",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ itoa = "1.0"
 libc = "0.2"
 loom = "0.7"
 memmap2 = "0.9"
-metriken = "0.8"
+metriken = "0.9"
 num_cpus = "1.16"
 parking_lot = "0.12"
 rand = "0.9"
@@ -62,20 +62,20 @@ tracing = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crates
-ringline = { git = "https://github.com/ringline-rs/ringline.git", rev = "6e373ef", features = ["timestamps"] }
-ringline-redis = { git = "https://github.com/ringline-rs/ringline.git", rev = "6e373ef" }
-http2-proto = "0.0.1"
-grpc-proto = "0.0.1"
+ringline = { version = "0.6", features = ["timestamps"] }
+ringline-redis = "0.7"
+http2-proto = "0.0.2"
+grpc-proto = "0.0.2"
 protocol-momento = { path = "protocol/momento" }
 protocol-ping = { path = "protocol/ping" }
-resp-proto = "0.0.1"
-memcache-proto = "0.0.1"
+resp-proto = "0.0.2"
+memcache-proto = "0.0.5"
 cache-core = { path = "cache/core" }
 segcache = { path = "cache/segcache" }
 slab-cache = { path = "cache/slab" }
 heap-cache = { path = "cache/heap" }
 metrics = { path = "metrics" }
-ketama = "0.0.1"
+ketama = "0.0.2"
 
 
 # Jemalloc allocator

--- a/cache-bench/src/main.rs
+++ b/cache-bench/src/main.rs
@@ -501,8 +501,8 @@ fn percentile(hist: &AtomicHistogram, p: f64) -> f64 {
 }
 
 fn percentile_from_histogram(hist: &Histogram, p: f64) -> f64 {
-    if let Ok(Some(results)) = hist.percentiles(&[p])
-        && let Some((_pct, bucket)) = results.first()
+    if let Ok(Some(results)) = hist.quantile(p / 100.0)
+        && let Some(bucket) = results.entries().values().next()
     {
         return bucket.end() as f64;
     }
@@ -518,10 +518,8 @@ fn max_percentile(hist: &AtomicHistogram) -> f64 {
 }
 
 fn max_from_histogram(hist: &Histogram) -> f64 {
-    if let Ok(Some(results)) = hist.percentiles(&[100.0])
-        && let Some((_pct, bucket)) = results.first()
-    {
-        return bucket.end() as f64;
+    if let Ok(Some(results)) = hist.quantile(1.0) {
+        return results.max().end() as f64;
     }
     0.0
 }

--- a/proxy/src/async_worker.rs
+++ b/proxy/src/async_worker.rs
@@ -971,21 +971,17 @@ pub fn run_async(
     init_config_channel(config_rx);
 
     // Build ringline config.
-    let krio_config = ringline::Config {
-        recv_buffer: ringline::RecvBufferConfig {
-            ring_size: config.uring.buffer_count.next_power_of_two(),
-            buffer_size: config.uring.buffer_size as u32,
-            ..Default::default()
-        },
-        worker: ringline::WorkerConfig {
-            threads: num_workers,
-            pin_to_core: false, // We pin in create_for_worker.
-            core_offset: 0,
-        },
-        sq_entries: config.uring.sq_depth,
-        tcp_nodelay: true,
-        ..Default::default()
-    };
+    let krio_config = ringline::ConfigBuilder::new()
+        .recv_buffer(
+            config.uring.buffer_count.next_power_of_two(),
+            config.uring.buffer_size as u32,
+        )
+        .workers(num_workers)
+        .pin_to_core(false) // We pin in create_for_worker.
+        .core_offset(0)
+        .sq_entries(config.uring.sq_depth)
+        .tcp_nodelay(true)
+        .build()?;
 
     // Launch ringline with async event handler.
     let (shutdown_handle, handles) = RinglineBuilder::new(krio_config)

--- a/proxy/tests/async_proxy_test.rs
+++ b/proxy/tests/async_proxy_test.rs
@@ -55,15 +55,15 @@ impl AsyncEventHandler for RespEchoBackend {
 // ── Helpers ─────────────────────────────────────────────────────────
 
 fn test_krio_config() -> Config {
-    let mut config = Config::default();
-    config.worker.threads = 1;
-    config.worker.pin_to_core = false;
-    config.sq_entries = 64;
-    config.recv_buffer.ring_size = 64;
-    config.recv_buffer.buffer_size = 4096;
-    config.max_connections = 64;
-    config.send_copy_count = 64;
-    config
+    ringline::ConfigBuilder::new()
+        .workers(1)
+        .pin_to_core(false)
+        .sq_entries(64)
+        .recv_buffer(64, 4096)
+        .max_connections(64)
+        .send_pool(64, 16384)
+        .build()
+        .expect("valid test ringline config")
 }
 
 fn free_port() -> u16 {

--- a/server/src/admin/mod.rs
+++ b/server/src/admin/mod.rs
@@ -218,15 +218,14 @@ fn generate_prometheus_output(cache_stats_fn: &CacheStatsFn) -> String {
                 {
                     output.push_str(&format!("# TYPE {} histogram\n", prom_name));
 
-                    // Output percentiles as summary-style metrics
-                    let percentiles = [50.0, 90.0, 95.0, 99.0, 99.9, 99.99];
-                    if let Ok(Some(results)) = snapshot.percentiles(&percentiles) {
-                        for (pct, bucket) in results {
-                            let quantile = pct / 100.0;
+                    // Output quantiles as summary-style metrics
+                    let quantiles = [0.5, 0.9, 0.95, 0.99, 0.999, 0.9999];
+                    if let Ok(Some(results)) = snapshot.quantiles(&quantiles) {
+                        for (quantile, bucket) in results.entries() {
                             output.push_str(&format!(
                                 "{}{{quantile=\"{}\"}} {}\n",
                                 prom_name,
-                                quantile,
+                                quantile.as_f64(),
                                 bucket.end()
                             ));
                         }

--- a/server/src/async_native/handler.rs
+++ b/server/src/async_native/handler.rs
@@ -16,10 +16,7 @@ use bytes::Bytes;
 use cache_core::Cache;
 use cache_core::disk::AlignedBufferPool;
 use parking_lot::Mutex;
-use ringline::{
-    AsyncEventHandler, ConnCtx, DriverCtx, GuardBox, MAX_GUARDS, MAX_IOVECS, RegionId, SendGuard,
-    SendPart,
-};
+use ringline::{AsyncEventHandler, ConnCtx, DriverCtx, GuardBox, RegionId, SendGuard, SendPart};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -229,13 +226,19 @@ async fn flush_worker<C: Cache>(
                 DiskBackend::Nvme { device, block_size } => {
                     let lba = req.disk_offset / *block_size as u64;
                     let num_blocks = (req.buffer_len / *block_size) as u16;
-                    match ringline::nvme_write(
-                        *device,
-                        lba,
-                        num_blocks,
-                        req.buffer_ptr as u64,
-                        req.buffer_len,
-                    ) {
+                    // SAFETY: the flush buffer is owned by the cache's write
+                    // buffer for this segment and is only released by
+                    // `complete_flush` / the retry path below, both of which
+                    // run after the future resolves.
+                    match unsafe {
+                        ringline::nvme_write(
+                            *device,
+                            lba,
+                            num_blocks,
+                            req.buffer_ptr as u64,
+                            req.buffer_len,
+                        )
+                    } {
                         Ok(fut) => fut.await,
                         Err(e) => Err(e),
                     }
@@ -525,13 +528,18 @@ async fn submit_and_await_disk_read<C: Cache>(
             DiskBackend::Nvme { device, block_size } => {
                 let lba = pending_info.params.disk_offset / *block_size as u64;
                 let num_blocks = (pending_info.params.read_len / *block_size) as u16;
-                ringline::nvme_read(
-                    *device,
-                    lba,
-                    num_blocks,
-                    buffer.addr(),
-                    pending_info.params.read_len,
-                )
+                // SAFETY: `buffer` comes from the read buffer pool, is aligned
+                // for O_DIRECT/NVMe, and is only returned to the pool by
+                // `release_read!` after the future below resolves.
+                unsafe {
+                    ringline::nvme_read(
+                        *device,
+                        lba,
+                        num_blocks,
+                        buffer.addr(),
+                        pending_info.params.read_len,
+                    )
+                }
             }
         }
     };
@@ -627,6 +635,17 @@ async fn submit_and_await_disk_read<C: Cache>(
 /// Minimum part size to use zero-copy guard path instead of copy.
 const GUARD_MIN_SIZE: usize = 1024;
 
+/// Maximum iovecs in a single scatter-gather send SQE.
+///
+/// Mirrors ringline's internal `MAX_IOVECS` (unexported since 0.3.0). A batch
+/// larger than this is rejected whole by `submit_batch`, so we split here.
+const MAX_IOVECS: usize = 32;
+
+/// Maximum zero-copy guards in a single scatter-gather send SQE.
+///
+/// Mirrors ringline's internal `MAX_GUARDS` (unexported since 0.3.0).
+const MAX_GUARDS: usize = 8;
+
 /// Zero-copy send guard backed by a `Bytes` handle.
 struct BytesGuard(Bytes);
 
@@ -646,8 +665,8 @@ impl SendGuard for BytesGuard {
 /// parts (< 1KB) are copy iovecs; large parts (≥ 1KB) are zero-copy guards.
 /// Up to MAX_IOVECS parts and MAX_GUARDS guards per SQE.
 ///
-/// When `must_yield` is true (backpressure path), the first SQE uses
-/// `submit_batch_await` to guarantee at least one yield.
+/// When `must_yield` is true (backpressure path), the first SQE is awaited (or
+/// followed by an explicit yield) to guarantee at least one yield.
 async fn drain_pending(
     conn: &ConnCtx,
     connection: &mut Connection,
@@ -766,31 +785,22 @@ async fn drain_pending(
 
             let batch_count = batch.len();
 
-            let result = if need_yield {
-                match conn.send_parts().submit_batch_await(batch) {
-                    Ok((_, fut)) => {
+            let result = match conn.send_parts().submit_batch(batch) {
+                Ok(_) => {
+                    // ringline 0.3.0 removed `submit_batch_await`, so the batch
+                    // is fire-and-forget; yield explicitly to give the executor a
+                    // chance to reap completions before we queue more.
+                    if need_yield {
                         need_yield = false;
-                        if fut.await.is_err() {
-                            connection.advance_write(advanced);
-                            return Err(());
-                        }
-                        Ok(())
+                        yield_once().await;
                     }
-                    Err(e) if e.kind() == io::ErrorKind::Other => {
-                        connection.advance_write(advanced);
-                        return Ok(());
-                    }
-                    Err(_) => Err(()),
+                    Ok(())
                 }
-            } else {
-                match conn.send_parts().submit_batch(batch) {
-                    Ok(_) => Ok(()),
-                    Err(e) if e.kind() == io::ErrorKind::Other => {
-                        connection.advance_write(advanced);
-                        return Ok(());
-                    }
-                    Err(_) => Err(()),
+                Err(e) if e.kind() == io::ErrorKind::Other => {
+                    connection.advance_write(advanced);
+                    return Ok(());
                 }
+                Err(_) => Err(()),
             };
 
             if result.is_err() {

--- a/server/src/async_native/mod.rs
+++ b/server/src/async_native/mod.rs
@@ -94,35 +94,29 @@ mod server {
             );
         }
 
-        let krio_config = ringline::Config {
-            sq_entries: config.uring.sq_depth,
-            sqpoll: config.uring.sqpoll,
-            sqpoll_idle_ms: config.uring.sqpoll_idle_ms,
-            recv_buffer: ringline::RecvBufferConfig {
-                ring_size: config.uring.buffer_count.next_power_of_two(),
-                buffer_size: config.uring.buffer_size as u32,
-                ..Default::default()
-            },
-            worker: ringline::WorkerConfig {
-                threads: num_workers,
-                pin_to_core: cpu_affinity.is_some(),
-                core_offset: cpu_affinity.as_ref().map(|c| c[0]).unwrap_or(0),
-            },
-            tcp_nodelay: true,
-            send_copy_slot_size,
-            send_copy_count,
-            send_slab_slots: 4096,
-            ..Default::default()
-        };
+        let mut krio_builder = ringline::ConfigBuilder::new()
+            .sq_entries(config.uring.sq_depth)
+            .sqpoll(config.uring.sqpoll)
+            .sqpoll_idle_ms(config.uring.sqpoll_idle_ms)
+            .recv_buffer(
+                config.uring.buffer_count.next_power_of_two(),
+                config.uring.buffer_size as u32,
+            )
+            .workers(num_workers)
+            .pin_to_core(cpu_affinity.is_some())
+            .core_offset(cpu_affinity.as_ref().map(|c| c[0]).unwrap_or(0))
+            .tcp_nodelay(true)
+            .send_pool(send_copy_count, send_copy_slot_size)
+            .send_slab_slots(4096);
 
         // Enable ringline's disk I/O subsystem based on backend
-        let mut krio_config = krio_config;
         match disk_io_backend {
             Some(DiskIoBackendConfig::DirectIo) => {
-                krio_config.direct_io = Some(ringline::direct_io::DirectIoConfig::default());
+                krio_builder =
+                    krio_builder.direct_io(ringline::direct_io::DirectIoConfig::default());
             }
             Some(DiskIoBackendConfig::Nvme) => {
-                krio_config.nvme = Some(ringline::nvme::NvmeConfig::default());
+                krio_builder = krio_builder.nvme(ringline::nvme::NvmeConfig::default());
             }
             _ => {}
         }
@@ -168,14 +162,12 @@ mod server {
         };
 
         // Load TLS config if configured
-        let krio_config = if let Some(ref tls_cfg) = config.listener[0].tls {
-            let mut c = krio_config;
-            c.tls = Some(crate::tls::load_server_config(tls_cfg)?);
+        if let Some(ref tls_cfg) = config.listener[0].tls {
+            krio_builder = krio_builder.tls(crate::tls::load_server_config(tls_cfg)?);
             info!("TLS enabled");
-            c
-        } else {
-            krio_config
-        };
+        }
+
+        let krio_config = krio_builder.build()?;
 
         let bind_target = config.listener[0]
             .bind_target()

--- a/server/src/bin/ping.rs
+++ b/server/src/bin/ping.rs
@@ -184,22 +184,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("Starting ping server on {}", listen);
 
-    let krio_config = ringline::Config {
-        sq_entries: config.uring.sq_depth,
-        sqpoll: config.uring.sqpoll,
-        recv_buffer: ringline::RecvBufferConfig {
-            ring_size: config.uring.buffer_count.next_power_of_two(),
-            buffer_size: config.uring.buffer_size,
-            ..Default::default()
-        },
-        worker: ringline::WorkerConfig {
-            threads: if threads == 0 { 0 } else { threads },
-            pin_to_core: false,
-            core_offset: 0,
-        },
-        tcp_nodelay: true,
-        ..Default::default()
-    };
+    let krio_config = ringline::ConfigBuilder::new()
+        .sq_entries(config.uring.sq_depth)
+        .sqpoll(config.uring.sqpoll)
+        .recv_buffer(
+            config.uring.buffer_count.next_power_of_two(),
+            config.uring.buffer_size,
+        )
+        .workers(threads)
+        .pin_to_core(false)
+        .core_offset(0)
+        .tcp_nodelay(true)
+        .build()?;
 
     let workers = if threads == 0 {
         "auto"

--- a/server/src/tls.rs
+++ b/server/src/tls.rs
@@ -26,7 +26,5 @@ pub fn load_server_config(
         .with_single_cert(certs, key)
         .map_err(|e| format!("invalid TLS certificate/key: {e}"))?;
 
-    Ok(ringline::TlsConfig {
-        server_config: Arc::new(server_config),
-    })
+    Ok(ringline::TlsConfig::new(Arc::new(server_config)))
 }


### PR DESCRIPTION
Moves off the pinned git revision (`6e373ef`, 0.0.3-alpha) to the published crates.io releases, and brings the rest of the dependency set in line with what ringline 0.6 builds against.

## Dependencies

| Crate | Before | After |
|---|---|---|
| ringline | git rev `6e373ef` (0.0.3-alpha) | **0.6.0** |
| ringline-redis | git rev `6e373ef` (0.1.1) | **0.7.0** |
| resp-proto / memcache-proto | 0.0.1 / 0.0.1 | 0.0.2 / 0.0.5 |
| http2-proto / grpc-proto / ketama | 0.0.1 each | 0.0.2 each |
| metriken | 0.8 | 0.9 |

The proto and metriken bumps aren't optional extras. `0.0.x` releases are semver-incompatible with each other, so leaving the parsers at 0.0.1 would have compiled a second copy of each alongside ringline's. And `/metrics` iterates the global `metriken::metrics()` registry, which is per-crate-version — crucible on 0.8 with ringline on 0.7 meant two registries, and ringline's I/O metrics were silently absent from the Prometheus output with no error. `Cargo.lock` now has exactly one `metriken`.

## API migrations (all forced by upstream breaking changes)

- **`ringline::Config` literals → `ConfigBuilder`** (server, proxy, ping, proxy test). `WorkerConfig`/`RecvBufferConfig` are no longer exported, `send_copy_count`/`send_copy_slot_size` fold into `send_pool(count, slot_size)`, and `Config::validate()` now always runs at `build()` time.
- **`TlsConfig::new(Arc<ServerConfig>)`** instead of a struct literal.
- **`nvme_read`/`nvme_write` are `unsafe fn`** — both call sites wrapped with a SAFETY comment on buffer lifetime (the `direct_io_*` arms already were).
- **`AsyncSendBuilder::submit_batch_await` and exported `MAX_IOVECS`/`MAX_GUARDS` removed** (ringline #231). `drain_pending` now submits with `submit_batch` and yields explicitly on the backpressure path; the handler defines its own batch caps mirroring ringline's internal limits (32 iovecs / 8 guards — a batch over the cap is rejected whole).
- **`Histogram::percentiles()` deprecated in metriken 0.9** — admin and cache-bench move to `quantiles()`/`quantile()` (0–100 → 0.0–1.0 scale; the Prometheus `quantile=` labels come out unchanged).

## One semantic change

The `submit_batch_await` removal is the only change that isn't behavior-preserving. That backpressure batch is now fire-and-forget with an explicit yield rather than awaited to kernel send completion, so a send error on it surfaces via the read side instead of immediately. Upstream removed the method as dead code, but crucible was using it — worth considering restoring it in ringline if we want real completion-backpressure back on that path.

## Defaults that shifted underneath, needing no code change

- `recv_accumulator_max` now defaults to 1 GiB (was unbounded). `max_value_size` is validated below `segment_size`, far under the cap.
- Default worker count is physical rather than logical cores. The server always passes an explicit `num_cpus::get()`, so only `crucible-ping` with `threads = 0` is affected.

## Testing

Verified on macOS, which builds against ringline's **mio** backend: `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and `cargo fmt` all clean with zero warnings; full workspace test suite green, including `async_server_integration` (7), `async_proxy_test` (6), `e2e_resp` (5), `io_engine_integration` (22), `large_value_io_tests` (6), plus 413 cache-core and 269 momento unit tests.

The `has_io_uring` paths compile only on Linux 6.0+, so CI covers what this machine cannot. A `/smoketest` run on Linux would be the real end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu