### PR TITLE
deps: repoint ringline at crates.io 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   yields, which is exactly the shape that hung. Only a completion can free a
   pool slot, so that wait never ended
 
-### Note
-- `ringline` and `ringline-redis` are pinned to a git rev until a release
-  carries both of the above; the workspace switches back to the crates.io
-  versions once they are published
+- **Back on published crates**: `ringline` 0.6.1 and `ringline-redis` 0.7.0
+  from crates.io, replacing the temporary git pin taken while the two changes
+  above were unreleased. `ringline-redis` is unchanged at 0.7.0 and picks up
+  the new core through its own `ringline = "0.6"` requirement, so `--locked`
+  builds are reproducible from the registry again
 
 ## [0.4.1] - 2026-02-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -449,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -758,7 +758,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -988,7 +988,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1386,7 +1386,8 @@ dependencies = [
 [[package]]
 name = "ringline"
 version = "0.6.1"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=be00fde#be00fdee6ea2f5b7cc94ae05aa75d3ba714e40a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4463bc0612d0a978136a35eb437d598c680d54f8e7b198f74809b3903e20fffb"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -1403,7 +1404,8 @@ dependencies = [
 [[package]]
 name = "ringline-redis"
 version = "0.7.0"
-source = "git+https://github.com/ringline-rs/ringline.git?rev=be00fde#be00fdee6ea2f5b7cc94ae05aa75d3ba714e40a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c556a8440503cbf9c1c06c0395ab61980acde31805549caf8989983c4f1f18e5"
 dependencies = [
  "bytes",
  "histogram 0.11.4",
@@ -1424,7 +1426,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1745,7 +1747,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2206,7 +2208,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,12 +62,8 @@ tracing = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # Internal crates
-# Pinned to git until a release carries ringline-rs/ringline#337
-# (`submit_batch_await`, which the server's drain path needs) and #340 (the
-# io_uring completion-reaping fix). Switch back to the crates.io versions once
-# both are published.
-ringline = { git = "https://github.com/ringline-rs/ringline.git", rev = "be00fde", features = ["timestamps"] }
-ringline-redis = { git = "https://github.com/ringline-rs/ringline.git", rev = "be00fde" }
+ringline = { version = "0.6.1", features = ["timestamps"] }
+ringline-redis = "0.7"
 http2-proto = "0.0.2"
 grpc-proto = "0.0.2"
 protocol-momento = { path = "protocol/momento" }


### PR DESCRIPTION
Closes out the temporary git pin from #83. ringline 0.6.1 is published, so the workspace goes back to registry dependencies.

## What changed

```diff
-ringline = { git = "...", rev = "be00fde", features = ["timestamps"] }
-ringline-redis = { git = "...", rev = "be00fde" }
+ringline = { version = "0.6.1", features = ["timestamps"] }
+ringline-redis = "0.7"
```

Both now resolve from the registry with checksums, so `--locked` builds are reproducible without a git fetch. ringline 0.6.1 carries the two changes #83 needed: `submit_batch_await` (ringline-rs/ringline#337) and the io_uring completion-reaping liveness fix (#340).

## Why `ringline-redis` doesn't move

It stays at 0.7.0 and was not republished — nothing in it changed between ringline 0.6.0 and 0.6.1. It picks up the new core through its own `ringline = "0.6"` caret requirement, and the lockfile confirms it: `ringline-redis 0.7.0` now resolves against `ringline 0.6.1`, both from the registry.

## Testing

macOS/mio: `check --workspace --all-targets`, `clippy --all-targets`, `fmt` all clean. Full workspace suite green **except** `cache-core`'s `test_increment_concurrent_no_lost_updates`.

That failure is unrelated to this PR and pre-existing:

- `cache/` is byte-identical to `main` on this branch (`git diff main -- cache/` is empty)
- `cache-core` has no ringline dependency at all
- it reproduces on unmodified code at roughly **1 run in 12** under full-suite parallel load, and 0/25 when run in isolation

Worth its own investigation — the test sets `counter` before spawning any thread and nothing deletes it, so a worker seeing `KeyNotFound` means the key went briefly invisible while four threads incremented it. That looks like a real visibility gap in the concurrent increment/CAS path rather than a flaky test. Filed here only as an observation; not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu