### PR TITLE
test(cache-core): audit model hazard reachability, and make it self-checking

### DIFF
--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -3392,6 +3392,7 @@ mod loom_tests {
     /// Each read entry point carries its own hand-written copy of the bucket
     /// scan, so each gets its own model rather than hiding behind a sibling.
     fn read_survives_relocation(read: fn(&MultiChoiceHashtable, &KeyOracle) -> bool) {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(move || {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3409,6 +3410,7 @@ mod loom_tests {
 
             assert!(found, "live key reported absent during relocation");
         });
+        witness.assert_reached();
     }
 
     #[test]
@@ -3445,6 +3447,7 @@ mod loom_tests {
     /// after a single retry reports the live key absent here.
     #[test]
     fn loom_lookup_survives_repeated_relocation() {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(|| {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3465,6 +3468,7 @@ mod loom_tests {
 
             assert!(found, "live key reported absent across two relocations");
         });
+        witness.assert_reached();
     }
     /// A relocation's relink must not be defeated by a concurrent reader.
     ///
@@ -3583,6 +3587,7 @@ mod loom_tests {
     /// the slot and follows the entry to its new location.
     #[test]
     fn loom_update_if_present_survives_a_relocation() {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(|| {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3609,6 +3614,7 @@ mod loom_tests {
                 "a live key was reported absent by update_if_present during relocation"
             );
         });
+        witness.assert_reached();
     }
 
     /// `insert_if_absent` must leave exactly ONE live entry too.
@@ -3622,6 +3628,7 @@ mod loom_tests {
     /// own duplicate check. The key ends up in the table twice.
     #[test]
     fn loom_insert_if_absent_leaves_a_single_live_entry() {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(|| {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3653,6 +3660,7 @@ mod loom_tests {
                 "insert_if_absent published a duplicate entry for a key already in the table"
             );
         });
+        witness.assert_reached();
     }
 
     #[test]
@@ -3724,6 +3732,7 @@ mod loom_tests {
 
     #[test]
     fn loom_lookup_survives_tombstoned_relocation() {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(|| {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3754,6 +3763,7 @@ mod loom_tests {
                 "live key reported absent across a tombstoned relocation"
             );
         });
+        witness.assert_tombstone_reached();
     }
 
     /// `insert` must leave exactly ONE live entry for a key, in every
@@ -3766,6 +3776,7 @@ mod loom_tests {
     /// deleted key reappears with a stale value.
     #[test]
     fn loom_insert_leaves_a_single_live_entry() {
+        let witness = KeyOracle::arm_hazard_witness();
         loom::model(|| {
             let ht = Arc::new(MultiChoiceHashtable::new(4));
             let oracle = Arc::new(KeyOracle::new());
@@ -3794,5 +3805,6 @@ mod loom_tests {
                 "insert published a duplicate entry for a key already in the table"
             );
         });
+        witness.assert_reached();
     }
 }

--- a/cache/core/src/loom_oracle.rs
+++ b/cache/core/src/loom_oracle.rs
@@ -72,6 +72,67 @@ const OTHER_ID: u64 = 2;
 /// Set in a cell word when the occupant is delete-marked in place.
 const DELETED: u64 = 1 << 32;
 
+/// How many times a model's reader was handed a location that no longer held
+/// its key, counted across every loom execution of the current model.
+///
+/// These are `std` atomics, not model atomics, on purpose: they must survive
+/// across loom's repeated executions of the closure, which reset all loom
+/// state. They are the model's HAZARD WITNESS — see
+/// [`KeyOracle::assert_hazard_reached`].
+static OCCUPANT_MISS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static TOMBSTONE_MISS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Serializes witness-bearing models against each other; see
+/// [`KeyOracle::arm_hazard_witness`].
+static WITNESS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Proof that a model reached the hazard it claims to model.
+///
+/// Holds the witness lock for the duration of one model. Consumed by one of
+/// its `assert_*` methods, which is what makes forgetting the check visible:
+/// an unused `HazardWitness` is an unused variable.
+pub(crate) struct HazardWitness(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+impl HazardWitness {
+    /// Assert that the model actually REACHED the hazard it claims to model.
+    ///
+    /// A model whose reader is never handed a stale location is not testing
+    /// the slot protocol at all — it is asserting that a quiet table stays
+    /// quiet, and it passes against arbitrarily broken code. That is not
+    /// hypothetical: `loom_lookup_survives_tombstoned_relocation` shipped in
+    /// exactly that state until #95, because a non-atomic read-modify-write in
+    /// [`KeyOracle::tombstone`] silently collapsed loom's exploration and the
+    /// reader observed zero misses across every execution.
+    ///
+    /// Reddening under a neutered `verify_slot` is the proof that a model CAN
+    /// fail; this is the standing check that it still can, so the failure mode
+    /// cannot come back unnoticed when something unrelated changes.
+    ///
+    /// Only for models whose hazard is expressed through the verifier. Models
+    /// about CAS contention (`remove` and `convert_to_ghost` take no verifier)
+    /// have a different witness and must not use this.
+    pub(crate) fn assert_reached(self) {
+        let occupant = OCCUPANT_MISS.load(std::sync::atomic::Ordering::Relaxed);
+        let tombstone = TOMBSTONE_MISS.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            occupant + tombstone > 0,
+            "model never reached its hazard: the verifier was never handed a \
+             location that had stopped being the key's, so this model would \
+             pass against broken code"
+        );
+    }
+
+    /// As [`HazardWitness::assert_reached`], but for a model whose hazard is
+    /// specifically a DELETE-MARKED occupant rather than a replaced one.
+    pub(crate) fn assert_tombstone_reached(self) {
+        assert!(
+            TOMBSTONE_MISS.load(std::sync::atomic::Ordering::Relaxed) > 0,
+            "model never observed a delete-marked occupant, so it is not \
+             exercising verify_slot's tombstone poll"
+        );
+    }
+}
+
 /// Where the subject key starts out.
 pub(crate) const SRC: usize = 0;
 /// An intermediate location, for models that need two successive drains.
@@ -202,6 +263,27 @@ impl KeyOracle {
         }
         found
     }
+
+    /// Arm the hazard witness. Call immediately before `loom::model`, and
+    /// call [`HazardWitness::assert_reached`] on the result afterwards.
+    ///
+    /// The returned guard holds a process-wide lock for as long as it lives.
+    /// The counters are global — the verifier has no idea which model is
+    /// running — and `cargo test` runs tests in PARALLEL, so without the lock
+    /// two witness-bearing models would reset and read each other's counts and
+    /// the witness would report whatever the scheduler happened to produce.
+    /// Only witness-bearing models contend for it; the rest still run
+    /// concurrently.
+    pub(crate) fn arm_hazard_witness() -> HazardWitness {
+        // A panicking model poisons the lock; the next model still wants a
+        // working witness, so take the guard either way.
+        let guard = WITNESS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        OCCUPANT_MISS.store(0, std::sync::atomic::Ordering::Relaxed);
+        TOMBSTONE_MISS.store(0, std::sync::atomic::Ordering::Relaxed);
+        HazardWitness(guard)
+    }
 }
 
 impl KeyVerifier for KeyOracle {
@@ -213,9 +295,25 @@ impl KeyVerifier for KeyOracle {
             return false;
         }
         let word = self.cells[(raw - 1) as usize].load(Ordering::Acquire);
+        use std::sync::atomic::Ordering as O;
         if word & !DELETED != key_id(key) {
+            let n = OCCUPANT_MISS.fetch_add(1, O::Relaxed) + 1;
+            eprintln!(
+                "MISS occupant={} tombstone={}",
+                n,
+                TOMBSTONE_MISS.load(O::Relaxed)
+            );
             return false;
         }
-        allow_deleted || (word & DELETED) == 0
+        if !allow_deleted && (word & DELETED) != 0 {
+            let n = TOMBSTONE_MISS.fetch_add(1, O::Relaxed) + 1;
+            eprintln!(
+                "MISS occupant={} tombstone={}",
+                OCCUPANT_MISS.load(O::Relaxed),
+                n
+            );
+            return false;
+        }
+        true
     }
 }


### PR DESCRIPTION
#95 found that a model can pass because it never reaches its hazard, not because the code is correct. That was one model with one cause. This audits **every** oracle-backed model for the same failure, and replaces the one-off measurement with a standing check.

## The audit

Instrumenting the verifier and the CAS retry loops, then running each model in its own process. **Every model does reach a hazard — there is no second silent one.** But exposure varies by two orders of magnitude:

| models | exposure |
|---|---|
| `repeated_relocation`, `tombstoned_relocation`, `insert_if_absent` | 80–183 verify misses |
| the four read-path models, `update_if_present_survives_a_relocation` | 4 verify misses |
| `loom_insert_leaves_a_single_live_entry` | **2 verify misses** |
| the four frequency-bump models | **2 CAS retries** |
| the two election models | 0 verify misses, 6 CAS retries |

The election models observing zero verify misses is **correct, not a gap**: `remove` and `convert_to_ghost` take no verifier, so their hazard is CAS contention — which the retry count confirms they reach.

The models at 2 are at the minimum possible non-zero signal. They redden under their neuters, so they work, but the margin is thin enough that an unrelated change could silently take them to zero. Which is exactly what happened in #95.

## The standing check

A one-off audit doesn't stop this regressing, so the measurement is now permanent rather than a number in a PR description.

`KeyOracle::arm_hazard_witness()` returns a `HazardWitness` that the model consumes with `assert_reached()` (or `assert_tombstone_reached()`), asserting the verifier was handed at least one location that had stopped being the key's. Wired into the nine verifier-mediated models.

**Proved to work** by reintroducing the exact #95 bug — `tombstone` as a non-atomic `load` + `store` instead of `fetch_or`:

```
test loom_lookup_survives_tombstoned_relocation ... FAILED
model never observed a delete-marked occupant, so it is not
exercising verify_slot's tombstone poll
```

That bug previously shipped silently green.

## On parallelism

The witness holds a process-wide lock for the life of a model. The counters are global — the verifier has no idea which model is running — and `cargo test` runs tests **in parallel**, so without the lock two witness-bearing models would reset and read each other's counts, and the witness would report whatever the scheduler produced. Only witness-bearing models contend for it; everything else still runs concurrently. The guard is consumed by its assertion, so forgetting the check shows up as an unused variable.

## Both checks kept

Reddening under a neutered `verify_slot` remains the proof that a model **can** fail; the witness is the standing check that it **still** can. Both survive: with `verify_slot` neutered, 10 models still redden.

Test-only; no production code changed. 418 non-loom tests and 59 loom tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu