### PR TITLE
test(cache-core): cover the two-ADD race, and settle whether #94's third site earns its place

### DIFF
--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -3766,6 +3766,41 @@ mod loom_tests {
         witness.assert_tombstone_reached();
     }
 
+    /// Two concurrent ADDs of the SAME key.
+    ///
+    /// This is the race `try_insert_empty_for_add`'s lost-CAS branch exists
+    /// for: both writers find the same empty slot, one CAS wins, and the loser
+    /// must recognise that the word now in the slot is its OWN key rather than
+    /// moving on to claim a second slot. Every other model races an ADD
+    /// against a relocation, which never enters that branch.
+    #[test]
+    fn loom_concurrent_adds_leave_a_single_live_entry() {
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+            // Both writers have already written their copy of the item.
+            oracle.place(SRC, KEY);
+            oracle.place(DST, KEY);
+
+            let ht1 = ht.clone();
+            let o1 = oracle.clone();
+            let first = thread::spawn(move || ht_insert(&ht1, KEY, KeyOracle::location(SRC), &*o1));
+
+            let second = ht_insert(&ht, KEY, KeyOracle::location(DST), &*oracle);
+            let first = first.join().unwrap();
+
+            assert!(
+                !(first.is_ok() && second.is_ok()),
+                "both ADDs reported success for the same key"
+            );
+            assert_eq!(
+                KeyOracle::drain_live_entries(&ht),
+                1,
+                "concurrent ADDs must leave exactly one live entry"
+            );
+        });
+    }
+
     /// `insert` must leave exactly ONE live entry for a key, in every
     /// interleaving and in every bucket.
     ///


### PR DESCRIPTION
#94 hardened `try_insert_empty_for_add`'s lost-CAS branch without a model that needed it, and said so. This settles the question by building the model that actually exercises that branch.

## The gap in the earlier measurement

Every existing model races an ADD against a **relocation** — which never enters that branch. It fires only when an ADD loses its compare-exchange on an empty slot to **another ADD**. So "not necessary" was really "not exercised".

`loom_concurrent_adds_leave_a_single_live_entry` creates that race: two threads adding the same key at different locations. Instrumenting the branch, it is reached **8 times** here and **zero** times in every relocation model.

## Findings

**The branch is not load-bearing.** Removing it *entirely* leaves the model green — the loser walks on, claims another slot, and `check_for_duplicate_after_insert` catches the duplicate and rolls it back. Routing it through `verify_slot` buys **no safety**; the safety comes from the duplicate guard.

**It is not dead code, and it does not hurt.** It sits on a lost-CAS path that only runs under contention, and `verify_slot`'s success path costs one prefetch over a bare `verify`. What it buys is churn: the loser is told the key exists rather than publishing an entry and rolling it back. Under relocation a bare `verify` would false-absent and lose even that.

**Verdict: keep it**, on those grounds — cheap, reached, correct — but as a redundancy fix, not a bug fix. That is now recorded in the code's history rather than resting on my say-so.

## The new model is proved able to fail

| neutered | model |
|---|---|
| duplicate guard (`check_for_duplicate_after_insert`) disabled | **FAILED** |
| site C removed entirely | ok |
| site C routed through bare `verify` | ok |

The first row is also the direct evidence for which check actually carries this case.

## A separate defect found on the way

The model written to probe the branch's value found something it does **not** cover: two ADDs racing for the last free slot in an otherwise full table. The loser finds no second slot to claim, so the duplicate guard never runs, and it reports `HashTableFull` for a key that is present.

That reproduces *with* the branch present, so it is neither an argument for nor against it. Filed as #97 with the model, rather than shipped red here.

Test-only; no production code changed. 418 non-loom tests and 60 loom tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu