### PR TITLE
fix(cache-core): free-queue provenance, a header data race, and Retry read as empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,15 @@ jobs:
     #    ones are not. `disk::disk_segment_meta` DOES run: it allocates through
     #    the global allocator.
     #  - `hugepage::` -- Miri accepts `mmap` only with MAP_PRIVATE|MAP_ANONYMOUS
-    #    and the hugepage path adds MAP_HUGETLB, and MADV_HUGEPAGE is not
-    #    implemented either. Excluded rather than worked around: unlike a
-    #    prefetch, the mmap flags decide what is actually allocated, so
-    #    compiling them out would change what is tested. Both are Linux-only,
-    #    so neither reproduces when running Miri on macOS.
+    #    and the hugepage path adds MAP_HUGETLB. Excluded rather than worked
+    #    around: unlike a prefetch, the mmap flags decide what is actually
+    #    allocated, so compiling them out would change what is tested.
+    #
+    #    The THP `madvise` hint in the same file IS compiled out under
+    #    `cfg(miri)` -- it is advisory and its result is already discarded, and
+    #    every pool-building test reaches it, so without that nothing here
+    #    would run on Linux at all. Both are Linux-only paths, so neither
+    #    reproduces when running Miri on macOS: they were found on CI.
     #  - the SIMD tag scan and prefetch hints are inline asm Miri cannot run.
     #    `cfg(miri)` routes to the scalar fallback, which computes the same
     #    mask, and drops the prefetches, which have no semantic effect. So the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,48 +127,42 @@ jobs:
   miri:
     name: Test (miri)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Miri under Stacked Borrows, over the parts of cache-core it can execute.
+    timeout-minutes: 45
+    # Miri under Stacked Borrows, over nearly all of cache-core.
     #
-    # This checks something TSan structurally cannot: the ALIASING claim a
-    # reference makes, as opposed to the accesses it performs. The flags byte
-    # is written by `mark_deleted` after an item is published, so a `&[u8]`
-    # spanning a header is `noalias readonly` at the ABI boundary and
-    # `SharedReadOnly` under Stacked Borrows -- neither true of memory a
-    # concurrent writer mutates. Reading the flags byte from such a slice
-    # retags a `SharedReadWrite` `&AtomicU8` from a read-only parent, which
-    # Miri rejects at the retag, single-threaded, with no race required.
+    # This checks two things TSan structurally cannot. First, the ALIASING
+    # claim a reference makes rather than the accesses it performs: a `&[u8]`
+    # spanning an item header is `noalias readonly` and `SharedReadOnly`, and
+    # `mark_deleted` writes the flags byte inside it, so merely creating that
+    # reference is wrong -- Miri rejects it single-threaded, no race needed.
+    # Second, PROVENANCE: a raw pointer that stops being valid before it is
+    # used, which no sanitiser sees because the address is still correct.
     #
-    # It earned its place the way the TSan job did: run against the tree
-    # before the decoders took raw pointers, it failed on an existing test.
-    # Widening its scope past that first version immediately found a second,
-    # unrelated provenance defect (see the free-queue issue below).
+    # It has found four defects so far, none of which the other jobs caught:
+    # the header decoders' `&[u8]`, whole-item slices spanning the flags byte
+    # (a genuine data race), a free-queue pointer invalidated by the pool's own
+    # use of its `Box`, and `Steal::Retry` read as "queue empty".
     #
-    # `-Zmiri-disable-isolation` is required and not optional: `clocksource`
-    # calls `clock_gettime`, which isolation blocks. Anonymous `mmap` needs
-    # nothing -- Miri shims it, so the real hugepage allocator runs here.
+    # `-Zmiri-disable-isolation` is required: `clocksource` calls
+    # `clock_gettime`, which isolation blocks. Anonymous `mmap` needs nothing --
+    # Miri shims it.
     #
-    # What is NOT covered, and why:
+    # Excluded, and why:
     #
-    #  - `disk::`  -- `memmap2` maps a FILE, which Miri does not support.
-    #    Anonymous mappings are fine; file-backed ones are not.
-    #  - `hugepage::` -- Miri accepts `mmap` only with
-    #    MAP_PRIVATE|MAP_ANONYMOUS, and the hugepage path adds MAP_HUGETLB.
-    #    It also does not implement MADV_HUGEPAGE, so the THP hint in
-    #    `allocate_on_node` needs skipping before these tests run at all.
-    #    Both are Linux-only paths, so neither shows up when running Miri on
-    #    macOS -- they were found here, on CI, not locally. Excluded rather
-    #    than worked around: unlike a prefetch, the mmap flags decide what is
-    #    actually allocated, so compiling them out would change what is
-    #    tested rather than drop a hint.
-    #  - `layer::`, `organization::`, `cache::` -- these build a real
-    #    `MemoryPool`, which hands every segment a free-queue pointer it then
-    #    invalidates. That is a genuine defect Miri reports, not a limitation:
-    #    it is filed, and fixing it is what widens this job.
-    #  - the SIMD tag scan and the prefetch hints are inline asm Miri cannot
-    #    execute. `cfg(miri)` routes to the scalar fallback, which computes the
-    #    same mask, and drops the prefetches, which have no semantic effect.
-    #    So the vectorised load itself is not what is checked here.
+    #  - the four `disk::` modules that build a pool -- `memmap2` maps a FILE,
+    #    which Miri does not support. Anonymous mappings are fine; file-backed
+    #    ones are not. `disk::disk_segment_meta` DOES run: it allocates through
+    #    the global allocator.
+    #  - `hugepage::` -- Miri accepts `mmap` only with MAP_PRIVATE|MAP_ANONYMOUS
+    #    and the hugepage path adds MAP_HUGETLB, and MADV_HUGEPAGE is not
+    #    implemented either. Excluded rather than worked around: unlike a
+    #    prefetch, the mmap flags decide what is actually allocated, so
+    #    compiling them out would change what is tested. Both are Linux-only,
+    #    so neither reproduces when running Miri on macOS.
+    #  - the SIMD tag scan and prefetch hints are inline asm Miri cannot run.
+    #    `cfg(miri)` routes to the scalar fallback, which computes the same
+    #    mask, and drops the prefetches, which have no semantic effect. So the
+    #    vectorised load itself is not what is checked here.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -181,9 +175,12 @@ jobs:
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation"
         run: |
-          cargo +nightly miri test -p cache-core --lib item::
-          cargo +nightly miri test -p cache-core --lib slice_segment::
-          cargo +nightly miri test -p cache-core --lib hashtable_impl::
+          cargo +nightly miri test -p cache-core --lib -- \
+            --skip disk::file_pool \
+            --skip disk::disk_layer \
+            --skip disk::io_uring \
+            --skip disk::recovery \
+            --skip hugepage::
 
   smoketest:
     name: Smoketest (${{ matrix.config }})

--- a/cache/core/src/disk/file_pool.rs
+++ b/cache/core/src/disk/file_pool.rs
@@ -139,9 +139,14 @@ pub struct FilePool {
     /// Segment metadata.
     segments: Vec<FileSegment<'static>>,
 
-    /// Lock-free free list.
-    /// Boxed for stable address - segments hold raw pointers to this.
-    free_queue: Box<crossbeam_deque::Injector<u32>>,
+    /// Lock-free free list. Segments hold raw pointers to this.    ///
+    /// `Arc`, not `Box`: every segment holds a raw pointer into this queue and
+    /// pushes itself back on release. Dereferencing a `Box` asserts unique
+    /// ownership, which under Stacked Borrows pops every pointer derived from
+    /// it, so the pool's own use of the queue invalidated the pointer the
+    /// segments were holding. An `Arc` is a shared owner and makes no such
+    /// assertion.
+    free_queue: std::sync::Arc<crossbeam_deque::Injector<u32>>,
 
     /// Pool ID (0-3).
     pool_id: u8,
@@ -277,21 +282,31 @@ impl RamPool for FilePool {
     }
 
     fn reserve(&self) -> Option<u32> {
-        match self.free_queue.steal() {
-            crossbeam_deque::Steal::Success(segment_id) => {
-                let segment = &self.segments[segment_id as usize];
+        use crate::memory_pool::MAX_STEAL_RETRIES;
 
-                // Transition Free -> Reserved
-                if !segment.try_reserve() {
-                    // Segment not in Free state - push back and return None
-                    self.free_queue.push(segment_id);
-                    return None;
+        // Bounded retry: `Injector::steal` returns `Retry` transiently, meaning
+        // "another thread was mid-operation, ask again", NOT "the queue is
+        // empty". Only `Empty` answers the question. See `MemoryPool::reserve`.
+        for _ in 0..MAX_STEAL_RETRIES {
+            match self.free_queue.steal() {
+                crossbeam_deque::Steal::Success(segment_id) => {
+                    let segment = &self.segments[segment_id as usize];
+
+                    // Transition Free -> Reserved
+                    if !segment.try_reserve() {
+                        // Segment not in Free state - push back and retry
+                        self.free_queue.push(segment_id);
+                        continue;
+                    }
+
+                    return Some(segment_id);
                 }
-
-                Some(segment_id)
+                crossbeam_deque::Steal::Retry => continue,
+                crossbeam_deque::Steal::Empty => return None,
             }
-            crossbeam_deque::Steal::Empty | crossbeam_deque::Steal::Retry => None,
         }
+
+        None
     }
 
     fn release(&self, id: u32) {
@@ -470,8 +485,11 @@ impl FilePoolBuilder {
         }
 
         // Initialize free queue first (boxed for stable address)
-        let free_queue = Box::new(crossbeam_deque::Injector::new());
-        let free_queue_ptr: *const crossbeam_deque::Injector<u32> = &*free_queue;
+        let free_queue = std::sync::Arc::new(crossbeam_deque::Injector::new());
+        // `Arc::as_ptr`, not `&*free_queue`: a shared reference narrows the
+        // provenance to read-only, and pushing through it needs write access.
+        let free_queue_ptr: *const crossbeam_deque::Injector<u32> =
+            std::sync::Arc::as_ptr(&free_queue);
 
         // Initialize segments with pointer to free queue
         let mut segments = Vec::with_capacity(num_segments);

--- a/cache/core/src/disk/io_uring_pool.rs
+++ b/cache/core/src/disk/io_uring_pool.rs
@@ -31,10 +31,15 @@ pub struct IoUringPool {
     /// In-RAM metadata for each disk segment.
     segments: Vec<DiskSegmentMeta>,
     /// Lock-free free queue for segment allocation.
-    free_queue: Box<crossbeam_deque::Injector<u32>>,
+    ///
+    /// `Arc`, not `Box`: see `MemoryPool::free_queue`. Segments hold raw
+    /// pointers into this queue and push themselves back on release, and a
+    /// `Box` deref asserts unique ownership, which pops those pointers off the
+    /// borrow stack.
+    free_queue: std::sync::Arc<crossbeam_deque::Injector<u32>>,
     /// Spare queue for segments that need special handling.
     #[allow(dead_code)]
-    spare_queue: Box<crossbeam_deque::Injector<u32>>,
+    spare_queue: std::sync::Arc<crossbeam_deque::Injector<u32>>,
     /// Pool ID (0-3).
     pool_id: u8,
     /// Size of each segment in bytes.
@@ -68,10 +73,12 @@ impl IoUringPool {
             "block_size must be a power of two"
         );
 
-        let free_queue = Box::new(crossbeam_deque::Injector::new());
-        let spare_queue = Box::new(crossbeam_deque::Injector::new());
+        // `Arc`, not `Box`: see `MemoryPool::free_queue`. Segments hold raw
+        // pointers into this queue, and a `Box` deref would invalidate them.
+        let free_queue = std::sync::Arc::new(crossbeam_deque::Injector::new());
+        let spare_queue = std::sync::Arc::new(crossbeam_deque::Injector::new());
 
-        let free_queue_ptr = &*free_queue as *const crossbeam_deque::Injector<u32>;
+        let free_queue_ptr = std::sync::Arc::as_ptr(&free_queue);
 
         let mut segments = Vec::with_capacity(segment_count);
         for i in 0..segment_count {

--- a/cache/core/src/hugepage.rs
+++ b/cache/core/src/hugepage.rs
@@ -305,8 +305,15 @@ fn allocate_regular_internal(
         return Err(std::io::Error::last_os_error());
     }
 
-    // Try to enable THP via madvise (Linux only, best-effort)
-    #[cfg(target_os = "linux")]
+    // Try to enable THP via madvise (Linux only, best-effort).
+    //
+    // `not(miri)`: Miri implements only a few `madvise` advice values and
+    // MADV_HUGEPAGE is not among them. The call is advisory and its result is
+    // already discarded, so skipping it changes nothing observable -- and
+    // without this, Miri cannot run ANY test that builds a pool on Linux,
+    // which is most of `cache-core`. (This path does not exist in a macOS
+    // build, so it only shows up on CI.)
+    #[cfg(all(target_os = "linux", not(miri)))]
     unsafe {
         // MADV_HUGEPAGE = 14
         let _ = libc::madvise(ptr, alloc_size, 14);

--- a/cache/core/src/memory_pool.rs
+++ b/cache/core/src/memory_pool.rs
@@ -22,7 +22,7 @@ use crate::sync::{AtomicU32, Ordering};
 /// Maximum number of steal retries before giving up. Bounds the retry loop
 /// in `reserve_spare` and `reserve` to prevent unbounded spinning under
 /// pathological contention.
-const MAX_STEAL_RETRIES: usize = 64;
+pub(crate) const MAX_STEAL_RETRIES: usize = 64;
 
 /// A pool of segments backed by in-memory allocation.
 ///
@@ -42,12 +42,19 @@ pub struct MemoryPool {
     segments: Vec<SliceSegment<'static>>,
 
     /// Lock-free free list for normal allocation.
-    /// Boxed for stable address.
-    free_queue: Box<crossbeam_deque::Injector<u32>>,
+    ///
+    /// `Arc`, not `Box`, and that is load-bearing: every segment holds a raw
+    /// pointer into this queue and pushes itself back on release. Dereferencing
+    /// a `Box` asserts unique ownership, which under Stacked Borrows pops every
+    /// pointer derived from it — so each of the pool's own `free_queue.push()`
+    /// calls invalidated the pointer all the segments were holding. An `Arc` is
+    /// a shared owner and makes no such assertion.
+    free_queue: std::sync::Arc<crossbeam_deque::Injector<u32>>,
 
     /// Lock-free free list reserved for compaction operations.
-    /// Boxed for stable address.
-    spare_queue: Box<crossbeam_deque::Injector<u32>>,
+    ///
+    /// `Arc` for the same reason as `free_queue`.
+    spare_queue: std::sync::Arc<crossbeam_deque::Injector<u32>>,
 
     /// Target capacity for spare queue (typically = num_workers).
     spare_capacity: u32,
@@ -119,22 +126,31 @@ impl MemoryPool {
             }
         }
 
-        // Fallback: try main free queue if spare is empty
-        match self.free_queue.steal() {
-            crossbeam_deque::Steal::Success(segment_id) => {
-                let segment = &self.segments[segment_id as usize];
+        // Fallback: try main free queue if spare is empty. Bounded retry for
+        // the same reason as the loop above and as `reserve` -- a `Retry` from
+        // `Injector::steal` means "ask again", not "the queue is empty", and
+        // treating it as the latter reports the pool exhausted while segments
+        // are sitting in it.
+        for _ in 0..MAX_STEAL_RETRIES {
+            match self.free_queue.steal() {
+                crossbeam_deque::Steal::Success(segment_id) => {
+                    let segment = &self.segments[segment_id as usize];
 
-                // Transition Free -> Reserved
-                if !segment.try_reserve() {
-                    // Segment not in Free state - push back and return None
-                    self.free_queue.push(segment_id);
-                    return None;
+                    // Transition Free -> Reserved
+                    if !segment.try_reserve() {
+                        // Segment not in Free state - push back and retry
+                        self.free_queue.push(segment_id);
+                        continue;
+                    }
+
+                    return Some(segment_id);
                 }
-
-                Some(segment_id)
+                crossbeam_deque::Steal::Retry => continue,
+                crossbeam_deque::Steal::Empty => return None,
             }
-            crossbeam_deque::Steal::Empty | crossbeam_deque::Steal::Retry => None,
         }
+
+        None
     }
 
     /// Release a segment back to the appropriate queue with automatic balancing.
@@ -211,22 +227,34 @@ impl RamPool for MemoryPool {
     }
 
     fn reserve(&self) -> Option<u32> {
-        // Normal allocation only uses free_queue, never spare_queue
-        match self.free_queue.steal() {
-            crossbeam_deque::Steal::Success(segment_id) => {
-                let segment = &self.segments[segment_id as usize];
+        // Normal allocation only uses free_queue, never spare_queue.
+        //
+        // Bounded retry, matching `reserve_spare`. `Injector::steal` returns
+        // `Retry` transiently -- it means "another thread was mid-operation,
+        // ask again", NOT "the queue is empty". Returning `None` on it reports
+        // the pool exhausted while segments are sitting in the queue, which
+        // costs a spurious eviction or allocation failure. Only `Empty` is an
+        // answer about the queue's contents.
+        for _ in 0..MAX_STEAL_RETRIES {
+            match self.free_queue.steal() {
+                crossbeam_deque::Steal::Success(segment_id) => {
+                    let segment = &self.segments[segment_id as usize];
 
-                // Transition Free -> Reserved
-                if !segment.try_reserve() {
-                    // Segment not in Free state - push back and return None
-                    self.free_queue.push(segment_id);
-                    return None;
+                    // Transition Free -> Reserved
+                    if !segment.try_reserve() {
+                        // Segment not in Free state - push back and retry
+                        self.free_queue.push(segment_id);
+                        continue;
+                    }
+
+                    return Some(segment_id);
                 }
-
-                Some(segment_id)
+                crossbeam_deque::Steal::Retry => continue,
+                crossbeam_deque::Steal::Empty => return None,
             }
-            crossbeam_deque::Steal::Empty | crossbeam_deque::Steal::Retry => None,
         }
+
+        None
     }
 
     fn release(&self, id: u32) {
@@ -421,12 +449,17 @@ impl MemoryPoolBuilder {
         // Allocate backing memory (optionally bound to NUMA node)
         let heap = allocate_on_node(actual_size, self.hugepage_size, self.numa_node)?;
 
-        // Create both queues (boxed for stable address)
-        let free_queue = Box::new(crossbeam_deque::Injector::new());
-        let spare_queue = Box::new(crossbeam_deque::Injector::new());
+        // Create both queues. `Arc` for a stable address AND for provenance
+        // that survives the pool's own use of the queue -- see the field docs.
+        let free_queue = std::sync::Arc::new(crossbeam_deque::Injector::new());
+        let spare_queue = std::sync::Arc::new(crossbeam_deque::Injector::new());
 
-        // Get pointer to free_queue for segments (guards will push here on release)
-        let free_queue_ptr: *const crossbeam_deque::Injector<u32> = &*free_queue;
+        // Pointer to free_queue for segments (guards push here on release).
+        // `Arc::as_ptr`, not `&*free_queue`: a shared reference would narrow
+        // the provenance to read-only, and pushing through it later needs
+        // write access to the queue's interior.
+        let free_queue_ptr: *const crossbeam_deque::Injector<u32> =
+            std::sync::Arc::as_ptr(&free_queue);
 
         // Initialize segments with pointer to free_queue
         let mut segments = Vec::with_capacity(num_segments);

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -322,8 +322,12 @@ impl<'a> SliceSegment<'a> {
             return Err(CacheError::InvalidOffset);
         }
 
-        let raw = unsafe { std::slice::from_raw_parts(data_ptr, item_size) };
-
+        // Slice the item's BODY only. A slice spanning the header would
+        // include the flags byte, and `mark_deleted` writes that byte through
+        // an atomic after the item is published -- so merely creating such a
+        // reference is a read that races the write. Key, value and optional
+        // bytes are written before publication and never mutated, so shared
+        // references over them are honest.
         let optional_start = BasicHeader::SIZE;
         let optional_end = optional_start + header.optional_len() as usize;
         let key_start = optional_end;
@@ -331,16 +335,25 @@ impl<'a> SliceSegment<'a> {
         let value_start = key_end;
         let value_end = value_start + header.value_len() as usize;
 
-        if &raw[key_start..key_end] != key {
+        let stored_key =
+            unsafe { std::slice::from_raw_parts(data_ptr.add(key_start), key_end - key_start) };
+        let stored_value = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(value_start), value_end - value_start)
+        };
+        let stored_optional = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(optional_start), optional_end - optional_start)
+        };
+
+        if stored_key != key {
             self.ref_count.fetch_sub(1, Ordering::Release);
             return Err(CacheError::KeyMismatch);
         }
 
         Ok(BasicItemGuard::new(
             &self.ref_count,
-            &raw[key_start..key_end],
-            &raw[value_start..value_end],
-            &raw[optional_start..optional_end],
+            stored_key,
+            stored_value,
+            stored_optional,
             &self.metadata,
             self.free_queue,
             self.id,
@@ -396,8 +409,12 @@ impl<'a> SliceSegment<'a> {
             return Err(CacheError::InvalidOffset);
         }
 
-        let raw = unsafe { std::slice::from_raw_parts(data_ptr, item_size) };
-
+        // Slice the item's BODY only. A slice spanning the header would
+        // include the flags byte, and `mark_deleted` writes that byte through
+        // an atomic after the item is published -- so merely creating such a
+        // reference is a read that races the write. Key, value and optional
+        // bytes are written before publication and never mutated, so shared
+        // references over them are honest.
         let optional_start = TtlHeader::SIZE;
         let optional_end = optional_start + header.optional_len() as usize;
         let key_start = optional_end;
@@ -405,16 +422,25 @@ impl<'a> SliceSegment<'a> {
         let value_start = key_end;
         let value_end = value_start + header.value_len() as usize;
 
-        if &raw[key_start..key_end] != key {
+        let stored_key =
+            unsafe { std::slice::from_raw_parts(data_ptr.add(key_start), key_end - key_start) };
+        let stored_value = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(value_start), value_end - value_start)
+        };
+        let stored_optional = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(optional_start), optional_end - optional_start)
+        };
+
+        if stored_key != key {
             self.ref_count.fetch_sub(1, Ordering::Release);
             return Err(CacheError::KeyMismatch);
         }
 
         Ok(BasicItemGuard::new(
             &self.ref_count,
-            &raw[key_start..key_end],
-            &raw[value_start..value_end],
-            &raw[optional_start..optional_end],
+            stored_key,
+            stored_value,
+            stored_optional,
             &self.metadata,
             self.free_queue,
             self.id,
@@ -766,8 +792,11 @@ impl SegmentKeyVerify for SliceSegment<'_> {
             let key_start = TtlHeader::SIZE + header.optional_len() as usize;
             let key_end = key_start + header.key_len() as usize;
 
-            let raw = unsafe { std::slice::from_raw_parts(data_ptr, item_size) };
-            if key_end <= raw.len() && &raw[key_start..key_end] == key {
+            // Body only -- see the note in `get_item`: a slice spanning the
+            // header would race `mark_deleted`'s write to the flags byte.
+            let stored_key =
+                unsafe { std::slice::from_raw_parts(data_ptr.add(key_start), key_end - key_start) };
+            if key_end <= item_size && stored_key == key {
                 Some((header.key_len(), header.optional_len(), header.value_len()))
             } else {
                 None
@@ -1443,7 +1472,6 @@ impl SegmentGuard for SliceSegment<'_> {
         }
 
         let data_ptr = unsafe { self.data.as_ptr().add(offset as usize) };
-        let raw = unsafe { std::slice::from_raw_parts(data_ptr, item_size) };
 
         // Compute slice boundaries from header info
         let optional_start = header_size;
@@ -1453,11 +1481,23 @@ impl SegmentGuard for SliceSegment<'_> {
         let value_start = key_end;
         let value_end = value_start + value_len as usize;
 
+        // Body only -- see the note in `get_item`: a slice spanning the header
+        // would include the flags byte that `mark_deleted` writes after
+        // publication, and creating it races that write.
+        let stored_key =
+            unsafe { std::slice::from_raw_parts(data_ptr.add(key_start), key_end - key_start) };
+        let stored_value = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(value_start), value_end - value_start)
+        };
+        let stored_optional = unsafe {
+            std::slice::from_raw_parts(data_ptr.add(optional_start), optional_end - optional_start)
+        };
+
         Ok(BasicItemGuard::new(
             &self.ref_count,
-            &raw[key_start..key_end],
-            &raw[value_start..value_end],
-            &raw[optional_start..optional_end],
+            stored_key,
+            stored_value,
+            stored_optional,
             &self.metadata,
             self.free_queue,
             self.id,


### PR DESCRIPTION
Fixes #103, and completes #88.

Widening the Miri job past its initial three filters found **three** defects. Each was invisible to the other CI jobs: TSan sees accesses, not the claims a reference makes or whether a pointer is still valid.

## 1. The free-queue pointer (#103)

`MemoryPool::build` took a raw pointer from a shared borrow of a boxed `Injector`, handed it to every segment, then kept using the `Box`. Dereferencing a `Box` asserts unique ownership, which under Stacked Borrows pops every pointer derived from it — so the pool's own `free_queue.push()` invalidated the pointer all the segments held, and every segment release pushes through it.

The queues are now `Arc` — a shared owner, which makes no such assertion — and the pointer comes from `Arc::as_ptr` rather than `&*queue`, which would narrow provenance to read-only when pushing needs write access. `FilePool` and `IoUringPool` had the identical pattern and get the same fix.

## 2. Whole-item slices spanning the flags byte — a real data race

#88 converted the header *decoders* to raw pointers but left four `from_raw_parts(data_ptr, item_size)` slices. Those span the header, and therefore the flags byte `mark_deleted` writes after publication. **Creating such a reference is itself a read**, and Miri reports it racing that write:

```
Data race detected between (1) retag read on thread `unnamed-3`
and (2) atomic read-modify-write on thread `unnamed-2`
   --> slice_segment.rs:1248   flags_atomic.fetch_or(0x40, Release)
```

This is a genuine race, not the aliasing lie #88 described — and it only became visible once fix 1 let threaded tests run under Miri. All four now slice the item's **body**: key, value and optional bytes are written before publication and never mutated, so references over them are honest.

The test that caught it is `test_increment_concurrent_no_lost_updates`, which this project's notes record as **historically flaky**. A data race in the path it exercises is a plausible cause; I have not proven that link.

## 3. `Steal::Retry` treated as "queue empty"

`Injector::steal` returns `Retry` transiently — it means "ask again", not "there is nothing here". Three sites returned `None` on it, reporting the pool exhausted while segments sat in the queue, which costs a needless eviction or allocation failure:

- `MemoryPool::reserve`
- the free-queue fallback inside `MemoryPool::reserve_spare`
- `FilePool::reserve`

All three now use the bounded retry the neighbouring loops already had. Note `reserve_spare` retried its *spare* queue and then fell through to a bare steal — the awareness existed, and two callers missed it. Same shape as #89, where one call site was fixed and its siblings were not.

## Miri scope: 3 tests → 378

Everything except `hugepage::` and the four file-mmap `disk::` modules, which are excluded for genuine limitations rather than defects — the job's comments distinguish the two. `disk::disk_segment_meta` *does* run, so #90's fixes are covered too.

421 cache-core tests, 61 loom tests, the full workspace, clippy and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu