### PR TITLE
fix(cache-core): stop false-absent lookups; add TSan job and fix the race it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,44 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p cache-core --features loom
 
+  tsan:
+    name: Test (tsan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # ThreadSanitizer over the lock-free cache crates. TSan models atomics
+    # correctly, so the hashtable slot protocol, segment state machine and
+    # refcounts produce no reports of their own -- it flags exactly the
+    # non-atomic accesses that race, which stress tests only hit by luck.
+    # It earned its place immediately: the item flags byte was written by
+    # mark_deleted's atomic fetch_or and read by every lookup's header
+    # decode as a plain byte, and TSan reported it on the first run.
+    #
+    # No suppressions: the tree is clean, and a report should fail the job
+    # rather than accumulate exceptions. halt_on_error stops at the first.
+    #
+    # Scope is `--lib` on the four cache crates: that is where the shared
+    # mutable state lives, it runs in seconds under the sanitizer, and it
+    # skips both the integration soaks (large_value_tests, tens of seconds
+    # each before TSan's slowdown) and doctests, whose rustdoc invocations
+    # do not get the sanitizer ABI flags under -Zbuild-std.
+    env:
+      RUSTFLAGS: "-Zsanitizer=thread"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: tsan
+      - name: Test under ThreadSanitizer
+        env:
+          TSAN_OPTIONS: "halt_on_error=1"
+        run: >
+          cargo +nightly test
+          -p cache-core -p segcache -p slab-cache -p heap-cache
+          -Zbuild-std --target x86_64-unknown-linux-gnu --lib
+
   smoketest:
     name: Smoketest (${{ matrix.config }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,18 @@ jobs:
     # No suppressions: the tree is clean, and a report should fail the job
     # rather than accumulate exceptions. halt_on_error stops at the first.
     #
-    # Scope is `--lib` on the four cache crates: that is where the shared
-    # mutable state lives, it runs in seconds under the sanitizer, and it
-    # skips both the integration soaks (large_value_tests, tens of seconds
-    # each before TSan's slowdown) and doctests, whose rustdoc invocations
-    # do not get the sanitizer ABI flags under -Zbuild-std.
+    # Scope is `--lib` on the four cache crates plus the disk-tier
+    # integration test: that is where the shared mutable state lives, it runs
+    # in seconds under the sanitizer, and it skips both the integration soaks
+    # (large_value_tests, tens of seconds each before TSan's slowdown) and
+    # doctests, whose rustdoc invocations do not get the sanitizer ABI flags
+    # under -Zbuild-std.
+    #
+    # The disk-tier test is included deliberately. `DiskSegmentMeta` carries
+    # its own `mark_deleted`, and a `--lib`-only scope does not execute it --
+    # which is exactly how its non-atomic tombstone write survived the first
+    # pass of this job. Concurrency coverage is what this job can see, so a
+    # path with no concurrent test is a path TSan is not checking.
     env:
       RUSTFLAGS: "-Zsanitizer=thread"
     steps:
@@ -109,10 +116,13 @@ jobs:
       - name: Test under ThreadSanitizer
         env:
           TSAN_OPTIONS: "halt_on_error=1"
-        run: >
-          cargo +nightly test
-          -p cache-core -p segcache -p slab-cache -p heap-cache
-          -Zbuild-std --target x86_64-unknown-linux-gnu --lib
+        run: |
+          cargo +nightly test \
+            -p cache-core -p segcache -p slab-cache -p heap-cache \
+            -Zbuild-std --target x86_64-unknown-linux-gnu --lib
+          cargo +nightly test \
+            -p segcache -Zbuild-std --target x86_64-unknown-linux-gnu \
+            --test io_uring_disk_tier_tests
 
   smoketest:
     name: Smoketest (${{ matrix.config }})

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -619,11 +619,31 @@ impl Segment for DiskSegmentMeta {
             return;
         }
 
-        // Set deleted flag in the header
-        unsafe {
-            let flags_ptr = data_ptr.add(offset as usize + 1);
-            let flags = *flags_ptr;
-            *flags_ptr = flags | 0x40; // Set is_deleted bit
+        // Set the deleted flag atomically. This byte is read concurrently by
+        // every header decode (`item::read_flags`), so a plain
+        // read-modify-write here is a data race with live readers.
+        let flags_ptr = unsafe { data_ptr.add(offset as usize + 1) };
+
+        #[cfg(not(feature = "loom"))]
+        {
+            // SAFETY: `flags_ptr` addresses the header's flags byte, which is
+            // in bounds (checked above). `AtomicU8` matches `u8` in layout and
+            // alignment, and every other writer of this byte uses the same
+            // atomic view.
+            let flags_atomic = unsafe { &*(flags_ptr as *const AtomicU8) };
+            flags_atomic.fetch_or(0x40, Ordering::Release);
+        }
+
+        #[cfg(feature = "loom")]
+        {
+            // loom does not re-export `AtomicU8` and its atomics cannot be
+            // built from a raw pointer, so the loom build pairs volatile
+            // access with the volatile readers, as `SliceSegment` does.
+            fence(Ordering::Release);
+            unsafe {
+                let old = std::ptr::read_volatile(flags_ptr);
+                std::ptr::write_volatile(flags_ptr, old | 0x40);
+            }
         }
     }
 
@@ -640,9 +660,10 @@ impl Segment for DiskSegmentMeta {
             unsafe { std::slice::from_raw_parts(data_ptr.add(offset as usize), BasicHeader::SIZE) };
         let header = BasicHeader::from_bytes(header_bytes);
 
-        if header.is_deleted() {
-            return Ok(false); // Already deleted
-        }
+        // NOTE: the is_deleted check that used to live here has moved below
+        // the flag write. Checking first and acting later let two concurrent
+        // deletes of the same item both observe "live" and both decrement the
+        // live counters, wrapping `live_items` past zero.
 
         // Verify key
         let key_start = offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -656,11 +677,33 @@ impl Segment for DiskSegmentMeta {
             return Err(CacheError::KeyMismatch);
         }
 
-        // Set deleted flag
-        unsafe {
-            let flags_ptr = data_ptr.add(offset as usize + 1);
-            let flags = *flags_ptr;
-            *flags_ptr = flags | 0x40;
+        // Set the deleted flag atomically and let the returned value decide
+        // who owns the delete. The flag byte is read concurrently by every
+        // header decode, so a plain read-modify-write here both races those
+        // readers and loses the race between two deleters: the winner is
+        // whoever observes the bit still clear, and only that caller may
+        // adjust the live counters.
+        let flags_ptr = unsafe { data_ptr.add(offset as usize + 1) };
+
+        #[cfg(not(feature = "loom"))]
+        let old_flags = {
+            // SAFETY: as in `mark_deleted_at_offset` above.
+            let flags_atomic = unsafe { &*(flags_ptr as *const AtomicU8) };
+            flags_atomic.fetch_or(0x40, Ordering::Release)
+        };
+
+        #[cfg(feature = "loom")]
+        let old_flags = {
+            fence(Ordering::Release);
+            unsafe {
+                let old = std::ptr::read_volatile(flags_ptr);
+                std::ptr::write_volatile(flags_ptr, old | 0x40);
+                old
+            }
+        };
+
+        if (old_flags & 0x40) != 0 {
+            return Ok(false); // Someone else marked it deleted first.
         }
 
         let padded_size = header.padded_size() as u32;

--- a/cache/core/src/hashtable.rs
+++ b/cache/core/src/hashtable.rs
@@ -35,6 +35,21 @@ pub trait KeyVerifier: Send + Sync {
     ///
     /// # Returns
     /// `true` if the key matches at this location.
+    ///
+    /// # What `false` does *not* mean
+    ///
+    /// `false` is not "this entry is some other key". An implementation
+    /// reads item bytes at whatever location it is handed, and that location
+    /// can stop being the entry's while the comparison is in flight — a
+    /// concurrent publish moves the entry and delete-marks what it left
+    /// behind. Such a comparison also answers `false`, about memory that is
+    /// no longer the caller's business.
+    ///
+    /// Callers must therefore not read a single `false` as "this slot does
+    /// not hold the key": doing so reports live keys absent. Bucket scans go
+    /// through `MultiChoiceHashtable::verify_slot`, which re-reads the slot
+    /// word to separate the two cases. Implementations only owe an honest
+    /// answer about the location they were given.
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool;
 
     /// Prefetch memory at the given location.

--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -517,6 +517,12 @@ impl MultiChoiceHashtable {
                 return None;
             }
 
+            // The slot moved, so the budget above was not spent on a stable
+            // slot after all. Reset it: it bounds one publish landing, not a
+            // key's whole relocation history, and letting it accumulate
+            // across generations answers `None` for a live, visibly-moving
+            // key -- the false absent this function exists to prevent.
+            tombstone_polls = 0;
             packed = current;
         }
     }
@@ -2005,6 +2011,104 @@ mod tests {
         assert!(
             verifier.probes.load(std::sync::atomic::Ordering::SeqCst) >= 3,
             "the delayed-publish window was never exercised"
+        );
+    }
+
+    /// Verifier that walks a key through many successive locations, each
+    /// one costing a tombstone poll before its publish is observed.
+    ///
+    /// This is the shape that catches a tombstone budget scoped to the whole
+    /// lookup rather than to one publish: every generation spends a poll, so
+    /// a cumulative counter runs out and answers absent for a key that is
+    /// live and visibly moving.
+    struct WalkingPublishVerifier {
+        key: Vec<u8>,
+        table: std::sync::Mutex<Option<std::sync::Arc<MultiChoiceHashtable>>>,
+        /// Locations the key occupies, in order.
+        stops: Vec<Location>,
+        /// How far along `stops` the published entry currently is.
+        published: std::sync::atomic::AtomicUsize,
+        /// Probes seen against the current stop.
+        probes_here: std::sync::atomic::AtomicU32,
+    }
+
+    impl KeyVerifier for WalkingPublishVerifier {
+        fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
+            use std::sync::atomic::Ordering as O;
+            if key != self.key.as_slice() {
+                return false;
+            }
+            let idx = self.published.load(O::SeqCst);
+            let current = self.stops[idx];
+
+            if location == current {
+                // The live entry, once it has stopped moving.
+                if idx == self.stops.len() - 1 {
+                    return true;
+                }
+                // Still walking: this stop reads as our key, tombstoned.
+                //
+                // Advance on the *fourth* probe, not the second. A scan
+                // iteration spends two probes (the live check, then the
+                // tombstone re-probe) before it re-reads the slot, so
+                // publishing on probe 2 would move the slot before that
+                // re-read and the poll branch would never run. Letting one
+                // whole iteration find the slot unchanged is what spends a
+                // tombstone poll per hop -- which is the accounting this
+                // test exists to pin.
+                if self.probes_here.fetch_add(1, O::SeqCst) + 1 >= 4 {
+                    self.probes_here.store(0, O::SeqCst);
+                    let table = self.table.lock().unwrap().clone().unwrap();
+                    assert!(
+                        table.cas_location(&self.key, current, self.stops[idx + 1], true),
+                        "each hop of the walk must land"
+                    );
+                    self.published.store(idx + 1, O::SeqCst);
+                }
+                return allow_deleted;
+            }
+            false
+        }
+    }
+
+    /// A key relocating through more generations than the tombstone budget
+    /// must still be found. The budget bounds one publish landing, not the
+    /// key's whole relocation history.
+    #[test]
+    fn relocation_walk_longer_than_the_tombstone_budget_is_still_found() {
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicU32, AtomicUsize};
+
+        let table = StdArc::new(MultiChoiceHashtable::new(8));
+        let key = b"walker".to_vec();
+
+        // Comfortably more hops than MAX_TOMBSTONE_POLLS.
+        let stops: Vec<Location> = (1..=20).map(|i| Location::new(0x1000 * i)).collect();
+
+        let seed = StaticVerifier {
+            key: key.clone(),
+            location: stops[0],
+        };
+        table.insert(&key, stops[0], &seed).unwrap();
+
+        let verifier = WalkingPublishVerifier {
+            key: key.clone(),
+            table: std::sync::Mutex::new(Some(StdArc::clone(&table))),
+            stops: stops.clone(),
+            published: AtomicUsize::new(0),
+            probes_here: AtomicU32::new(0),
+        };
+
+        assert!(
+            table.contains(&key, &verifier),
+            "a key that relocated through more hops than the tombstone budget \
+             was reported absent -- the budget is accumulating across \
+             relocations instead of bounding one publish"
+        );
+        assert!(
+            verifier.published.load(std::sync::atomic::Ordering::SeqCst) > 8,
+            "the walk did not exceed the tombstone budget, so this test would \
+             not have caught a cumulative counter"
         );
     }
 

--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -10,7 +10,7 @@
 use crate::error::{CacheError, CacheResult};
 use crate::hashtable::{Hashtable, KeyVerifier};
 use crate::location::Location;
-use crate::sync::{AtomicU64, Ordering};
+use crate::sync::{AtomicU64, Ordering, fence, spin_loop};
 use ahash::RandomState;
 
 /// Maximum number of bucket choices supported.
@@ -393,8 +393,6 @@ impl MultiChoiceHashtable {
         result
     }
 
-    /// Search a bucket for an item, updating frequency on hit.
-    #[inline]
     /// Verify the entry a slot currently publishes, distinguishing a real
     /// key mismatch from a comparison that raced a publish.
     ///
@@ -423,11 +421,35 @@ impl MultiChoiceHashtable {
     /// against what the slot publishes now, converging on the entry's current
     /// location.
     ///
-    /// Frequency lives in the same word, so the comparison is on the location
-    /// and tag bits only — a concurrent reader bumping frequency must not look
-    /// like a relocation.
+    /// Comparing only location and tag bits leaves an A→B→A hole: a slot can
+    /// move away and come back to the same location when a segment is
+    /// recycled and the same key lands at the same offset. So an unchanged
+    /// slot is not trusted on its own. Every writer moves or clears the slot
+    /// *before* it delete-marks what it superseded, so "the slot still
+    /// publishes this location, and the item there is our key with a
+    /// tombstone" is never a settled state — it means a publish is in
+    /// flight. That is the one case an unchanged slot is not authoritative,
+    /// and re-probing with `allow_deleted` is what distinguishes it from the
+    /// genuine "some other key lives here".
+    ///
+    /// # Progress
+    ///
+    /// The retry is unbounded on purpose. It only advances when another
+    /// thread has *completed* a publish to this slot, so the loop is
+    /// lock-free by the usual argument rather than a spin: bounding it and
+    /// answering `None` on exhaustion would reintroduce exactly the false
+    /// absent this exists to prevent, and would be indistinguishable from
+    /// the authoritative answer at every call site. The tombstone case is
+    /// bounded instead, because there a stable slot means the key really is
+    /// deleted and `None` is the right answer.
+    ///
+    /// Convergence is within one slot. An entry that relocates into a
+    /// different slot, or into a bucket this scan already passed, is still
+    /// missed; publishes are in-place slot compare_exchanges, so that does
+    /// not arise from the publish path this guards.
     ///
     /// Returns the (possibly refreshed) slot word and location on a match.
+    #[inline]
     fn verify_slot(
         &self,
         bucket: &Hashbucket,
@@ -439,16 +461,18 @@ impl MultiChoiceHashtable {
     ) -> Option<(u64, Location)> {
         const TAG_MASK: u64 = 0xFFF0_0000_0000_0000;
         const GHOST_LOCATION: u64 = 0x0000_0FFF_FFFF_FFFF;
+        // Bound only the in-flight-publish case: a slot that keeps publishing
+        // a tombstone of our key resolves within a publish, and if it never
+        // moves the key is genuinely deleted.
+        const MAX_TOMBSTONE_POLLS: u32 = 8;
+
         // Every caller has already matched the slot's tag against the key's
         // before calling, so the tag we must stay within is the one the
         // starting word carries.
         let tag_shifted = packed & TAG_MASK;
-        // A publish can land between the load and the compare. Bounding the
-        // retries keeps a pathological writer from pinning a reader here; the
-        // bound is far above any real relocation rate for one slot.
-        const MAX_ATTEMPTS: usize = 8;
+        let mut tombstone_polls = 0u32;
 
-        for _ in 0..MAX_ATTEMPTS {
+        loop {
             let location = Hashbucket::location(packed);
             verifier.prefetch(location);
 
@@ -456,13 +480,32 @@ impl MultiChoiceHashtable {
                 return Some((packed, location));
             }
 
+            // Is this our key wearing a tombstone, rather than a different
+            // key? Only asked on the mismatch path, which is rare.
+            let tombstoned_self = !allow_deleted && verifier.verify(key, location, true);
+
+            // Order the item reads above *before* the slot re-read below. A
+            // load-acquire orders what follows it, not what precedes it, so
+            // on a weakly-ordered target (aarch64 is supported) the header
+            // and key loads could otherwise be satisfied after this load and
+            // observe a delete-mark the re-read did not account for.
+            fence(Ordering::Acquire);
             let current = bucket.items[slot_index].load(Ordering::Acquire);
-            if Hashbucket::location(current) == location
-                && (current & TAG_MASK) == (packed & TAG_MASK)
-            {
-                // The slot still publishes what we compared against, so the
-                // mismatch is this slot's real answer.
-                return None;
+
+            if Hashbucket::location(current) == location && (current & TAG_MASK) == tag_shifted {
+                if !tombstoned_self {
+                    // The slot still publishes what we compared against, so
+                    // the mismatch is this slot's real answer.
+                    return None;
+                }
+                // A publish is in flight, or the key is deleted. Give the
+                // publisher a bounded window to land its slot swap.
+                tombstone_polls += 1;
+                if tombstone_polls >= MAX_TOMBSTONE_POLLS {
+                    return None;
+                }
+                spin_loop();
+                continue;
             }
 
             // The slot moved under us. Anything that is no longer a live
@@ -476,10 +519,10 @@ impl MultiChoiceHashtable {
 
             packed = current;
         }
-
-        None
     }
 
+    /// Search a bucket for an item, updating frequency on hit.
+    #[inline]
     fn search_bucket_for_get(
         &self,
         bucket_index: usize,
@@ -709,9 +752,13 @@ impl MultiChoiceHashtable {
                     continue;
                 }
 
-                // A false absent here makes `cas` read the entry as changed
-                // and fail spuriously, so it takes the same stale-location
-                // guard as the other read paths (see `verify_slot`).
+                // Same stale-location guard as the other read paths (see
+                // `verify_slot`). This backs `get_frequency`, whose callers
+                // are the eviction and demotion fate decisions in the TTL and
+                // FIFO layers; a false absent there scores a hot item as
+                // freq 0 and discards it. (`cas` asks a different function,
+                // `get_item_frequency`, which is location-scoped and does not
+                // come through here.)
                 if let Some((packed, _location)) =
                     self.verify_slot(bucket, slot_index, key, verifier, false, packed)
                 {
@@ -1880,6 +1927,123 @@ mod tests {
         fn verify(&self, key: &[u8], location: Location, _allow_deleted: bool) -> bool {
             key == self.key.as_slice() && location == self.location
         }
+    }
+
+    /// Verifier whose location is our key wearing a tombstone, with the
+    /// publish that supersedes it landing only after a few probes.
+    ///
+    /// This is the A→B→A shape: the slot word still reads the old location,
+    /// so a location+tag comparison alone would call the mismatch
+    /// authoritative. Only the `allow_deleted` re-probe distinguishes "our
+    /// key, tombstoned, publish in flight" from "some other key lives here".
+    struct DelayedPublishVerifier {
+        key: Vec<u8>,
+        old_location: Location,
+        new_location: Location,
+        table: std::sync::Mutex<Option<std::sync::Arc<MultiChoiceHashtable>>>,
+        probes: std::sync::atomic::AtomicU32,
+        publish_after: u32,
+    }
+
+    impl KeyVerifier for DelayedPublishVerifier {
+        fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
+            if key == self.key.as_slice() && location == self.old_location {
+                let n = self
+                    .probes
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                    + 1;
+                if n == self.publish_after {
+                    let table = self.table.lock().unwrap().clone().unwrap();
+                    assert!(
+                        table.cas_location(&self.key, self.old_location, self.new_location, true),
+                        "the delayed publish must land"
+                    );
+                }
+                // Our key, tombstoned: absent to a live-only lookup, present
+                // to one that accepts tombstones.
+                return allow_deleted;
+            }
+            key == self.key.as_slice() && location == self.new_location
+        }
+    }
+
+    /// An unchanged slot is not on its own proof of a real key mismatch. If
+    /// the item it points at is our key with a tombstone, a publish is in
+    /// flight -- writers move the slot before delete-marking -- so the scan
+    /// must wait for it rather than answer absent.
+    #[test]
+    fn tombstoned_self_is_not_an_authoritative_mismatch() {
+        use std::sync::Arc as StdArc;
+
+        let table = StdArc::new(MultiChoiceHashtable::new(8));
+        let key = b"counter".to_vec();
+        let old_location = Location::new(0x1000);
+        let new_location = Location::new(0x2000);
+
+        let seed = StaticVerifier {
+            key: key.clone(),
+            location: old_location,
+        };
+        table.insert(&key, old_location, &seed).unwrap();
+
+        let verifier = DelayedPublishVerifier {
+            key: key.clone(),
+            old_location,
+            new_location,
+            table: std::sync::Mutex::new(Some(StdArc::clone(&table))),
+            probes: std::sync::atomic::AtomicU32::new(0),
+            // Land the publish after the first poll's pair of probes, so the
+            // scan must actually poll rather than see it immediately.
+            publish_after: 3,
+        };
+
+        assert!(
+            table.contains(&key, &verifier),
+            "a tombstone at a not-yet-moved slot was treated as a different \
+             key, reporting a live key absent"
+        );
+        assert!(
+            verifier.probes.load(std::sync::atomic::Ordering::SeqCst) >= 3,
+            "the delayed-publish window was never exercised"
+        );
+    }
+
+    /// The bounded side of the same rule: a slot that keeps publishing a
+    /// tombstone of our key really is a deleted key, and must be reported
+    /// absent rather than polled forever.
+    #[test]
+    fn stable_tombstone_reports_absent() {
+        use std::sync::Arc as StdArc;
+
+        let table = StdArc::new(MultiChoiceHashtable::new(8));
+        let key = b"gone".to_vec();
+        let location = Location::new(0x3000);
+
+        let seed = StaticVerifier {
+            key: key.clone(),
+            location,
+        };
+        table.insert(&key, location, &seed).unwrap();
+
+        // Never publishes: `allow_deleted` matches, live lookups do not.
+        struct TombstoneVerifier {
+            key: Vec<u8>,
+            location: Location,
+        }
+        impl KeyVerifier for TombstoneVerifier {
+            fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
+                key == self.key.as_slice() && location == self.location && allow_deleted
+            }
+        }
+
+        let verifier = TombstoneVerifier {
+            key: key.clone(),
+            location,
+        };
+        assert!(
+            !table.contains(&key, &verifier),
+            "a settled tombstone must read as absent"
+        );
     }
 
     /// A lookup that races a publish must not report the key absent: the

--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -395,6 +395,91 @@ impl MultiChoiceHashtable {
 
     /// Search a bucket for an item, updating frequency on hit.
     #[inline]
+    /// Verify the entry a slot currently publishes, distinguishing a real
+    /// key mismatch from a comparison that raced a publish.
+    ///
+    /// # Why a bare `verify` is not enough
+    ///
+    /// [`KeyVerifier::verify`] answers a `bool` by reading item bytes at the
+    /// location it is handed. That answer conflates two very different
+    /// outcomes: "this slot holds some other key", which is authoritative,
+    /// and "the location I was handed stopped being this entry's while I was
+    /// looking", which says nothing about the key.
+    ///
+    /// The second outcome is reachable on every publish.
+    /// `TieredCache::cas` swaps the slot to the new location *first* and
+    /// delete-marks the superseded item *second*, so a reader that loaded the
+    /// slot word before the swap and verifies after the delete-mark compares
+    /// against a delete-marked item and gets `false` — for a key that is live
+    /// in that very slot the whole time. Treating that as a mismatch ends the
+    /// scan in a false absent: `contains` reports a live key missing, and
+    /// `increment` turns that into `KeyNotFound`.
+    ///
+    /// # The invariant this rests on
+    ///
+    /// Re-read the slot word after a `false`. If the published location is
+    /// unchanged, nothing moved under us and the mismatch is authoritative.
+    /// If it moved, the comparison was against a stale location: retry
+    /// against what the slot publishes now, converging on the entry's current
+    /// location.
+    ///
+    /// Frequency lives in the same word, so the comparison is on the location
+    /// and tag bits only — a concurrent reader bumping frequency must not look
+    /// like a relocation.
+    ///
+    /// Returns the (possibly refreshed) slot word and location on a match.
+    fn verify_slot(
+        &self,
+        bucket: &Hashbucket,
+        slot_index: usize,
+        key: &[u8],
+        verifier: &impl KeyVerifier,
+        allow_deleted: bool,
+        mut packed: u64,
+    ) -> Option<(u64, Location)> {
+        const TAG_MASK: u64 = 0xFFF0_0000_0000_0000;
+        const GHOST_LOCATION: u64 = 0x0000_0FFF_FFFF_FFFF;
+        // Every caller has already matched the slot's tag against the key's
+        // before calling, so the tag we must stay within is the one the
+        // starting word carries.
+        let tag_shifted = packed & TAG_MASK;
+        // A publish can land between the load and the compare. Bounding the
+        // retries keeps a pathological writer from pinning a reader here; the
+        // bound is far above any real relocation rate for one slot.
+        const MAX_ATTEMPTS: usize = 8;
+
+        for _ in 0..MAX_ATTEMPTS {
+            let location = Hashbucket::location(packed);
+            verifier.prefetch(location);
+
+            if verifier.verify(key, location, allow_deleted) {
+                return Some((packed, location));
+            }
+
+            let current = bucket.items[slot_index].load(Ordering::Acquire);
+            if Hashbucket::location(current) == location
+                && (current & TAG_MASK) == (packed & TAG_MASK)
+            {
+                // The slot still publishes what we compared against, so the
+                // mismatch is this slot's real answer.
+                return None;
+            }
+
+            // The slot moved under us. Anything that is no longer a live
+            // entry for our tag cannot be our key.
+            if current == 0
+                || (current & GHOST_LOCATION) == GHOST_LOCATION
+                || (current & TAG_MASK) != tag_shifted
+            {
+                return None;
+            }
+
+            packed = current;
+        }
+
+        None
+    }
+
     fn search_bucket_for_get(
         &self,
         bucket_index: usize,
@@ -428,13 +513,11 @@ impl MultiChoiceHashtable {
                 continue;
             }
 
-            let location = Hashbucket::location(packed);
-
-            // Prefetch segment data while we verify - pipeline the memory access
-            verifier.prefetch(location);
-
-            // Verify key matches using the verifier
-            if verifier.verify(key, location, false) {
+            // Verify against what the slot publishes, retrying if a publish
+            // moves it under us (see `verify_slot`).
+            if let Some((packed, location)) =
+                self.verify_slot(bucket, slot_index, key, verifier, false, packed)
+            {
                 // Update frequency (best effort)
                 let freq = Hashbucket::freq(packed);
                 if freq < 127
@@ -488,12 +571,10 @@ impl MultiChoiceHashtable {
                 continue;
             }
 
-            let location = Hashbucket::location(packed);
-
-            // Prefetch segment data while we verify
-            verifier.prefetch(location);
-
-            if verifier.verify(key, location, false) {
+            if self
+                .verify_slot(bucket, slot_index, key, verifier, false, packed)
+                .is_some()
+            {
                 return true;
             }
         }
@@ -534,12 +615,9 @@ impl MultiChoiceHashtable {
                 continue;
             }
 
-            let location = Hashbucket::location(packed);
-
-            // Prefetch segment data while we verify
-            verifier.prefetch(location);
-
-            if verifier.verify(key, location, false) {
+            if let Some((packed, _location)) =
+                self.verify_slot(bucket, slot_index, key, verifier, false, packed)
+            {
                 return Some(packed);
             }
         }
@@ -631,9 +709,12 @@ impl MultiChoiceHashtable {
                     continue;
                 }
 
-                let location = Hashbucket::location(packed);
-
-                if verifier.verify(key, location, false) {
+                // A false absent here makes `cas` read the entry as changed
+                // and fail spuriously, so it takes the same stale-location
+                // guard as the other read paths (see `verify_slot`).
+                if let Some((packed, _location)) =
+                    self.verify_slot(bucket, slot_index, key, verifier, false, packed)
+                {
                     return Some(Hashbucket::freq(packed));
                 }
             }
@@ -1743,6 +1824,101 @@ mod tests {
         fn add(&mut self, key: &[u8], location: Location, deleted: bool) {
             self.entries.push((key.to_vec(), location, deleted));
         }
+    }
+
+    /// Verifier that reproduces the stale-location false-absent race
+    /// deterministically, with no scheduler involvement.
+    ///
+    /// `TieredCache::cas` publishes a new value by swapping the slot to the
+    /// new location *first* and marking the superseded item deleted
+    /// *second*. A reader that loaded the slot word before the swap and
+    /// verifies after the delete-mark compares against a location that is
+    /// no longer published, sees a deleted item, and — because `verify`
+    /// answers a bare `bool` — cannot distinguish "this slot holds a
+    /// different key" from "I looked at the wrong place". It concludes the
+    /// key is absent while the key is live in that very slot.
+    ///
+    /// This verifier performs that publish from inside its own `verify`
+    /// call, which is exactly where the racing writer would land.
+    struct RacingPublishVerifier {
+        key: Vec<u8>,
+        old_location: Location,
+        new_location: Location,
+        table: std::sync::Mutex<Option<std::sync::Arc<MultiChoiceHashtable>>>,
+        raced: std::sync::atomic::AtomicBool,
+    }
+
+    impl KeyVerifier for RacingPublishVerifier {
+        fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
+            if key == self.key.as_slice() && location == self.old_location {
+                // First look at the stale location: run the concurrent
+                // publish now, then answer as the segment would once the
+                // superseded item is delete-marked.
+                if !self.raced.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    let table = self.table.lock().unwrap().clone().unwrap();
+                    assert!(
+                        table.cas_location(&self.key, self.old_location, self.new_location, true,),
+                        "precondition: the racing publish must land, or the \
+                         test is not exercising the stale-location window"
+                    );
+                }
+                // The superseded item is now delete-marked.
+                return allow_deleted;
+            }
+            // The live item at the new location.
+            key == self.key.as_slice() && location == self.new_location
+        }
+    }
+
+    /// Verifier that recognizes exactly one (key, location) pair as live.
+    struct StaticVerifier {
+        key: Vec<u8>,
+        location: Location,
+    }
+
+    impl KeyVerifier for StaticVerifier {
+        fn verify(&self, key: &[u8], location: Location, _allow_deleted: bool) -> bool {
+            key == self.key.as_slice() && location == self.location
+        }
+    }
+
+    /// A lookup that races a publish must not report the key absent: the
+    /// key is live in the slot the whole time, only its location moves.
+    #[test]
+    fn stale_location_verify_does_not_report_false_absent() {
+        use std::sync::Arc as StdArc;
+
+        let table = StdArc::new(MultiChoiceHashtable::new(8));
+        let key = b"counter".to_vec();
+        let old_location = Location::new(0x1000);
+        let new_location = Location::new(0x2000);
+
+        let seed = StaticVerifier {
+            key: key.clone(),
+            location: old_location,
+        };
+        table.insert(&key, old_location, &seed).unwrap();
+
+        let racer = RacingPublishVerifier {
+            key: key.clone(),
+            old_location,
+            new_location,
+            table: std::sync::Mutex::new(Some(StdArc::clone(&table))),
+            raced: std::sync::atomic::AtomicBool::new(false),
+        };
+
+        assert!(
+            table.contains(&key, &racer),
+            "contains() reported a live key absent after a publish moved its \
+             location mid-verify"
+        );
+
+        // Precondition: the race actually happened. Without this the test
+        // could pass vacuously if the scan never visited the stale location.
+        assert!(
+            racer.raced.load(std::sync::atomic::Ordering::SeqCst),
+            "the stale-location window was never exercised"
+        );
     }
 
     impl KeyVerifier for MockVerifier {

--- a/cache/core/src/item.rs
+++ b/cache/core/src/item.rs
@@ -8,6 +8,43 @@
 use crate::sync::{AtomicU32, Ordering};
 use std::time::Duration;
 
+/// Read an item's flags byte.
+///
+/// The flags byte is the one header byte written after an item is published:
+/// `Segment::mark_deleted` sets the tombstone bit on a live, reader-visible
+/// item with an atomic `fetch_or`. Readers decode `optional_len`,
+/// `is_deleted` and `is_numeric` out of that same byte on every lookup, so a
+/// plain load here races that store -- a data race in the memory model
+/// whatever the hardware happens to do, and one ThreadSanitizer reports on
+/// the first concurrent delete.
+///
+/// `Relaxed` is sufficient. The byte carries no ordering dependency of its
+/// own: an item's contents are published before it becomes reachable, and
+/// this read establishes nothing beyond the flag bits themselves.
+///
+/// # Safety
+///
+/// `ptr` must point at the flags byte of a live item header.
+#[inline(always)]
+unsafe fn read_flags(ptr: *const u8) -> u8 {
+    #[cfg(not(feature = "loom"))]
+    {
+        // SAFETY: caller guarantees `ptr` addresses the flags byte. `AtomicU8`
+        // has the same layout and alignment (1) as `u8`, and every writer of
+        // this byte goes through the same atomic view.
+        unsafe {
+            (*(ptr as *const core::sync::atomic::AtomicU8))
+                .load(core::sync::atomic::Ordering::Relaxed)
+        }
+    }
+    #[cfg(feature = "loom")]
+    {
+        // loom's atomics cannot be conjured from a raw pointer, so the loom
+        // build keeps the volatile read the writer side pairs with there.
+        unsafe { std::ptr::read_volatile(ptr) }
+    }
+}
+
 // ============================================================================
 // BasicHeader - Header with segment-level TTL
 // ============================================================================
@@ -128,7 +165,7 @@ impl BasicHeader {
 
         // Read key_len, flags, and value_len from new layout
         let key_len = unsafe { *ptr };
-        let flags = unsafe { *ptr.add(1) };
+        let flags = unsafe { read_flags(ptr.add(1)) };
         let value_len = unsafe { ptr.add(2).cast::<u32>().read_unaligned() };
 
         let optional_len = flags & 0x3F;
@@ -173,7 +210,7 @@ impl BasicHeader {
 
         // Items are 8-byte aligned
         let key_len = unsafe { *ptr };
-        let flags = unsafe { *ptr.add(1) };
+        let flags = unsafe { read_flags(ptr.add(1)) };
         // value_len at offset 2 is NOT 4-byte aligned, must use unaligned read
         let value_len = unsafe { ptr.add(2).cast::<u32>().read_unaligned() };
 
@@ -434,7 +471,7 @@ impl TtlHeader {
 
         // Read key_len, flags, value_len, and expire_at from new layout
         let key_len = unsafe { *ptr };
-        let flags = unsafe { *ptr.add(1) };
+        let flags = unsafe { read_flags(ptr.add(1)) };
         let value_len = unsafe { ptr.add(2).cast::<u32>().read_unaligned() };
         let expire_at = unsafe { ptr.add(6).cast::<u32>().read_unaligned() };
 
@@ -487,7 +524,7 @@ impl TtlHeader {
 
         // Items are 8-byte aligned
         let key_len = unsafe { *ptr };
-        let flags = unsafe { *ptr.add(1) };
+        let flags = unsafe { read_flags(ptr.add(1)) };
         // value_len at offset 2 is NOT 4-byte aligned, must use unaligned read
         let value_len = unsafe { ptr.add(2).cast::<u32>().read_unaligned() };
         // expire_at at offset 6 is NOT 4-byte aligned, must use unaligned read


### PR DESCRIPTION
Three commits: the false-absent fix, the TSan job, and the fixes from an adversarial self-review of the first two.

Started from the `test_increment_concurrent_no_lost_updates` failure in #84 — which was a real bug, not a flaky test.

---

## 1. Read-path lookups reported live keys absent

Failed about **1 run in 12** under full-suite parallel load (0/25 in isolation): a worker got `KeyNotFound` for `counter`, a key set before any thread spawns and never deleted.

**Cause.** `KeyVerifier::verify` answers a bare `bool`, conflating *"this slot holds some other key"* (authoritative) with *"the location I was handed stopped being this entry's while I was looking"* (says nothing). Every read path treated the second as the first.

`TieredCache::cas` makes that window wide: it swaps the slot to the new location **first**, then delete-marks the superseded item **second**. A reader that loaded the slot word before the swap and verifies after the delete-mark sees a delete-marked item, gets `false`, and concludes the key is gone — while it is live in that very slot. No segment recycling needed, which is why it reproduces readily rather than needing loom.

**Fix.** Read paths go through `verify_slot` — the shape of brayniac/cache-rs#60.

**Evidence.** `stale_location_verify_does_not_report_false_absent` reproduces it deterministically: the verifier performs the racing publish from inside its own `verify` call. Red before, green after. Original flake: **1-in-12 → 0/70**.

## 2. ThreadSanitizer job, and the race it found immediately

A `Test (tsan)` job over the cache crates. It reported a race on its first run: `SliceSegment::mark_deleted` sets the tombstone bit with an atomic `fetch_or`, while `TtlHeader::from_bytes_unchecked` read that same byte with a plain load on every lookup. All four decode sites now go through `read_flags`, a Relaxed atomic load. This is brayniac/cache-rs#90, found the same way.

---

## Adversarial review

Three subagents against the risk areas, plus direct checks. **Four findings fixed, one of them a regression this branch introduced.**

### Fixed

**A regression introduced here.** Inserting `verify_slot` split `search_bucket_for_get`'s doc comment and `#[inline]` from the function they belonged to — the attribute landed on `verify_slot`, and the hottest function in the cache lost its inline hint and docs. Clippy's "attribute also specified here" warning was reporting exactly this, and I resolved it the wrong way by dropping the *new* attribute rather than noticing the orphaned one.

**The same race, unfixed in the disk tier.** `DiskSegmentMeta` carries its own `mark_deleted`/`mark_deleted_at_offset` doing a plain non-atomic read-modify-write of the byte commit 2 made readers load atomically — so atomic load racing non-atomic store on the disk-tier GET and DELETE paths. The "tree is clean" claim was wrong. Those lines also had a **lost update**: they checked `is_deleted` and acted later, so two concurrent deletes both saw it live and both decremented, wrapping `live_items: AtomicU32` past zero and feeding garbage to every capacity and eviction decision. The delete is now owned by whoever the `fetch_or` shows flipped the bit.

**A→B→A on the slot word.** Comparing location and tag bits couldn't distinguish "never moved" from "moved away and came back to the same location" — reachable when a segment is recycled and the same key lands at the same offset, and far easier on the heap backend's 9-bit generation. Since every writer moves or clears the slot *before* delete-marking what it superseded, "slot still publishes this location and the item there is our key with a tombstone" is never settled — it means a publish is in flight. A re-probe with `allow_deleted` separates that from a genuine mismatch.

**Missing load-load ordering.** The authoritative conclusion needs the item reads to complete before the slot re-read, but a load-acquire orders what *follows* it, not what precedes it. On aarch64 — a supported target — the header and key loads could be satisfied after the re-read and observe a delete-mark it didn't account for. An `Acquire` fence now precedes the re-read.

The retry bound also went away: it only advances when another thread has *completed* a publish, so it's lock-free rather than a spin, and answering `None` on exhaustion reintroduced the exact false absent this exists to prevent. The tombstone case is bounded instead — there a stable slot means the key really is deleted, so `None` is correct.

Two regression tests, both verified red without their fix: `tombstoned_self_is_not_an_authoritative_mismatch`, `stable_tombstone_reports_absent`. The TSan job now also runs the disk-tier test — a `--lib` scope never executes `DiskSegmentMeta::mark_deleted`, which is how its race survived the job's first pass.

### Verified safe

- **`cas`'s spurious-vs-real CAS discrimination is untouched.** My own suspicion, and it was wrong: `cas` calls `get_item_frequency` → `search_bucket_for_item_freq`, which takes no verifier and can't reach `verify_slot`. `get_frequency` is a different function. (The comment that credited `cas` was wrong and is corrected.)
- **`search_bucket_for_freq` converging is correct** — `get_frequency` takes no location parameter, and every caller follows it with a location-scoped action that no-ops or rolls back if the entry moved.
- **Leaving the write-path sites unguarded is safe here**, and runs in the protective direction: converging reads gate several of those writes, so this reduces entries into them. `try_link_in_bucket` uses `allow_deleted = true` and so can't miss on this race at all.
- **Tag derivation from the starting word is equivalent to passing it** — all four call sites establish tag equality first; `Hashbucket::tag()` and `packed & TAG_MASK` denote the same 12 bits.
- **The refreshed word is safe for the frequency CAS** — the expected value is the full 64-bit word, so it can only succeed if the slot is still bit-identical.
- **`Relaxed` on `read_flags` is correct and never weaker than the plain load it replaced**; no consumer reads the flags to decide to read other bytes whose write must be visible.
- **The loom branch matches its writer side** and doesn't reduce loom's visibility — the previous plain read was equally untracked.
- **No observable behavior change** in header decoding: same masks, same fields, checksums unaffected.
- **Tests are non-vacuous** — each new test verified red with its fix neutered.

### Tracked, not grown into this PR

- #86 — `try_link_in_bucket` can create duplicate live entries for one key (**pre-existing, and the most serious of these**: a key can reappear after deletion)
- #87 — write-path verify sites still treat a raced verify as a key mismatch
- #88 — segment data handed to decoders as `&[u8]` while another thread mutates it (aliasing/provenance; a Miri job would make it actionable)

## Gate

416 cache-core tests, full workspace suite (37 binaries), loom (44), `clippy --workspace --all-targets -- -D warnings`, `fmt` — all green. TSan clean on aarch64-apple-darwin across the four cache crates plus the disk-tier test: **605 tests, zero warnings**.

Note the local TSan runs were on aarch64/macOS; CI runs it on x86_64/Linux, which is its first exercise on that target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu