### PR TITLE
fix(cache-core): harden the ADD path's verify sites against relocation

### DIFF
--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -1184,9 +1184,15 @@ impl MultiChoiceHashtable {
                     continue;
                 }
 
-                let location = Hashbucket::location(packed);
-
-                if verifier.verify(key, location, false) {
+                // `verify_slot`, not a bare `verify`: a relocation that
+                // recycles the location mid-comparison answers `false`,
+                // and reading that as "another key" makes this report a
+                // live key absent — which lets the ADD path publish a
+                // second entry for it.
+                if self
+                    .verify_slot(bucket, slot_index, key, verifier, false, packed)
+                    .is_some()
+                {
                     return true;
                 }
             }
@@ -1278,11 +1284,11 @@ impl MultiChoiceHashtable {
                         if new_current != 0
                             && !Hashbucket::is_ghost(new_current)
                             && Hashbucket::tag(new_current) == tag
+                            && self
+                                .verify_slot(bucket, slot_index, key, verifier, false, new_current)
+                                .is_some()
                         {
-                            let location = Hashbucket::location(new_current);
-                            if verifier.verify(key, location, false) {
-                                return Some(Err(CacheError::KeyExists));
-                            }
+                            return Some(Err(CacheError::KeyExists));
                         }
                         continue;
                     }
@@ -1335,9 +1341,15 @@ impl MultiChoiceHashtable {
                         continue;
                     }
 
-                    let location = Hashbucket::location(packed);
-
-                    if verifier.verify(key, location, false) {
+                    // `verify_slot`, not a bare `verify`: a relocation that
+                    // recycles the location mid-comparison answers `false`,
+                    // and reading that as "another key" makes this report a
+                    // live key absent — which lets the ADD path publish a
+                    // second entry for it.
+                    if self
+                        .verify_slot(bucket, slot_index, key, verifier, false, packed)
+                        .is_some()
+                    {
                         return true;
                     }
                 }
@@ -3595,6 +3607,50 @@ mod loom_tests {
             assert!(
                 replaced.is_ok(),
                 "a live key was reported absent by update_if_present during relocation"
+            );
+        });
+    }
+
+    /// `insert_if_absent` must leave exactly ONE live entry too.
+    ///
+    /// The ADD path has three bare `verify` sites — `check_key_exists` gates
+    /// entry, `try_insert_empty_for_add` re-checks a lost CAS, and
+    /// `check_for_duplicate_after_insert` is the guard meant to catch whatever
+    /// slips past the first. All three read a raced verify as "this is another
+    /// key", so a relocation that recycles the location mid-comparison makes
+    /// the whole path conclude the key is absent, claim a slot, and pass its
+    /// own duplicate check. The key ends up in the table twice.
+    #[test]
+    fn loom_insert_if_absent_leaves_a_single_live_entry() {
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+            oracle.place(SRC, KEY);
+            ht_insert(&ht, KEY, KeyOracle::location(SRC), &*oracle)
+                .expect("seed insert must find a slot");
+
+            let ht_w = ht.clone();
+            let oracle_w = oracle.clone();
+            // TWO successive drains. One is not enough: the ADD path's own
+            // `check_for_duplicate_after_insert` re-scans after claiming a
+            // slot, and by then a single relocation has landed, so the guard
+            // sees the entry and rolls the duplicate back. Two drains keep a
+            // location stale across BOTH the entry check and the guard.
+            let writer = thread::spawn(move || {
+                oracle_w.drain_relocate(&ht_w, SRC, MID);
+                oracle_w.drain_relocate(&ht_w, MID, DST);
+            });
+
+            // A racing ADD for the key that is already in the table.
+            oracle.place(NEW, KEY);
+            let _ = ht_insert(&ht, KEY, KeyOracle::location(NEW), &*oracle);
+
+            writer.join().unwrap();
+
+            assert_eq!(
+                KeyOracle::drain_live_entries(&ht),
+                1,
+                "insert_if_absent published a duplicate entry for a key already in the table"
             );
         });
     }


### PR DESCRIPTION
Fixes #87.

The three remaining bare `verifier.verify(...)` sites all sit on `insert_if_absent`:

- `check_key_exists` — gates entry
- `try_insert_empty_for_add` — re-checks a lost CAS
- `check_for_duplicate_after_insert` — the guard meant to catch whatever slips past the first

Each reads a raced verify as "this slot holds another key", so a relocation that recycles the location mid-comparison makes the path conclude the key is absent. The ADD then claims a slot, passes its own duplicate check, and **the key is in the table twice** — the #86 symptom on a path #92 does not cover.

All three now go through `verify_slot`, which re-reads the slot to separate "another key" from "the location moved".

## The reproduction needs *two* relocations

`loom_insert_if_absent_leaves_a_single_live_entry` is red with one drain? No — it passes. That is the interesting part.

With a single relocation the ADD path already recovers: `check_for_duplicate_after_insert` re-scans after claiming a slot, and by then the relink has landed, so the guard sees the entry and rolls the duplicate back. It takes **two successive drains** to keep a location stale across both the entry check and the guard. Segment merges run repeatedly, so this is a reachable state, not a contrived one.

## Which sites are load-bearing

Neutering each back to a bare `verify`:

| hardened | model |
|---|---|
| none (pre-fix baseline) | **FAILED** |
| only `check_key_exists` | ok |
| only `check_for_duplicate_after_insert` | ok |
| only `try_insert_empty_for_add` | **FAILED** |
| all three | ok |

`check_key_exists` and `check_for_duplicate_after_insert` are each **independently sufficient**. Both are kept rather than picking one: the invariant should not rest on a single backstop, and which one runs depends on whether the ADD reaches its claim pass at all.

**`try_insert_empty_for_add` is not proven necessary by any model here** — it is covered by the other two. It is hardened anyway, for consistency with its siblings and because catching the collision there avoids publishing an entry only to roll it back. It is a redundancy fix rather than a bug fix and should be read that way.

## Already done

The other two sites #87 names are fixed: `try_link_in_bucket` in #92, `try_replace_existing_for_replace` in #93.

418 non-loom tests and 56 loom tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu