### PR TITLE
test(cache-core): restore three loom models I wrongly deleted, and fix the fixture bug that hid one

### DIFF
--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -3377,7 +3377,7 @@ mod loom_tests {
     // stop being the entry's underneath a reader.
     // -------------------------------------------------------------------------
 
-    use crate::loom_oracle::{DST, KEY, KeyOracle, MID, NEW, SRC};
+    use crate::loom_oracle::{DST, KEY, KeyOracle, MID, NEW, OTHER, SRC};
 
     /// Driver for the read-path models: one thread drains [`KEY`] from `SRC`
     /// to `DST` while the main thread performs `read`.
@@ -3651,6 +3651,107 @@ mod loom_tests {
                 KeyOracle::drain_live_entries(&ht),
                 1,
                 "insert_if_absent published a duplicate entry for a key already in the table"
+            );
+        });
+    }
+
+    #[test]
+    fn loom_remove_does_not_unlink_a_relocated_entry() {
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+            oracle.place(SRC, KEY);
+            ht_insert(&ht, KEY, KeyOracle::location(SRC), &*oracle)
+                .expect("seed insert must find a slot");
+
+            let ht_w = ht.clone();
+            let oracle_w = oracle.clone();
+            let writer = thread::spawn(move || oracle_w.drain_relocate(&ht_w, SRC, DST));
+
+            let unlinked = ht_remove(&ht, KEY, KeyOracle::location(SRC));
+            let relinked = writer.join().unwrap();
+
+            assert!(
+                !(unlinked && relinked),
+                "the unlink and the relink both claimed the same entry"
+            );
+
+            let live = KeyOracle::drain_live_entries(&ht);
+            if relinked {
+                assert_eq!(live, 1, "the relink won, so exactly one entry must remain");
+            } else if unlinked {
+                assert_eq!(live, 0, "the unlink won, so no entry may remain");
+            }
+        });
+    }
+
+    #[test]
+    fn loom_ghost_conversion_does_not_capture_a_relocated_entry() {
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+            oracle.place(SRC, KEY);
+            ht_insert(&ht, KEY, KeyOracle::location(SRC), &*oracle)
+                .expect("seed insert must find a slot");
+
+            let ht_w = ht.clone();
+            let oracle_w = oracle.clone();
+            let writer = thread::spawn(move || oracle_w.drain_relocate(&ht_w, SRC, DST));
+
+            let ghosted = <MultiChoiceHashtable as Hashtable>::convert_to_ghost(
+                &ht,
+                KEY,
+                KeyOracle::location(SRC),
+            );
+            let relinked = writer.join().unwrap();
+
+            assert!(
+                !(ghosted && relinked),
+                "the ghost conversion and the relink both claimed the same entry"
+            );
+
+            let live = KeyOracle::drain_live_entries(&ht);
+            if relinked {
+                assert_eq!(live, 1, "the relink won, so exactly one entry must remain");
+            } else if ghosted {
+                assert_eq!(
+                    live, 0,
+                    "the ghost conversion won, so no live entry remains"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn loom_lookup_survives_tombstoned_relocation() {
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+            oracle.place(SRC, KEY);
+            ht_insert(&ht, KEY, KeyOracle::location(SRC), &*oracle)
+                .expect("seed insert must find a slot");
+
+            let ht_w = ht.clone();
+            let oracle_w = oracle.clone();
+            let writer = thread::spawn(move || {
+                oracle_w.place(DST, KEY);
+                oracle_w.tombstone(SRC);
+                let relinked = ht_w.cas_location(
+                    KEY,
+                    KeyOracle::location(SRC),
+                    KeyOracle::location(DST),
+                    true,
+                );
+                oracle_w.place(SRC, OTHER);
+                relinked
+            });
+
+            let found = ht_lookup(&ht, KEY, &*oracle).is_some();
+            let _relinked = writer.join().unwrap();
+
+            assert!(
+                found,
+                "live key reported absent across a tombstoned relocation"
             );
         });
     }

--- a/cache/core/src/loom_oracle.rs
+++ b/cache/core/src/loom_oracle.rs
@@ -69,6 +69,9 @@ pub(crate) const OTHER: &[u8] = b"other";
 const KEY_ID: u64 = 1;
 const OTHER_ID: u64 = 2;
 
+/// Set in a cell word when the occupant is delete-marked in place.
+const DELETED: u64 = 1 << 32;
+
 /// Where the subject key starts out.
 pub(crate) const SRC: usize = 0;
 /// An intermediate location, for models that need two successive drains.
@@ -128,6 +131,34 @@ impl KeyOracle {
         self.cells[cell].store(id, Ordering::Release);
     }
 
+    /// Delete-mark the occupant of `cell` in place.
+    ///
+    /// The bytes still spell the key — this is a flag flip in the item header,
+    /// not a rewrite — so the location keeps matching under
+    /// `allow_deleted = true` and stops matching under `allow_deleted = false`.
+    /// That asymmetry is the whole input to `verify_slot`'s tombstone poll.
+    ///
+    /// # This MUST be one atomic read-modify-write
+    ///
+    /// It is a `fetch_or`, matching production (`mark_deleted` is a
+    /// `fetch_or` on the item flags byte). Writing it the obvious way —
+    /// `load` then `store` — is not merely unfaithful, it silently destroys
+    /// the model: with a non-atomic RMW in the writer, loom stopped exploring
+    /// any interleaving in which the reader observes the writer mid-flight.
+    /// The model then passed against deliberately broken code, because its
+    /// hazard was never reached even once. Instrumenting the verifier showed
+    /// the difference starkly — 0 observed misses with `load`/`store`, 183
+    /// with `fetch_or`.
+    ///
+    /// The general lesson for this fixture: a non-atomic read-modify-write on
+    /// a model atomic can collapse the explored state space to nothing, and a
+    /// model that cannot reach its hazard passes for the wrong reason. Prefer
+    /// a single atomic operation for every oracle mutation, and confirm each
+    /// model reddens against broken code.
+    pub(crate) fn tombstone(&self, cell: usize) {
+        self.cells[cell].fetch_or(DELETED, Ordering::Release);
+    }
+
     /// One merge-drain relocation of [`KEY`], in the order production performs
     /// it:
     ///
@@ -174,20 +205,17 @@ impl KeyOracle {
 }
 
 impl KeyVerifier for KeyOracle {
-    /// `allow_deleted` is ignored: the oracle models a location's OCCUPANT,
-    /// not the delete flag in an item header. Every hazard it can express —
-    /// relocation, recycle, refill — changes who lives at a location, which
-    /// both values of `allow_deleted` answer identically. The delete-marked
-    /// case is covered deterministically by the directed tests above
-    /// (`tombstoned_self_is_not_an_authoritative_mismatch` and friends);
-    /// modelling it here would add a dimension no model asserts on.
-    fn verify(&self, key: &[u8], location: Location, _allow_deleted: bool) -> bool {
+    fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let raw = location.as_raw();
         // Locations the oracle never issued (GHOST, or a backend-shaped word a
         // model handed in by mistake) match nothing.
         if raw == 0 || raw > NUM_CELLS as u64 {
             return false;
         }
-        self.cells[(raw - 1) as usize].load(Ordering::Acquire) == key_id(key)
+        let word = self.cells[(raw - 1) as usize].load(Ordering::Acquire);
+        if word & !DELETED != key_id(key) {
+            return false;
+        }
+        allow_deleted || (word & DELETED) == 0
     }
 }


### PR DESCRIPTION
#91 dropped three oracle-backed models as vacuous because they stayed green against deliberately broken code. **Two of those verdicts were wrong**, and the third had a fixable cause in the fixture. All three are restored, each now proved able to fail.

## The election models were never vacuous — my experiment was broken

When I probed `loom_remove_does_not_unlink_a_relocated_entry` for its outcome pairs, the patch **replaced** the assertion with an `eprintln!` instead of adding one. Every "neutered" run after that had nothing left to assert, so it reported `ok` and I read that as "this model cannot fail."

Both it and `loom_ghost_conversion_does_not_capture_a_relocated_entry` redden properly under a neutered expected-location guard, producing exactly the forbidden outcome:

```
PAIR unlinked=true relinked=true
test loom_remove_does_not_unlink_a_relocated_entry ... FAILED
```

## The tombstone model was unreachable — a non-atomic RMW in the fixture

`KeyOracle::tombstone` was written the obvious way: `load` then `store`. That is not merely unfaithful to production (`mark_deleted` is a `fetch_or` on the item flags byte, as #85 established) — it **silently destroyed the model**. With the non-atomic RMW in the writer, loom stopped exploring every interleaving in which the reader observes the writer mid-flight, so the model's hazard was never reached even once and it passed for the wrong reason.

Instrumenting the verifier to count observed misses isolated it:

| `tombstone()` written as | tombstone misses | occupant misses |
|---|---|---|
| `load` + `store` | **0** | **0** |
| `fetch_or` | 183 | 160 |

Removing the single `tombstone()` call from the model restored reachability on its own, which pinned the cause to that call rather than to the model's shape. Its sibling `loom_lookup_survives_relocation`, which has no `tombstone()`, reached its hazard 4 times in the same conditions.

With `tombstone` as a `fetch_or`, the model reddens under a neutered `verify_slot` alongside its siblings.

## The lesson, now documented on the method

A non-atomic read-modify-write on a model atomic can collapse the explored state space to nothing, and **a model that cannot reach its hazard passes for the wrong reason**. Every oracle mutation should be a single atomic operation, and every model should be confirmed red against broken code.

This also revises the "deliberately not ported" note in #91: only the incarnation-tag model genuinely cannot port here. The other three were my error.

## Proof matrix

| neutered | models that redden |
|---|---|
| `verify_slot` | `lookup`, `repeated_relocation`, `tombstoned_relocation` |
| unlink expected-location guard | `loom_remove_does_not_unlink_a_relocated_entry` |
| ghost expected-location guard | `loom_ghost_conversion_does_not_capture_a_relocated_entry` |

Test-only; no production code changed. 418 non-loom tests and 59 loom tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu