### PR TITLE
feat(cache-core): incarnation-tagged locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
     #    which Miri does not support. Anonymous mappings are fine; file-backed
     #    ones are not. `disk::disk_segment_meta` DOES run: it allocates through
     #    the global allocator.
+    #  - `cache::tests::test_stale_location_is_rejected_on_the_disk_arms` --
+    #    same reason, but it lives outside the `disk::` modules: it builds a
+    #    DiskLayer, and therefore a file-backed FilePool, to reach the verifier's
+    #    disk arms. Module-level skips do not catch it.
     #  - `hugepage::` -- Miri accepts `mmap` only with MAP_PRIVATE|MAP_ANONYMOUS
     #    and the hugepage path adds MAP_HUGETLB. Excluded rather than worked
     #    around: unlike a prefetch, the mmap flags decide what is actually
@@ -184,7 +188,8 @@ jobs:
             --skip disk::disk_layer \
             --skip disk::io_uring \
             --skip disk::recovery \
-            --skip hugepage::
+            --skip hugepage:: \
+            --skip test_stale_location_is_rejected_on_the_disk_arms
 
   smoketest:
     name: Smoketest (${{ matrix.config }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "loom",
  "parking_lot",
  "smallvec",
+ "tempfile",
  "tikv-jemalloc-ctl",
 ]
 
@@ -1688,6 +1689,7 @@ dependencies = [
  "crossbeam-deque",
  "loom",
  "parking_lot",
+ "tempfile",
 ]
 
 [[package]]

--- a/cache/core/src/cache.rs
+++ b/cache/core/src/cache.rs
@@ -62,6 +62,19 @@ impl CacheLayer {
         dispatch!(self, layer_id())
     }
 
+    /// Get the location layout of this layer's pool.
+    ///
+    /// A location naming this layer's pool must be decoded with it: pools with
+    /// different segment sizes or alignment factors split the bits differently.
+    pub fn layout(&self) -> &crate::location_layout::LocationLayout {
+        match self {
+            CacheLayer::Fifo(layer) => layer.pool().layout(),
+            CacheLayer::Ttl(layer) => layer.pool().layout(),
+            CacheLayer::Disk(layer) => layer.pool().layout(),
+            CacheLayer::IoUringDisk(layer) => layer.pool().layout(),
+        }
+    }
+
     /// Write an item to this layer.
     pub fn write_item(
         &self,
@@ -117,11 +130,12 @@ impl CacheLayer {
                 if location.pool_id() != pool.pool_id() {
                     return None;
                 }
-                let segment = pool.get(location.segment_id())?;
+                let (_, segment_id, _, offset) = location.unpack(pool.layout());
+                let segment = pool.get(segment_id)?;
                 if !segment.state().is_readable() {
                     return None;
                 }
-                segment.get_value_ref_raw(location.offset(), key).ok()
+                segment.get_value_ref_raw(offset, key).ok()
             }};
         }
 
@@ -874,7 +888,7 @@ impl<H: Hashtable> TieredCache<H> {
         let layer = self.layers.get(layer_idx)?;
 
         // Get the segment to retrieve its generation
-        let segment = layer.get_segment(item_loc.segment_id())?;
+        let segment = layer.get_segment(item_loc.segment_id(layer.layout()))?;
         let generation = segment.generation();
 
         // Get value from layer
@@ -908,7 +922,7 @@ impl<H: Hashtable> TieredCache<H> {
         let layer = self.layers.get(layer_idx)?;
 
         // Get the segment to retrieve its generation
-        let segment = layer.get_segment(item_loc.segment_id())?;
+        let segment = layer.get_segment(item_loc.segment_id(layer.layout()))?;
         let generation = segment.generation();
 
         // Call function with value
@@ -958,7 +972,7 @@ impl<H: Hashtable> TieredCache<H> {
 
         // Get the segment to check generation
         let segment = layer
-            .get_segment(item_loc.segment_id())
+            .get_segment(item_loc.segment_id(layer.layout()))
             .ok_or(CacheError::KeyNotFound)?;
         let current_generation = segment.generation();
 
@@ -1564,8 +1578,11 @@ struct CacheKeyVerifier<'a> {
 impl KeyVerifier for CacheKeyVerifier<'_> {
     #[inline(always)]
     fn prefetch(&self, location: Location) {
-        // Unpack location to get segment and offset
-        let (pool_id, segment_id, offset) = ItemLocation::from_location(location).unpack();
+        // pool_id sits at a fixed position and decodes without a layout; the
+        // rest of the split is per-pool, so resolve the pool first and let its
+        // layout decode segment_id and offset.
+        let item_loc = ItemLocation::from_location(location);
+        let pool_id = item_loc.pool_id();
 
         // Direct pool lookup - pool_id is 2 bits (0-3), pools is [_; 4]
         // SAFETY: pool_id is extracted from ItemLocation which stores it in 2 bits
@@ -1576,18 +1593,21 @@ impl KeyVerifier for CacheKeyVerifier<'_> {
         // Get data pointer based on pool type
         let ptr = match pool_ref {
             PoolRef::Memory(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return;
                 };
                 unsafe { segment.data_ptr().add(offset as usize) }
             }
             PoolRef::Disk(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return;
                 };
                 unsafe { segment.data_ptr().add(offset as usize) }
             }
             PoolRef::IoUring(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(meta) = pool.get_meta(segment_id) else {
                     return;
                 };
@@ -1631,8 +1651,11 @@ impl KeyVerifier for CacheKeyVerifier<'_> {
 
     #[inline(always)]
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
-        // Unpack all location fields in one pass
-        let (pool_id, segment_id, offset) = ItemLocation::from_location(location).unpack();
+        // pool_id sits at a fixed position and decodes without a layout; the
+        // rest of the split is per-pool, so resolve the pool first and let its
+        // layout decode segment_id and offset.
+        let item_loc = ItemLocation::from_location(location);
+        let pool_id = item_loc.pool_id();
 
         // Direct pool lookup - pool_id is 2 bits (0-3), pools is [_; 4]
         // SAFETY: pool_id is extracted from ItemLocation which stores it in 2 bits
@@ -1646,18 +1669,21 @@ impl KeyVerifier for CacheKeyVerifier<'_> {
         // Use verify_key_at_offset from SegmentKeyVerify trait
         match pool_ref {
             PoolRef::Memory(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return false;
                 };
                 segment.verify_key_at_offset(offset, key, allow_deleted)
             }
             PoolRef::Disk(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return false;
                 };
                 segment.verify_key_at_offset(offset, key, allow_deleted)
             }
             PoolRef::IoUring(pool) => {
+                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
                 let Some(meta) = pool.get_meta(segment_id) else {
                     return false;
                 };

--- a/cache/core/src/cache.rs
+++ b/cache/core/src/cache.rs
@@ -1593,24 +1593,35 @@ impl KeyVerifier for CacheKeyVerifier<'_> {
         // Get data pointer based on pool type
         let ptr = match pool_ref {
             PoolRef::Memory(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return;
                 };
+                // Do not prefetch off a stale location either: the address it
+                // names belongs to a later incarnation's item.
+                if segment.incarnation() != incarnation {
+                    return;
+                }
                 unsafe { segment.data_ptr().add(offset as usize) }
             }
             PoolRef::Disk(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return;
                 };
+                if segment.incarnation() != incarnation {
+                    return;
+                }
                 unsafe { segment.data_ptr().add(offset as usize) }
             }
             PoolRef::IoUring(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(meta) = pool.get_meta(segment_id) else {
                     return;
                 };
+                if meta.incarnation() != incarnation {
+                    return;
+                }
                 let Some(data_ptr) = meta.write_buffer_ptr() else {
                     return;
                 };
@@ -1669,24 +1680,37 @@ impl KeyVerifier for CacheKeyVerifier<'_> {
         // Use verify_key_at_offset from SegmentKeyVerify trait
         match pool_ref {
             PoolRef::Memory(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return false;
                 };
+                // A location naming a previous incarnation of this segment is
+                // not ours to resolve: the segment was drained and refilled,
+                // and this offset now holds a different item. Checked before
+                // touching any item bytes.
+                if segment.incarnation() != incarnation {
+                    return false;
+                }
                 segment.verify_key_at_offset(offset, key, allow_deleted)
             }
             PoolRef::Disk(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(segment) = pool.get(segment_id) else {
                     return false;
                 };
+                if segment.incarnation() != incarnation {
+                    return false;
+                }
                 segment.verify_key_at_offset(offset, key, allow_deleted)
             }
             PoolRef::IoUring(pool) => {
-                let (_, segment_id, _, offset) = item_loc.unpack(pool.layout());
+                let (_, segment_id, incarnation, offset) = item_loc.unpack(pool.layout());
                 let Some(meta) = pool.get_meta(segment_id) else {
                     return false;
                 };
+                if meta.incarnation() != incarnation {
+                    return false;
+                }
                 meta.verify_key_at_offset(offset, key, allow_deleted)
             }
         }
@@ -1799,6 +1823,217 @@ mod tests {
     use super::*;
     use crate::hashtable_impl::MultiChoiceHashtable;
     use crate::layer::{FifoLayerBuilder, TtlLayerBuilder};
+
+    /// The disk arms of the hot-path verifier reject a stale tag too.
+    ///
+    /// `test_stale_location_is_rejected_after_recycle` drives the Memory arm
+    /// through a real recycle; the two disk arms need a disk pool, which the
+    /// cache's own `set` never writes to directly. Here the recycle is staged
+    /// on the pool and the location built from the live one, so the key really
+    /// is at that offset and only the tag distinguishes them.
+    #[test]
+    fn test_stale_location_is_rejected_on_the_disk_arms() {
+        use crate::disk::{DiskLayerBuilder, IoUringDiskLayerBuilder};
+        use crate::pool::RamPool;
+        use crate::segment::Segment;
+        use crate::state::State;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        let fifo_layer = FifoLayerBuilder::new()
+            .layer_id(0)
+            .pool_id(0)
+            .segment_size(64 * 1024)
+            .heap_size(256 * 1024)
+            .spare_capacity(0)
+            .build()
+            .expect("fifo layer");
+        let disk_layer = DiskLayerBuilder::new()
+            .layer_id(1)
+            .pool_id(1)
+            .segment_size(64 * 1024)
+            .path(dir.path().join("disk.dat"))
+            .size(256 * 1024)
+            .build()
+            .expect("disk layer");
+        let io_uring_layer = IoUringDiskLayerBuilder::new()
+            .layer_id(2)
+            .pool_id(2)
+            .segment_size(64 * 1024)
+            .segment_count(4)
+            .build();
+
+        // Age every disk segment through a used incarnation before anything is
+        // written, so the tag a write stamps is non-zero.
+        for _ in 0..disk_layer.pool().segment_count() {
+            let id = disk_layer.pool().reserve().expect("free segment");
+            let segment = disk_layer.pool().get(id).expect("segment");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            disk_layer.pool().release(id);
+        }
+        for _ in 0..io_uring_layer.pool().segment_count() {
+            let id = io_uring_layer.pool().reserve().expect("free segment");
+            let segment = io_uring_layer.pool().get(id).expect("segment");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            io_uring_layer.pool().release(id);
+        }
+
+        let ttl = Duration::from_secs(3600);
+        let disk_live = disk_layer
+            .write_item(b"key", b"value", b"", ttl)
+            .expect("disk write");
+        let io_uring_live = io_uring_layer
+            .write_item_with_buffers(b"key", b"value", b"", ttl)
+            .expect("io_uring write");
+
+        let disk_layout = *disk_layer.pool().layout();
+        let io_uring_layout = *io_uring_layer.pool().layout();
+
+        let cache: TieredCache<MultiChoiceHashtable> =
+            TieredCacheBuilder::new(Arc::new(MultiChoiceHashtable::new(10)))
+                .with_fifo_layer(fifo_layer)
+                .with_disk_layer(disk_layer)
+                .with_io_uring_disk_layer(io_uring_layer)
+                .build();
+
+        for (label, live, layout) in [
+            ("Disk", disk_live, disk_layout),
+            ("IoUring", io_uring_live, io_uring_layout),
+        ] {
+            let (pool_id, segment_id, tag, offset) = live.unpack(&layout);
+            assert_ne!(
+                tag, 0,
+                "{label}: the segment must be past its first incarnation"
+            );
+            let stale = ItemLocation::new(&layout, pool_id, segment_id, tag - 1, offset);
+
+            assert!(
+                cache
+                    .create_key_verifier()
+                    .verify(b"key", live.to_location(), false),
+                "{label}: the current incarnation must resolve"
+            );
+            assert!(
+                !cache
+                    .create_key_verifier()
+                    .verify(b"key", stale.to_location(), false),
+                "{label}: a location from a previous incarnation must not resolve"
+            );
+        }
+    }
+
+    /// A cache whose FIFO layer holds one big item per segment, so writing the
+    /// same key repeatedly cycles segments and eventually reuses one.
+    fn create_recycling_test_cache() -> TieredCache<MultiChoiceHashtable> {
+        let hashtable = Arc::new(MultiChoiceHashtable::new(10));
+
+        let fifo_layer = FifoLayerBuilder::new()
+            .layer_id(0)
+            .pool_id(0)
+            .segment_size(1024)
+            .heap_size(4 * 1024) // 4 segments
+            .spare_capacity(0)
+            .build()
+            .expect("Failed to create FIFO layer");
+
+        TieredCacheBuilder::new(hashtable)
+            .with_fifo_layer(fifo_layer)
+            .eviction_threshold(1)
+            .build()
+    }
+
+    /// A location held across a segment recycle must stop resolving.
+    ///
+    /// This is the crucible#88 hazard, and the shape matters: segments are
+    /// append-only from a fixed start, so with uniform item sizes the n-th item
+    /// of every incarnation lands at the same offset. A stale location does not
+    /// merely point at free space -- it points at a *different live item*, and
+    /// here at one with the very same key. The key compare alone would resolve
+    /// it. Only the incarnation tag can tell the two apart.
+    #[test]
+    fn test_stale_location_is_rejected_after_recycle() {
+        let cache = create_recycling_test_cache();
+        let ttl = Duration::from_secs(60);
+
+        // One item per segment: 600 bytes of value leaves no room for a second.
+        let value = vec![b'v'; 600];
+
+        cache.set(b"key", &value, b"", ttl).unwrap();
+        let (stale_raw, _) = cache
+            .hashtable
+            .lookup(b"key", &cache.create_key_verifier())
+            .expect("key should be present");
+        let stale = ItemLocation::from_location(stale_raw);
+
+        // Sanity: it resolves now, so a later rejection means something.
+        assert!(
+            cache.create_key_verifier().verify(b"key", stale_raw, false),
+            "the location must resolve before any recycle"
+        );
+
+        let pool = match &cache.layers[0] {
+            CacheLayer::Fifo(layer) => layer.pool(),
+            _ => unreachable!("layer 0 is the FIFO layer"),
+        };
+        let (_, stale_segment, stale_tag, stale_offset) = stale.unpack(pool.layout());
+
+        // Rewrite the same key until the pool cycles back to that segment.
+        // Four segments and one item each, so a handful of rounds suffices;
+        // the loop is bounded generously and the guards below prove it ran.
+        let mut recycled = false;
+        for _ in 0..64 {
+            cache.set(b"key", &value, b"", ttl).unwrap();
+
+            let segment = pool
+                .get(stale_segment)
+                .expect("segment id came from a location");
+            if segment.incarnation() != stale_tag
+                && segment.verify_key_at_offset(stale_offset, b"key", false)
+            {
+                recycled = true;
+                break;
+            }
+        }
+
+        // Vacuity guards. Without the first, a loop that never recycled the
+        // segment would pass while proving nothing. Without the second, the
+        // rejection could come from the key compare rather than the tag.
+        assert!(
+            recycled,
+            "no recycle placed a matching key back at that offset; the test is vacuous"
+        );
+        let segment = pool.get(stale_segment).expect("segment");
+        assert_ne!(
+            segment.incarnation(),
+            stale_tag,
+            "the segment was not recycled; the test is vacuous"
+        );
+        assert!(
+            segment.verify_key_at_offset(stale_offset, b"key", false),
+            "the offset must hold a live matching key, or the key compare alone \
+             would reject and this test proves nothing"
+        );
+
+        assert!(
+            !cache.create_key_verifier().verify(b"key", stale_raw, false),
+            "a location from a previous incarnation must not resolve"
+        );
+
+        // ...and the live location still does.
+        let live = ItemLocation::new(
+            pool.layout(),
+            pool.pool_id(),
+            stale_segment,
+            segment.incarnation(),
+            stale_offset,
+        );
+        assert!(
+            cache
+                .create_key_verifier()
+                .verify(b"key", live.to_location(), false),
+            "the current incarnation must still resolve"
+        );
+    }
 
     fn create_test_cache() -> TieredCache<MultiChoiceHashtable> {
         let hashtable = Arc::new(MultiChoiceHashtable::new(10)); // 2^10 = 1024 buckets

--- a/cache/core/src/cache_trait.rs
+++ b/cache/core/src/cache_trait.rs
@@ -5,7 +5,7 @@
 //! protocol servers like iou-cache and tokio-cache.
 
 use crate::error::CacheError;
-use crate::state::{Metadata, State};
+use crate::state::{INVALID_SEGMENT_ID, Metadata, State};
 use crate::sync::{AtomicU32, AtomicU64, Ordering};
 use bytes::Bytes;
 use std::time::Duration;
@@ -227,8 +227,13 @@ impl Drop for ValueRef {
             let packed = unsafe { (*self.metadata).load(Ordering::Acquire) };
             let meta = Metadata::unpack(packed);
             if meta.state == State::AwaitingRelease {
-                // Try to transition AwaitingRelease -> Free
-                let new_meta = Metadata::new(State::Free);
+                // Try to transition AwaitingRelease -> Free.
+                // Preserve the incarnation: freeing a condemned segment is
+                // Task 3's business, and zeroing here would resurrect stale
+                // locations naming this segment.
+                let new_meta = meta
+                    .with_state(State::Free)
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
                 if unsafe {
                     (*self.metadata).compare_exchange(
                         packed,
@@ -756,6 +761,48 @@ pub enum LookupResult {
 #[cfg(all(test, not(feature = "loom")))]
 mod tests {
     use super::*;
+
+    /// `ValueRef::drop` frees a condemned segment, and must carry the
+    /// incarnation forward while doing so.
+    ///
+    /// The third copy of the `AwaitingRelease -> Free` transition, reachable
+    /// only through `Drop`, so no segment-level test touches it.
+    #[test]
+    fn test_value_ref_drop_preserves_incarnation() {
+        const TAG: u8 = 42;
+
+        let ref_count = AtomicU32::new(1);
+        let free_queue = crossbeam_deque::Injector::new();
+        let metadata = AtomicU64::new(
+            Metadata {
+                next: INVALID_SEGMENT_ID,
+                prev: INVALID_SEGMENT_ID,
+                state: State::AwaitingRelease,
+                incarnation: TAG,
+            }
+            .pack(),
+        );
+        let value = [1u8, 2, 3];
+
+        // SAFETY: every pointer outlives the ValueRef, and ref_count starts at
+        // 1 to stand for this reader.
+        let value_ref = unsafe {
+            ValueRef::new(
+                &ref_count,
+                value.as_ptr(),
+                value.len(),
+                &metadata,
+                &free_queue,
+                7,
+            )
+        };
+        drop(value_ref);
+
+        let meta = Metadata::unpack(metadata.load(Ordering::Acquire));
+        assert_eq!(meta.state, State::Free, "the last reader must free it");
+        assert_eq!(meta.incarnation, TAG, "ValueRef drop reset the tag");
+        assert_eq!(free_queue.len(), 1, "the segment must reach the free queue");
+    }
 
     #[test]
     fn test_owned_guard_new() {

--- a/cache/core/src/cache_trait.rs
+++ b/cache/core/src/cache_trait.rs
@@ -227,13 +227,22 @@ impl Drop for ValueRef {
             let packed = unsafe { (*self.metadata).load(Ordering::Acquire) };
             let meta = Metadata::unpack(packed);
             if meta.state == State::AwaitingRelease {
-                // Try to transition AwaitingRelease -> Free.
-                // Preserve the incarnation: freeing a condemned segment is
-                // Task 3's business, and zeroing here would resurrect stale
-                // locations naming this segment.
+                // AwaitingRelease -> Free ends a used incarnation, so the tag
+                // advances in the same CAS that publishes Free.
+                //
+                // This is the *main* condemned-free path, not an edge case: the
+                // layers condemn a segment with readers outstanding and leave
+                // the last guard drop to free it, calling `release_condemned`
+                // only as a fallback when the last reader vanished during the
+                // condemn window. A reader holding a location across this
+                // recycle is exactly what the tag defends against.
+                //
+                // `with_chain_ids` must stay: returning a freed segment to the
+                // free queue still linked to its neighbours is its own defect.
                 let new_meta = meta
                     .with_state(State::Free)
-                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+                    .bump_incarnation();
                 if unsafe {
                     (*self.metadata).compare_exchange(
                         packed,
@@ -762,13 +771,21 @@ pub enum LookupResult {
 mod tests {
     use super::*;
 
-    /// `ValueRef::drop` frees a condemned segment, and must carry the
-    /// incarnation forward while doing so.
+    /// `ValueRef::drop` frees a condemned segment, ending a used incarnation,
+    /// so the tag must advance.
     ///
-    /// The third copy of the `AwaitingRelease -> Free` transition, reachable
-    /// only through `Drop`, so no segment-level test touches it.
+    /// The fourth copy of the `AwaitingRelease -> Free` transition, reachable
+    /// only through `Drop`, so no segment-level test touches it -- and the
+    /// dominant one on the zero-copy read path: the layers condemn a segment
+    /// with readers outstanding and leave the last `ValueRef` drop to free it.
+    /// A reader holding a location across that recycle is exactly what the tag
+    /// defends against.
+    ///
+    /// Seeding a nonzero tag rather than starting from 0 is what distinguishes
+    /// a bump from a site that rebuilds `Metadata` from scratch: the latter
+    /// would land on 1, not 43.
     #[test]
-    fn test_value_ref_drop_preserves_incarnation() {
+    fn test_value_ref_drop_bumps_the_incarnation() {
         const TAG: u8 = 42;
 
         let ref_count = AtomicU32::new(1);
@@ -800,7 +817,11 @@ mod tests {
 
         let meta = Metadata::unpack(metadata.load(Ordering::Acquire));
         assert_eq!(meta.state, State::Free, "the last reader must free it");
-        assert_eq!(meta.incarnation, TAG, "ValueRef drop reset the tag");
+        assert_eq!(
+            meta.incarnation,
+            TAG + 1,
+            "ValueRef drop must end the incarnation, carrying the tag forward"
+        );
         assert_eq!(free_queue.len(), 1, "the segment must reach the free queue");
     }
 

--- a/cache/core/src/disk/disk_layer.rs
+++ b/cache/core/src/disk/disk_layer.rs
@@ -70,8 +70,9 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        if let Some(segment) = self.pool.get(item_loc.segment_id()) {
-            segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        let layout = self.pool.layout();
+        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
+            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
         } else {
             false
         }
@@ -193,7 +194,13 @@ impl DiskLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
                         hashtable.remove(key, location.to_location());
                     }
 
@@ -240,7 +247,13 @@ impl DiskLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         let verifier = SinglePoolVerifier { pool: &self.pool };
                         let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -345,7 +358,13 @@ impl Layer for DiskLayer {
 
             if let Some(segment) = self.pool.get(segment_id) {
                 if let Some(offset) = segment.append_item(key, value, optional) {
-                    return Ok(ItemLocation::new(self.pool.pool_id(), segment_id, offset));
+                    return Ok(ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    ));
                 }
 
                 // Segment is full
@@ -368,7 +387,8 @@ impl Layer for DiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
 
         let state = segment.state();
         if !state.is_readable() {
@@ -383,11 +403,9 @@ impl Layer for DiskLayer {
         }
 
         // Verify key matches
-        let header_info = segment.verify_key_unexpired(location.offset(), key, now)?;
+        let header_info = segment.verify_key_unexpired(offset, key, now)?;
 
-        segment
-            .get_item_verified(location.offset(), header_info)
-            .ok()
+        segment.get_item_verified(offset, header_info).ok()
     }
 
     fn mark_deleted(&self, location: ItemLocation) {
@@ -395,17 +413,15 @@ impl Layer for DiskLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
-            let offset = location.offset();
-            if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE)
-                && let Some(header) = unsafe { BasicHeader::try_from_ptr(data) }
-            {
-                let key_start =
-                    offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
-                let key_len = header.key_len() as usize;
-                if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                    let _ = segment.mark_deleted(offset, key);
-                }
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id)
+            && let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE)
+            && let Some(header) = unsafe { BasicHeader::try_from_ptr(data) }
+        {
+            let key_start = offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
+            let key_len = header.key_len() as usize;
+            if let Some(key) = segment.data_slice(key_start as u32, key_len) {
+                let _ = segment.mark_deleted(offset, key);
             }
         }
     }
@@ -415,7 +431,7 @@ impl Layer for DiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let segment = self.pool.get(location.segment_id(self.pool.layout()))?;
         let now = Self::now_secs();
         segment.segment_ttl(now)
     }
@@ -478,7 +494,13 @@ impl Layer for DiskLayer {
                 if let Some((offset, item_size, value_ptr)) =
                     segment.begin_append(key, value_len, optional)
                 {
-                    let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                    let location = ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    );
                     return Ok((location, value_ptr, item_size));
                 }
 
@@ -500,7 +522,7 @@ impl Layer for DiskLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        if let Some(segment) = self.pool.get(location.segment_id(self.pool.layout())) {
             segment.finalize_append(item_size);
         }
     }
@@ -510,8 +532,9 @@ impl Layer for DiskLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
-            segment.mark_deleted_at_offset(location.offset());
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            segment.mark_deleted_at_offset(offset);
         }
     }
 

--- a/cache/core/src/disk/disk_layer.rs
+++ b/cache/core/src/disk/disk_layer.rs
@@ -70,9 +70,15 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let layout = self.pool.layout();
-        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
-            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
+            segment.verify_key_at_offset(offset, key, allow_deleted)
         } else {
             false
         }
@@ -779,6 +785,49 @@ mod tests {
 
         layer.process_evicted_segment(segment_id, &hashtable);
         assert_all_removed(&layer, &hashtable, &keys);
+    }
+
+    /// A location from a previous incarnation must not resolve, even though
+    /// the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_verifier_rejects_a_stale_incarnation() {
+        let (_dir, layer) = create_test_layer();
+        let pool = &layer.pool;
+
+        // Age every segment through a used incarnation, so the tag the write
+        // stamps is non-zero and a predecessor tag exists to test against.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+        }
+
+        let live = layer
+            .write_item(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write");
+        let layout = pool.layout();
+        let (pool_id, segment_id, tag, offset) = live.unpack(layout);
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        // Same segment, same offset, previous tag.
+        let stale = ItemLocation::new(layout, pool_id, segment_id, tag - 1, offset);
+        let verifier = SinglePoolVerifier { pool };
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
     }
 
     #[test]

--- a/cache/core/src/disk/disk_layer.rs
+++ b/cache/core/src/disk/disk_layer.rs
@@ -185,7 +185,10 @@ impl DiskLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let key_start =
                         offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -238,7 +241,10 @@ impl DiskLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let key_start =
                         offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -674,6 +680,7 @@ impl Default for DiskLayerBuilder {
 #[cfg(all(test, not(feature = "loom")))]
 mod tests {
     use super::*;
+    use crate::hashtable_impl::MultiChoiceHashtable;
     use crate::item::ItemGuard;
     use tempfile::tempdir;
 
@@ -692,6 +699,86 @@ mod tests {
             .expect("Failed to create test layer");
 
         (dir, layer)
+    }
+
+    /// Fill one segment with `ITEMS` items and index them, returning the keys
+    /// and the segment they share.
+    fn fill_one_segment(layer: &DiskLayer, hashtable: &MultiChoiceHashtable) -> (Vec<String>, u32) {
+        let verifier = SinglePoolVerifier { pool: &layer.pool };
+        let ttl = Duration::from_secs(3600);
+
+        const ITEMS: usize = 5;
+        let mut keys = Vec::new();
+        let mut segment_id = None;
+        for i in 0..ITEMS {
+            let key = format!("key_{i:02}");
+            let location = layer
+                .write_item(key.as_bytes(), b"value", b"", ttl)
+                .expect("write");
+            hashtable
+                .insert(key.as_bytes(), location.to_location(), &verifier)
+                .expect("insert");
+            let id = location.segment_id(layer.pool.layout());
+            assert_eq!(
+                *segment_id.get_or_insert(id),
+                id,
+                "all items must share one segment for this to test the walk"
+            );
+            keys.push(key);
+        }
+        (keys, segment_id.expect("at least one item"))
+    }
+
+    fn assert_all_removed(layer: &DiskLayer, hashtable: &MultiChoiceHashtable, keys: &[String]) {
+        let verifier = SinglePoolVerifier { pool: &layer.pool };
+        for key in keys {
+            assert!(
+                hashtable.lookup(key.as_bytes(), &verifier).is_none(),
+                "{key} survived the walk -- it stopped short of that item"
+            );
+        }
+    }
+
+    /// Draining a pinned segment must visit every item, at the pool's stride.
+    ///
+    /// Disk pools align items to 512 bytes while `BasicHeader::padded_size()`
+    /// rounds to 8. A walk that advances by the latter lands mid-item on its
+    /// second iteration, reads a garbage header and stops -- silently, since
+    /// both quantities are `u32`. Hashtable entries left behind after the
+    /// segment is recycled is what that failure looks like from the outside.
+    #[test]
+    fn test_draining_a_segment_walks_every_item_at_the_disk_stride() {
+        let (_dir, layer) = create_test_layer();
+        assert_eq!(
+            layer.pool.layout().align_bytes(),
+            512,
+            "disk pools align to a sector"
+        );
+
+        let hashtable = MultiChoiceHashtable::new(10);
+        let (keys, segment_id) = fill_one_segment(&layer, &hashtable);
+
+        layer.drain_segment_from_hashtable(segment_id, &hashtable);
+        assert_all_removed(&layer, &hashtable, &keys);
+    }
+
+    /// The same for the unpinned path, which walks the segment itself rather
+    /// than deferring to `drain_segment_from_hashtable`.
+    #[test]
+    fn test_evicting_a_segment_walks_every_item_at_the_disk_stride() {
+        let (_dir, layer) = create_test_layer();
+
+        let hashtable = MultiChoiceHashtable::new(10);
+        let (keys, segment_id) = fill_one_segment(&layer, &hashtable);
+
+        // The eviction path leaves its victim in `Draining`, which is the
+        // state `process_evicted_segment` expects.
+        let segment = layer.pool.get(segment_id).expect("segment");
+        let state = segment.state();
+        assert!(segment.cas_metadata(state, State::Draining, None, None));
+
+        layer.process_evicted_segment(segment_id, &hashtable);
+        assert_all_removed(&layer, &hashtable, &keys);
     }
 
     #[test]

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -224,6 +224,11 @@ impl DiskSegmentMeta {
 }
 
 impl SegmentKeyVerify for DiskSegmentMeta {
+    #[inline]
+    fn incarnation(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
+    }
+
     fn verify_key_at_offset(&self, offset: u32, key: &[u8], allow_deleted: bool) -> bool {
         // When write buffer has been flushed to disk, we can't verify the key
         // in RAM. Trust the hashtable tag match — the server will verify the
@@ -335,11 +340,6 @@ impl Segment for DiskSegmentMeta {
 
     fn increment_generation(&self) {
         self.generation.fetch_add(1, Ordering::Release);
-    }
-
-    #[inline]
-    fn incarnation(&self) -> u8 {
-        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
     }
 
     #[inline]

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -411,11 +411,8 @@ impl Segment for DiskSegmentMeta {
         let next = new_next.unwrap_or(meta.next);
         let prev = new_prev.unwrap_or(meta.prev);
 
-        let new_meta = Metadata {
-            next,
-            prev,
-            state: new_state,
-        };
+        // Preserve the incarnation: a chain/state CAS never ends one.
+        let new_meta = meta.with_state(new_state).with_chain_ids(next, prev);
 
         self.metadata
             .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -880,20 +880,34 @@ mod tests {
     ///
     /// Returns the pool and injector alongside it because both must outlive
     /// the segment — the segment holds a raw pointer to the injector.
+    ///
+    /// `Arc`, not `Box`, for the reason `MemoryPool::free_queue` documents:
+    /// the segment holds a raw pointer into this queue and pushes itself back
+    /// on release, and moving a `Box` is a `Unique` retag that pops every
+    /// pointer derived from it. Miri caught exactly that here — returning the
+    /// `Box` invalidated the pointer the segment was holding, and
+    /// `release_condemned`'s `(*self.free_queue).push` then dereferenced it.
     fn segment_with_item(
         key: &[u8],
         value: &[u8],
     ) -> (
         DiskSegmentMeta,
         AlignedBufferPool,
-        Box<crossbeam_deque::Injector<u32>>,
+        std::sync::Arc<crossbeam_deque::Injector<u32>>,
     ) {
         let capacity = 4096usize;
         let mut pool = AlignedBufferPool::new(1, capacity, 512);
         let buf = pool.allocate().expect("one slot must be available");
-        let injector = Box::new(crossbeam_deque::Injector::new());
+        let injector = std::sync::Arc::new(crossbeam_deque::Injector::new());
 
-        let seg = DiskSegmentMeta::new(0, 0, capacity as u32, 0, &*injector, 512);
+        let seg = DiskSegmentMeta::new(
+            0,
+            0,
+            capacity as u32,
+            0,
+            std::sync::Arc::as_ptr(&injector),
+            512,
+        );
         seg.attach_write_buffer(buf);
 
         let header = BasicHeader::new(key.len() as u8, 0, value.len() as u32);
@@ -915,19 +929,28 @@ mod tests {
     ///
     /// Separate from `segment_with_item` because these tests append through the
     /// real path rather than writing a header by hand.
+    ///
+    /// `Arc` for the same reason as `segment_with_item`.
     fn segment_with_alignment(
         capacity: usize,
         align: usize,
     ) -> (
         DiskSegmentMeta,
         AlignedBufferPool,
-        Box<crossbeam_deque::Injector<u32>>,
+        std::sync::Arc<crossbeam_deque::Injector<u32>>,
     ) {
         let mut pool = AlignedBufferPool::new(1, capacity, 512);
         let buf = pool.allocate().expect("one slot must be available");
-        let injector = Box::new(crossbeam_deque::Injector::new());
+        let injector = std::sync::Arc::new(crossbeam_deque::Injector::new());
 
-        let seg = DiskSegmentMeta::new(0, 0, capacity as u32, 0, &*injector, align);
+        let seg = DiskSegmentMeta::new(
+            0,
+            0,
+            capacity as u32,
+            0,
+            std::sync::Arc::as_ptr(&injector),
+            align,
+        );
         seg.attach_write_buffer(buf);
         (seg, pool, injector)
     }

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -452,12 +452,19 @@ impl Segment for DiskSegmentMeta {
 
         let new_meta = meta.with_state(new_state).with_chain_ids(next, prev);
 
-        // Leaving `Locked` ends a used incarnation: the layers recycle a
-        // drained segment as `Locked -> Reserved` before releasing it
-        // `Reserved -> Free`. Bumping inside the same CAS that publishes the
-        // new state means no thread can observe the new state paired with the
-        // old tag. Every other transition is mid-life and preserves the tag.
-        let new_meta = if meta.state == State::Locked {
+        // *Leaving* `Locked` ends a used incarnation -- not merely being
+        // `Locked`. The layers recycle a drained segment as
+        // `Locked -> Reserved` before releasing it `Reserved -> Free`. Bumping
+        // inside the same CAS that publishes the new state means no thread can
+        // observe the new state paired with the old tag.
+        //
+        // The `new_state != Locked` half is load-bearing: a chain-pointer-only
+        // rewrite that stays in `Locked` is mid-life, and eleven identity CASes
+        // in `organization/` take exactly that shape. Keying on the source
+        // state alone would advance the tag twice in one lifetime, halving the
+        // space the collision argument rests on. Every other transition is
+        // mid-life and preserves the tag.
+        let new_meta = if meta.state == State::Locked && new_state != State::Locked {
             new_meta.bump_incarnation()
         } else {
             new_meta
@@ -1087,6 +1094,30 @@ mod tests {
             seg.incarnation(),
             4,
             "transitions into Locked are mid-life and must not bump"
+        );
+
+        // A chain-pointer-only rewrite that stays in Locked is mid-life, not
+        // the end of an incarnation. Eleven identity CASes in organization/
+        // take this shape; if one ever ran against a Locked neighbour, keying
+        // the bump on the source state alone would advance the tag twice in
+        // one lifetime.
+        let before = seg.incarnation();
+        assert!(seg.cas_metadata(State::Locked, State::Locked, Some(7), None));
+        assert_eq!(
+            seg.incarnation(),
+            before,
+            "a Locked -> Locked chain rewrite must not bump"
+        );
+        assert_eq!(
+            seg.next(),
+            Some(7),
+            "the chain pointer must still be written"
+        );
+        assert!(seg.try_release());
+        assert_eq!(
+            seg.incarnation(),
+            before + 1,
+            "leaving Locked must still bump exactly once"
         );
     }
 

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -326,6 +326,11 @@ impl Segment for DiskSegmentMeta {
     }
 
     #[inline]
+    fn incarnation(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
+    }
+
+    #[inline]
     fn capacity(&self) -> usize {
         self.capacity as usize
     }
@@ -389,11 +394,21 @@ impl Segment for DiskSegmentMeta {
         match meta.state {
             State::Free => false, // Already free (idempotent)
             State::Reserved | State::Linking | State::Locked => {
-                // Preserve the incarnation; Task 3 decides which transitions
-                // bump.
+                // Leaving `Locked` ends a used incarnation: the segment has
+                // been drained and cleared. `Reserved` and `Linking` must NOT
+                // bump -- `FilePool::release` returns never-used segments
+                // through here, and bumping there would advance a 6-bit tag at
+                // a rate decoupled from segment lifecycles.
+                let ends_incarnation = meta.state == State::Locked;
+
                 let new_meta = meta
                     .with_state(State::Free)
                     .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+                let new_meta = if ends_incarnation {
+                    new_meta.bump_incarnation()
+                } else {
+                    new_meta
+                };
                 self.metadata
                     .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
                     .is_ok()
@@ -419,8 +434,18 @@ impl Segment for DiskSegmentMeta {
         let next = new_next.unwrap_or(meta.next);
         let prev = new_prev.unwrap_or(meta.prev);
 
-        // Preserve the incarnation: a chain/state CAS never ends one.
         let new_meta = meta.with_state(new_state).with_chain_ids(next, prev);
+
+        // Leaving `Locked` ends a used incarnation: the layers recycle a
+        // drained segment as `Locked -> Reserved` before releasing it
+        // `Reserved -> Free`. Bumping inside the same CAS that publishes the
+        // new state means no thread can observe the new state paired with the
+        // old tag. Every other transition is mid-life and preserves the tag.
+        let new_meta = if meta.state == State::Locked {
+            new_meta.bump_incarnation()
+        } else {
+            new_meta
+        };
 
         self.metadata
             .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
@@ -439,10 +464,13 @@ impl Segment for DiskSegmentMeta {
             return false;
         }
 
-        // Preserve the incarnation; Task 3 decides which transitions bump.
+        // `AwaitingRelease -> Free` is unconditionally the end of a used
+        // incarnation: the segment was condemned while live and its last reader
+        // has just dropped. Always bump.
         let new_meta = meta
             .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
         if self
             .metadata
             .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
@@ -772,11 +800,14 @@ impl Segment for DiskSegmentMeta {
             .store(Self::INVALID_BUCKET_ID, Ordering::Release);
         self.merge_count.store(0, Ordering::Relaxed);
 
-        // Stores unconditionally, so load first to carry the incarnation
-        // forward -- exactly as `SliceSegment::force_free` does.
+        // Stores unconditionally, so load first to advance the incarnation
+        // rather than clobber it -- exactly as `SliceSegment::force_free` does.
+        // A bulk reset recycles the segment, so locations issued before it must
+        // stop resolving.
         let new_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire))
             .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
         self.metadata.store(new_meta.pack(), Ordering::Release);
     }
 }
@@ -810,18 +841,6 @@ impl DiskSegmentMeta {
                 }
             }
         }
-    }
-}
-
-/// Test-only accessors.
-///
-/// `Segment::incarnation()` arrives in Task 3 alongside the bump sites; this
-/// must not anticipate it, hence a private helper rather than a trait method.
-#[cfg(all(test, not(feature = "loom")))]
-impl DiskSegmentMeta {
-    /// The incarnation currently stored in the packed metadata word.
-    fn incarnation_for_test(&self) -> u8 {
-        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
     }
 }
 
@@ -865,6 +884,106 @@ mod tests {
         (seg, pool, injector)
     }
 
+    /// The disk twin of the slice-segment bump table: the incarnation advances
+    /// on exactly the transitions that end a *used* incarnation, and no others.
+    ///
+    /// The eviction path recycles a drained segment as `Locked -> Reserved` and
+    /// only then releases it `Reserved -> Free`, so keying the bump on
+    /// `Locked -> Free` -- which the layers never drive -- would leave the tag
+    /// at 0 forever with the whole suite still green. Keying on *leaving
+    /// Locked* is what makes it fire.
+    ///
+    /// The exclusions matter just as much: `FilePool::release` returns
+    /// never-used segments through `try_release`, and a bump there would drain
+    /// the 6-bit tag's collision hardness with no item lifecycle at all.
+    #[test]
+    fn test_disk_incarnation_bumps_on_exactly_the_used_incarnation_transitions() {
+        let (seg, _pool, _injector) = segment_with_item(b"k", b"v");
+        assert_eq!(seg.incarnation(), 0);
+
+        // Free -> Reserved starts an incarnation. Must NOT bump.
+        assert!(seg.try_reserve());
+        assert_eq!(seg.incarnation(), 0, "try_reserve must not bump");
+
+        // Reserved -> Free: reserved but never used. Must NOT bump.
+        assert!(seg.try_release());
+        assert_eq!(
+            seg.incarnation(),
+            0,
+            "Reserved -> Free is a never-used release and must not bump"
+        );
+
+        // Linking -> Free: lost a chain-extension election. Must NOT bump.
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::Linking, None, None));
+        assert!(seg.try_release());
+        assert_eq!(
+            seg.incarnation(),
+            0,
+            "Linking -> Free is a lost election and must not bump"
+        );
+
+        // Locked -> Reserved: THE REAL RECYCLE PATH. Must bump.
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(seg.cas_metadata(State::Locked, State::Reserved, None, None));
+        assert_eq!(
+            seg.incarnation(),
+            1,
+            "Locked -> Reserved is how a drained segment is recycled and must bump"
+        );
+
+        // The Reserved -> Free that follows must not bump again -- one
+        // incarnation ending is one bump, not two.
+        assert!(seg.try_release());
+        assert_eq!(
+            seg.incarnation(),
+            1,
+            "the release following a recycle must not double-bump"
+        );
+
+        // Locked -> Free: the other way out of Locked. Must bump.
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(seg.try_release());
+        assert_eq!(
+            seg.incarnation(),
+            2,
+            "Locked -> Free also ends a used incarnation and must bump"
+        );
+
+        // AwaitingRelease -> Free: condemned. Must bump.
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert!(seg.release_condemned());
+        assert_eq!(
+            seg.incarnation(),
+            3,
+            "AwaitingRelease -> Free ends a used incarnation and must bump"
+        );
+
+        // Bulk reset recycles the segment. Must bump.
+        assert!(seg.try_reserve());
+        seg.reset();
+        assert_eq!(
+            seg.incarnation(),
+            4,
+            "reset recycles the segment and must bump"
+        );
+        assert_eq!(seg.state(), State::Free);
+
+        // Sealed -> Draining and Draining -> Locked are mid-life. Must NOT bump.
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::Sealed, None, None));
+        assert!(seg.cas_metadata(State::Sealed, State::Draining, None, None));
+        assert!(seg.cas_metadata(State::Draining, State::Locked, None, None));
+        assert_eq!(
+            seg.incarnation(),
+            4,
+            "transitions into Locked are mid-life and must not bump"
+        );
+    }
+
     /// Every disk-segment transition must carry the incarnation forward.
     ///
     /// `Metadata::new` zeroes it and compiles clean, so nothing but this test
@@ -872,16 +991,20 @@ mod tests {
     /// stale locations rather than failing loudly. This is the disk twin of
     /// `slice_segment.rs`'s `test_segment_transitions_preserve_incarnation`;
     /// its absence is why these sites went unnoticed.
+    ///
+    /// This pins *preservation* for the transitions that do not end an
+    /// incarnation. `release_condemned` and `reset` do end one and now bump;
+    /// they are still checked here, relative to the seeded tag, because a site
+    /// that rebuilt `Metadata` from scratch and then bumped would land on 1
+    /// rather than `TAG + 1`. Which transitions bump is pinned separately by
+    /// `slice_segment.rs`'s
+    /// `test_incarnation_bumps_on_exactly_the_used_incarnation_transitions`.
     #[test]
     fn test_disk_segment_transitions_preserve_incarnation() {
         const TAG: u8 = 42;
 
         let (seg, _pool, _injector) = segment_with_item(b"k", b"v");
-        assert_eq!(
-            seg.incarnation_for_test(),
-            0,
-            "a brand-new segment starts at 0"
-        );
+        assert_eq!(seg.incarnation(), 0, "a brand-new segment starts at 0");
 
         // Seed a non-zero tag directly, the way a prior incarnation's release
         // would have left it.
@@ -897,31 +1020,31 @@ mod tests {
 
         // Free -> Reserved
         assert!(seg.try_reserve());
-        assert_eq!(seg.incarnation_for_test(), TAG, "try_reserve reset the tag");
+        assert_eq!(seg.incarnation(), TAG, "try_reserve reset the tag");
 
         // Reserved -> Free
         assert!(seg.try_release());
-        assert_eq!(seg.incarnation_for_test(), TAG, "try_release reset the tag");
+        assert_eq!(seg.incarnation(), TAG, "try_release reset the tag");
 
         // Reserved -> AwaitingRelease -> Free
         assert!(seg.try_reserve());
         assert!(seg.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
-        assert_eq!(
-            seg.incarnation_for_test(),
-            TAG,
-            "cas_metadata reset the tag"
-        );
+        assert_eq!(seg.incarnation(), TAG, "cas_metadata reset the tag");
+        // `release_condemned` ends a used incarnation, so it bumps; what is
+        // pinned here is that it bumps from the seeded tag rather than
+        // rebuilding the word from scratch, which would land on 1.
         assert!(seg.release_condemned());
         assert_eq!(
-            seg.incarnation_for_test(),
-            TAG,
-            "release_condemned reset the tag"
+            seg.incarnation(),
+            TAG + 1,
+            "release_condemned did not carry the tag forward"
         );
 
-        // Unconditional store back to Free
+        // Unconditional store back to Free. Also an incarnation-ending
+        // transition, so it bumps rather than preserves.
         assert!(seg.try_reserve());
         seg.reset();
-        assert_eq!(seg.incarnation_for_test(), TAG, "reset cleared the tag");
+        assert_eq!(seg.incarnation(), TAG + 2, "reset cleared the tag");
     }
 
     /// A key LONGER than the stored one must not match, even when the bytes

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -55,6 +55,12 @@ pub struct DiskSegmentMeta {
     /// Pool ID (0-3).
     pool_id: u8,
 
+    /// `log2` of the owning pool's offset alignment factor.
+    ///
+    /// Appends stride by `1 << align_shift`, because a `Location` stores
+    /// `offset / align_bytes` and cannot name a finer offset.
+    align_shift: u8,
+
     /// Segment-level expiration time (coarse seconds since epoch).
     expire_at: AtomicU32,
 
@@ -103,8 +109,13 @@ impl DiskSegmentMeta {
         capacity: u32,
         disk_offset: u64,
         free_queue: *const crossbeam_deque::Injector<u32>,
+        align_bytes: usize,
     ) -> Self {
         debug_assert!(pool_id <= 3, "pool_id {} exceeds 2-bit limit", pool_id);
+        debug_assert!(
+            align_bytes.is_power_of_two() && align_bytes >= 8,
+            "align_bytes {align_bytes} must be a power of two and at least 8"
+        );
 
         let initial_meta = Metadata::new(State::Free);
 
@@ -117,6 +128,7 @@ impl DiskSegmentMeta {
             id,
             capacity,
             pool_id,
+            align_shift: align_bytes.trailing_zeros() as u8,
             expire_at: AtomicU32::new(0),
             bucket_id: AtomicU16::new(Self::INVALID_BUCKET_ID),
             merge_count: AtomicU16::new(0),
@@ -331,6 +343,10 @@ impl Segment for DiskSegmentMeta {
     }
 
     #[inline]
+    fn align_bytes(&self) -> u32 {
+        1 << self.align_shift
+    }
+
     fn capacity(&self) -> usize {
         self.capacity as usize
     }
@@ -567,7 +583,9 @@ impl Segment for DiskSegmentMeta {
         let header_size = BasicHeader::SIZE;
 
         let item_size = header_size + optional.len() + key.len() + value.len();
-        let padded_size = (item_size + 7) & !7; // 8-byte alignment
+        // The pool's stride, not a hardcoded 8: every scan advances by the same
+        // quantity, and a `Location` cannot name a finer offset.
+        let padded_size = self.item_stride(item_size) as usize;
 
         // Reserve space atomically
         let offset = self.reserve_space(padded_size as u32)?;
@@ -640,7 +658,7 @@ impl Segment for DiskSegmentMeta {
         let header_size = BasicHeader::SIZE;
 
         let item_size = header_size + optional.len() + key.len() + value_len;
-        let padded_size = (item_size + 7) & !7;
+        let padded_size = self.item_stride(item_size) as usize;
 
         let offset = self.reserve_space(padded_size as u32)?;
 
@@ -775,7 +793,9 @@ impl Segment for DiskSegmentMeta {
             return Ok(false); // Someone else marked it deleted first.
         }
 
-        let padded_size = header.padded_size() as u32;
+        // Must be the stride the append charged to `live_bytes`, not the
+        // 8-padded body size, or the accounting drifts on a coarser pool.
+        let padded_size = self.item_stride(header.padded_size());
         self.live_items.fetch_sub(1, Ordering::Relaxed);
         self.live_bytes.fetch_sub(padded_size, Ordering::Relaxed);
 
@@ -866,7 +886,7 @@ mod tests {
         let buf = pool.allocate().expect("one slot must be available");
         let injector = Box::new(crossbeam_deque::Injector::new());
 
-        let seg = DiskSegmentMeta::new(0, 0, capacity as u32, 0, &*injector);
+        let seg = DiskSegmentMeta::new(0, 0, capacity as u32, 0, &*injector, 512);
         seg.attach_write_buffer(buf);
 
         let header = BasicHeader::new(key.len() as u8, 0, value.len() as u32);
@@ -882,6 +902,92 @@ mod tests {
         }
 
         (seg, pool, injector)
+    }
+
+    /// Build an empty segment with a given capacity and offset alignment.
+    ///
+    /// Separate from `segment_with_item` because these tests append through the
+    /// real path rather than writing a header by hand.
+    fn segment_with_alignment(
+        capacity: usize,
+        align: usize,
+    ) -> (
+        DiskSegmentMeta,
+        AlignedBufferPool,
+        Box<crossbeam_deque::Injector<u32>>,
+    ) {
+        let mut pool = AlignedBufferPool::new(1, capacity, 512);
+        let buf = pool.allocate().expect("one slot must be available");
+        let injector = Box::new(crossbeam_deque::Injector::new());
+
+        let seg = DiskSegmentMeta::new(0, 0, capacity as u32, 0, &*injector, align);
+        seg.attach_write_buffer(buf);
+        (seg, pool, injector)
+    }
+
+    /// Appends must stride by the pool's alignment, and a scan must agree.
+    ///
+    /// If appends pad to 512 and scans still advance by `header.padded_size()`
+    /// (which rounds to 8), the walk desyncs after the first item and silently
+    /// reads garbage. Offsets must also be representable: an unaligned offset
+    /// is truncated by `LocationLayout::pack` in release.
+    #[test]
+    fn test_disk_appends_stride_by_the_pools_alignment() {
+        let (meta, _pool, _injector) = segment_with_alignment(64 * 1024, 512);
+        assert!(meta.try_reserve());
+
+        // Three small items, each far below the alignment factor.
+        let mut offsets = Vec::new();
+        for i in 0..3u8 {
+            let key = [b'k', i];
+            let offset = meta.append_item(&key, b"v", &[]).expect("append");
+            offsets.push(offset);
+        }
+
+        for (i, &offset) in offsets.iter().enumerate() {
+            assert_eq!(
+                offset % 512,
+                0,
+                "item {i} at offset {offset} is not 512-aligned"
+            );
+        }
+        assert_eq!(offsets, vec![0, 512, 1024], "stride must be the alignment");
+
+        // A scan must land on exactly those offsets, not 8-byte ones.
+        let mut walked = Vec::new();
+        let mut offset = 0u32;
+        while offset < meta.write_offset() {
+            let ptr = meta.header_ptr(offset, BasicHeader::SIZE).expect("header");
+            let header = unsafe { BasicHeader::try_from_ptr(ptr) }.expect("valid header");
+            walked.push(offset);
+            offset += meta.item_stride(header.padded_size());
+        }
+        assert_eq!(
+            walked, offsets,
+            "the scan stride disagrees with the append stride"
+        );
+    }
+
+    /// Memory-style 8-byte alignment must be unaffected.
+    #[test]
+    fn test_disk_alignment_of_eight_is_unchanged() {
+        let (meta, _pool, _injector) = segment_with_alignment(64 * 1024, 8);
+        assert!(meta.try_reserve());
+        let a = meta.append_item(b"k1", b"v", &[]).expect("append");
+        let b = meta.append_item(b"k2", b"v", &[]).expect("append");
+        assert_eq!(a, 0);
+
+        // Derived, not hardcoded: `BasicHeader::SIZE` differs by feature, and
+        // the point is that the stride follows the item, not the disk default.
+        let expected = (BasicHeader::SIZE + b"k2".len() + b"v".len()).next_multiple_of(8) as u32;
+        assert_eq!(
+            b, expected,
+            "an 8-aligned pool must still pack items at 8 bytes"
+        );
+        assert!(
+            b < 512,
+            "an 8-aligned pool must not inherit the 512-byte disk stride"
+        );
     }
 
     /// The disk twin of the slice-segment bump table: the incarnation advances

--- a/cache/core/src/disk/disk_segment_meta.rs
+++ b/cache/core/src/disk/disk_segment_meta.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 /// 5. Subsequent reads go to disk via io_uring
 #[repr(C, align(64))]
 pub struct DiskSegmentMeta {
-    /// Packed metadata: [8 unused][8 state][24 prev][24 next]
+    /// Packed metadata: [2 unused][6 incarnation][8 state][24 prev][24 next]
     metadata: AtomicU64,
 
     /// Next write position in the segment.
@@ -362,7 +362,11 @@ impl Segment for DiskSegmentMeta {
             return false;
         }
 
-        let new_meta = Metadata::new(State::Reserved);
+        // Preserve the incarnation: reserving does not end one, and zeroing
+        // here would wipe the tag the release that freed this segment set.
+        let new_meta = meta
+            .with_state(State::Reserved)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
         self.metadata
             .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()
@@ -385,7 +389,11 @@ impl Segment for DiskSegmentMeta {
         match meta.state {
             State::Free => false, // Already free (idempotent)
             State::Reserved | State::Linking | State::Locked => {
-                let new_meta = Metadata::new(State::Free);
+                // Preserve the incarnation; Task 3 decides which transitions
+                // bump.
+                let new_meta = meta
+                    .with_state(State::Free)
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
                 self.metadata
                     .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
                     .is_ok()
@@ -431,7 +439,10 @@ impl Segment for DiskSegmentMeta {
             return false;
         }
 
-        let new_meta = Metadata::new(State::Free);
+        // Preserve the incarnation; Task 3 decides which transitions bump.
+        let new_meta = meta
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
         if self
             .metadata
             .compare_exchange(packed, new_meta.pack(), Ordering::AcqRel, Ordering::Relaxed)
@@ -761,7 +772,11 @@ impl Segment for DiskSegmentMeta {
             .store(Self::INVALID_BUCKET_ID, Ordering::Release);
         self.merge_count.store(0, Ordering::Relaxed);
 
-        let new_meta = Metadata::new(State::Free);
+        // Stores unconditionally, so load first to carry the incarnation
+        // forward -- exactly as `SliceSegment::force_free` does.
+        let new_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire))
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
         self.metadata.store(new_meta.pack(), Ordering::Release);
     }
 }
@@ -795,6 +810,18 @@ impl DiskSegmentMeta {
                 }
             }
         }
+    }
+}
+
+/// Test-only accessors.
+///
+/// `Segment::incarnation()` arrives in Task 3 alongside the bump sites; this
+/// must not anticipate it, hence a private helper rather than a trait method.
+#[cfg(all(test, not(feature = "loom")))]
+impl DiskSegmentMeta {
+    /// The incarnation currently stored in the packed metadata word.
+    fn incarnation_for_test(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
     }
 }
 
@@ -836,6 +863,65 @@ mod tests {
         }
 
         (seg, pool, injector)
+    }
+
+    /// Every disk-segment transition must carry the incarnation forward.
+    ///
+    /// `Metadata::new` zeroes it and compiles clean, so nothing but this test
+    /// stands between a refactor and a silently reset tag -- which resurrects
+    /// stale locations rather than failing loudly. This is the disk twin of
+    /// `slice_segment.rs`'s `test_segment_transitions_preserve_incarnation`;
+    /// its absence is why these sites went unnoticed.
+    #[test]
+    fn test_disk_segment_transitions_preserve_incarnation() {
+        const TAG: u8 = 42;
+
+        let (seg, _pool, _injector) = segment_with_item(b"k", b"v");
+        assert_eq!(
+            seg.incarnation_for_test(),
+            0,
+            "a brand-new segment starts at 0"
+        );
+
+        // Seed a non-zero tag directly, the way a prior incarnation's release
+        // would have left it.
+        let seeded = Metadata::unpack(seg.metadata.load(Ordering::Acquire)).with_state(State::Free);
+        seg.metadata.store(
+            Metadata {
+                incarnation: TAG,
+                ..seeded
+            }
+            .pack(),
+            Ordering::Release,
+        );
+
+        // Free -> Reserved
+        assert!(seg.try_reserve());
+        assert_eq!(seg.incarnation_for_test(), TAG, "try_reserve reset the tag");
+
+        // Reserved -> Free
+        assert!(seg.try_release());
+        assert_eq!(seg.incarnation_for_test(), TAG, "try_release reset the tag");
+
+        // Reserved -> AwaitingRelease -> Free
+        assert!(seg.try_reserve());
+        assert!(seg.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert_eq!(
+            seg.incarnation_for_test(),
+            TAG,
+            "cas_metadata reset the tag"
+        );
+        assert!(seg.release_condemned());
+        assert_eq!(
+            seg.incarnation_for_test(),
+            TAG,
+            "release_condemned reset the tag"
+        );
+
+        // Unconditional store back to Free
+        assert!(seg.try_reserve());
+        seg.reset();
+        assert_eq!(seg.incarnation_for_test(), TAG, "reset cleared the tag");
     }
 
     /// A key LONGER than the stored one must not match, even when the bytes

--- a/cache/core/src/disk/file_pool.rs
+++ b/cache/core/src/disk/file_pool.rs
@@ -5,6 +5,7 @@
 
 use crate::disk::config::{DiskConfig, SyncMode};
 use crate::disk::file_segment::FileSegment;
+use crate::location_layout::LocationLayout;
 use crate::pool::RamPool;
 use crate::segment::Segment;
 use memmap2::{MmapMut, MmapOptions};
@@ -20,6 +21,13 @@ pub const FILE_VERSION: u32 = 1;
 
 /// Header size (64 bytes, cache line aligned).
 pub const HEADER_SIZE: usize = 64;
+
+/// Default offset alignment factor for file-backed pools.
+///
+/// 8, matching the alignment the segment append path pads items to. Coarser
+/// alignment would buy addressable capacity (locations store `offset /
+/// align_bytes`) but the appended offsets would no longer be representable.
+const DEFAULT_ALIGN_BYTES: usize = 8;
 
 /// Header stored at the beginning of the disk cache file.
 ///
@@ -157,6 +165,9 @@ pub struct FilePool {
     /// Size of each segment in bytes.
     segment_size: usize,
 
+    /// Bit split for locations naming this pool.
+    layout: LocationLayout,
+
     /// Synchronization mode.
     sync_mode: SyncMode,
 }
@@ -281,6 +292,10 @@ impl RamPool for FilePool {
         self.segment_size
     }
 
+    fn layout(&self) -> &LocationLayout {
+        &self.layout
+    }
+
     fn reserve(&self) -> Option<u32> {
         use crate::memory_pool::MAX_STEAL_RETRIES;
 
@@ -338,6 +353,7 @@ pub struct FilePoolBuilder {
     size: usize,
     sync_mode: SyncMode,
     create_new: bool,
+    align_bytes: usize,
 }
 
 impl FilePoolBuilder {
@@ -354,6 +370,7 @@ impl FilePoolBuilder {
             size: 1024 * 1024 * 1024, // 1GB default
             sync_mode: SyncMode::default(),
             create_new: true,
+            align_bytes: DEFAULT_ALIGN_BYTES,
         }
     }
 
@@ -366,6 +383,21 @@ impl FilePoolBuilder {
     /// Set the segment size in bytes.
     pub fn segment_size(mut self, size: usize) -> Self {
         self.segment_size = size;
+        self
+    }
+
+    /// Set the offset alignment factor in bytes.
+    ///
+    /// Locations store `offset / align_bytes`, so this is the only lever on a
+    /// pool's addressable capacity: `2^36 * align_bytes`. Must be a power of
+    /// two, at least 8, and no larger than `segment_size`.
+    ///
+    /// Defaults to 8, the alignment the segment append path actually pads
+    /// items to. Raising it is only sound once that path pads to the same
+    /// factor; until then a coarser value produces item offsets this layout
+    /// cannot represent.
+    pub fn align_bytes(mut self, align: usize) -> Self {
+        self.align_bytes = align;
         self
     }
 
@@ -404,6 +436,7 @@ impl FilePoolBuilder {
             size: config.size,
             sync_mode: config.sync_mode,
             create_new: !config.recover_on_startup,
+            align_bytes: DEFAULT_ALIGN_BYTES,
         }
     }
 
@@ -416,6 +449,9 @@ impl FilePoolBuilder {
                 "size must be >= segment_size",
             ));
         }
+
+        let layout = LocationLayout::new(self.segment_size, self.align_bytes)?;
+        layout.validate_segment_count(num_segments)?;
 
         let total_file_size = HEADER_SIZE + num_segments * self.segment_size;
 
@@ -526,6 +562,7 @@ impl FilePoolBuilder {
             pool_id: self.pool_id,
             is_per_item_ttl: self.is_per_item_ttl,
             segment_size: self.segment_size,
+            layout,
             sync_mode: self.sync_mode,
         })
     }

--- a/cache/core/src/disk/file_pool.rs
+++ b/cache/core/src/disk/file_pool.rs
@@ -24,10 +24,12 @@ pub const HEADER_SIZE: usize = 64;
 
 /// Default offset alignment factor for file-backed pools.
 ///
-/// 8, matching the alignment the segment append path pads items to. Coarser
-/// alignment would buy addressable capacity (locations store `offset /
-/// align_bytes`) but the appended offsets would no longer be representable.
-const DEFAULT_ALIGN_BYTES: usize = 8;
+/// 512, a disk sector. Locations store `offset / align_bytes`, so this is what
+/// gives a disk pool 32 TiB of addressable capacity against 512 GiB at 8; it
+/// also stops items straddling an I/O block, which costs an extra block read.
+/// The price is up to 511 bytes of padding per item, which is why memory pools
+/// stay at 8.
+const DEFAULT_ALIGN_BYTES: usize = 512;
 
 /// Header stored at the beginning of the disk cache file.
 ///
@@ -392,10 +394,12 @@ impl FilePoolBuilder {
     /// pool's addressable capacity: `2^36 * align_bytes`. Must be a power of
     /// two, at least 8, and no larger than `segment_size`.
     ///
-    /// Defaults to 8, the alignment the segment append path actually pads
-    /// items to. Raising it is only sound once that path pads to the same
-    /// factor; until then a coarser value produces item offsets this layout
-    /// cannot represent.
+    /// Disk pools default to 512 (a sector) rather than 8. The justification is
+    /// the read path, not capacity: `item_disk_range` rounds reads down to a
+    /// `block_size` boundary, so an item straddling a block costs an extra
+    /// block read. Sector alignment removes that, wastes 256 bytes per item on
+    /// average, and yields 32 TiB per pool as a side effect. Segments append at
+    /// this stride -- see `Segment::item_stride`.
     pub fn align_bytes(mut self, align: usize) -> Self {
         self.align_bytes = align;
         self
@@ -542,6 +546,10 @@ impl FilePoolBuilder {
                     segment_ptr,
                     self.segment_size,
                     free_queue_ptr,
+                    // From the layout, not the builder field, so the stride a
+                    // segment appends by and the alignment a location is
+                    // packed with cannot drift apart.
+                    layout.align_bytes() as usize,
                 )
             };
 

--- a/cache/core/src/disk/file_segment.rs
+++ b/cache/core/src/disk/file_segment.rs
@@ -153,6 +153,11 @@ impl Segment for FileSegment<'_> {
     }
 
     #[inline]
+    fn incarnation(&self) -> u8 {
+        self.inner.incarnation()
+    }
+
+    #[inline]
     fn increment_generation(&self) {
         self.inner.increment_generation();
     }

--- a/cache/core/src/disk/file_segment.rs
+++ b/cache/core/src/disk/file_segment.rs
@@ -52,6 +52,8 @@ impl<'a> FileSegment<'a> {
     /// - `data`: Pointer to mmap'd segment memory
     /// - `len`: Size of segment memory in bytes
     /// - `free_queue`: Pointer to the pool's free queue for async segment release
+    /// - `align_bytes`: The owning pool's offset alignment factor. Disk pools
+    ///   use 512 so items start on sector boundaries; see `LocationLayout`.
     pub unsafe fn new(
         pool_id: u8,
         is_per_item_ttl: bool,
@@ -59,12 +61,21 @@ impl<'a> FileSegment<'a> {
         data: *mut u8,
         len: usize,
         free_queue: *const crossbeam_deque::Injector<u32>,
+        align_bytes: usize,
     ) -> Self {
         // SAFETY: Caller ensures data pointer is valid and has proper alignment.
         // The SliceSegment::new call requires the same safety guarantees.
         Self {
             inner: unsafe {
-                SliceSegment::new(pool_id, is_per_item_ttl, id, data, len, free_queue)
+                SliceSegment::new(
+                    pool_id,
+                    is_per_item_ttl,
+                    id,
+                    data,
+                    len,
+                    free_queue,
+                    align_bytes,
+                )
             },
             dirty: AtomicBool::new(false),
         }
@@ -160,6 +171,11 @@ impl Segment for FileSegment<'_> {
     #[inline]
     fn increment_generation(&self) {
         self.inner.increment_generation();
+    }
+
+    #[inline]
+    fn align_bytes(&self) -> u32 {
+        self.inner.align_bytes()
     }
 
     #[inline]
@@ -436,7 +452,8 @@ mod tests {
         let len = data.len();
 
         let free_queue_ptr: *const crossbeam_deque::Injector<u32> = &*TEST_FREE_QUEUE;
-        let segment = unsafe { FileSegment::new(2, false, 0, ptr, len, free_queue_ptr) };
+        // 512, the disk default: a FileSegment always belongs to a FilePool.
+        let segment = unsafe { FileSegment::new(2, false, 0, ptr, len, free_queue_ptr, 512) };
 
         (data, segment)
     }

--- a/cache/core/src/disk/file_segment.rs
+++ b/cache/core/src/disk/file_segment.rs
@@ -127,6 +127,11 @@ impl<'a> FileSegment<'a> {
 
 // Delegate SegmentKeyVerify to inner
 impl SegmentKeyVerify for FileSegment<'_> {
+    #[inline]
+    fn incarnation(&self) -> u8 {
+        self.inner.incarnation()
+    }
+
     fn verify_key_at_offset(&self, offset: u32, key: &[u8], allow_deleted: bool) -> bool {
         self.inner.verify_key_at_offset(offset, key, allow_deleted)
     }
@@ -161,11 +166,6 @@ impl Segment for FileSegment<'_> {
     #[inline]
     fn generation(&self) -> u16 {
         self.inner.generation()
-    }
-
-    #[inline]
-    fn incarnation(&self) -> u8 {
-        self.inner.incarnation()
     }
 
     #[inline]

--- a/cache/core/src/disk/io_uring_layer.rs
+++ b/cache/core/src/disk/io_uring_layer.rs
@@ -87,8 +87,9 @@ struct IoUringPoolVerifier<'a> {
 impl KeyVerifier for IoUringPoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        if let Some(segment) = self.pool.get(item_loc.segment_id()) {
-            segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        let layout = self.pool.layout();
+        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
+            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
         } else {
             false
         }
@@ -172,7 +173,13 @@ impl IoUringDiskLayer {
 
             if let Some(segment) = self.pool.get(segment_id) {
                 if let Some(offset) = segment.append_item(key, value, optional) {
-                    return Ok(ItemLocation::new(self.pool.pool_id(), segment_id, offset));
+                    return Ok(ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    ));
                 }
 
                 // Segment is full — seal it and queue for flush
@@ -202,7 +209,8 @@ impl IoUringDiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
 
         if !segment.state().is_readable() {
             return None;
@@ -233,7 +241,6 @@ impl IoUringDiskLayer {
         fence(Ordering::Acquire);
 
         let data_ptr = segment.write_buffer_ptr()?;
-        let offset = location.offset();
 
         // Parse header
         if offset as usize + BasicHeader::SIZE > segment.capacity() {
@@ -299,7 +306,8 @@ impl IoUringDiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
 
         if !segment.state().is_readable() {
             return None;
@@ -329,14 +337,13 @@ impl IoUringDiskLayer {
 
         // Compute block-aligned read range
         let (disk_offset, read_len, item_offset) =
-            self.pool
-                .item_disk_range(location.segment_id(), location.offset(), read_size);
+            self.pool.item_disk_range(segment_id, offset, read_size);
 
         Some(DiskReadParams {
             disk_offset,
             read_len,
             item_offset,
-            segment_id: location.segment_id(),
+            segment_id,
             pool_id: self.pool.pool_id(),
         })
     }
@@ -520,7 +527,13 @@ impl IoUringDiskLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
                         hashtable.remove(key, location.to_location());
                     }
 
@@ -582,8 +595,13 @@ impl IoUringDiskLayer {
                         if let Some(key) = segment.data_slice(key_start as u32, key_len)
                             && !header.is_deleted()
                         {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             let verifier = IoUringPoolVerifier { pool: &self.pool };
                             let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -690,7 +708,8 @@ impl Layer for IoUringDiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
         if !segment.state().is_readable() || !segment.has_write_buffer() {
             return None;
         }
@@ -701,7 +720,7 @@ impl Layer for IoUringDiskLayer {
             return None;
         }
 
-        let header_info = segment.verify_key_unexpired(location.offset(), key, now)?;
+        let header_info = segment.verify_key_unexpired(offset, key, now)?;
 
         // Build a BasicItemGuard from the write buffer data
         let ref_count_ptr = segment.ref_count_ptr();
@@ -714,7 +733,6 @@ impl Layer for IoUringDiskLayer {
         }
 
         let data_ptr = segment.write_buffer_ptr()?;
-        let offset = location.offset();
 
         let (key_len, optional_len, value_len) = header_info;
 
@@ -754,10 +772,11 @@ impl Layer for IoUringDiskLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
             // Can only mark deleted if write buffer is present
             if segment.has_write_buffer() {
-                segment.mark_deleted_at_offset(location.offset());
+                segment.mark_deleted_at_offset(offset);
             }
         }
     }
@@ -767,7 +786,7 @@ impl Layer for IoUringDiskLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let segment = self.pool.get(location.segment_id(self.pool.layout()))?;
         let now = Self::now_secs();
         segment.segment_ttl(now)
     }

--- a/cache/core/src/disk/io_uring_layer.rs
+++ b/cache/core/src/disk/io_uring_layer.rs
@@ -87,9 +87,15 @@ struct IoUringPoolVerifier<'a> {
 impl KeyVerifier for IoUringPoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let layout = self.pool.layout();
-        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
-            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
+            segment.verify_key_at_offset(offset, key, allow_deleted)
         } else {
             false
         }
@@ -1008,6 +1014,49 @@ mod tests {
             .segment_size(64 * 1024)
             .segment_count(4)
             .build()
+    }
+
+    /// A location from a previous incarnation must not resolve, even though
+    /// the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_verifier_rejects_a_stale_incarnation() {
+        let layer = test_layer();
+        let pool = &layer.pool;
+
+        // Age every segment through a used incarnation, so the tag the write
+        // stamps is non-zero and a predecessor tag exists to test against.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+        }
+
+        let live = layer
+            .write_item_with_buffers(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write");
+        let layout = pool.layout();
+        let (pool_id, segment_id, tag, offset) = live.unpack(layout);
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        // Same segment, same offset, previous tag.
+        let stale = ItemLocation::new(layout, pool_id, segment_id, tag - 1, offset);
+        let verifier = IoUringPoolVerifier { pool };
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
     }
 
     /// Draining a pinned segment must visit every item, at the pool's stride.

--- a/cache/core/src/disk/io_uring_layer.rs
+++ b/cache/core/src/disk/io_uring_layer.rs
@@ -255,6 +255,9 @@ impl IoUringDiskLayer {
             return None;
         }
 
+        // A bounds check on the item's actual bytes, not a stride: the padding
+        // past `padded_size()` is dead space the last item in a segment need
+        // not own, so checking the stride here would reject a valid read.
         let item_size = header.padded_size();
         if offset as usize + item_size > segment.capacity() {
             unsafe { (*ref_count_ptr).fetch_sub(1, Ordering::Release) };
@@ -518,7 +521,10 @@ impl IoUringDiskLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let key_start =
                         offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -586,7 +592,10 @@ impl IoUringDiskLayer {
             while offset < write_offset {
                 if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                     if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                        let item_size = header.padded_size() as u32;
+                        // The segment's stride, not the 8-byte padded body size: a scan
+                        // that advances by anything but what the append advanced by
+                        // desyncs after the first item on a coarser-aligned pool.
+                        let item_size = segment.item_stride(header.padded_size());
 
                         let key_start =
                             offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -941,5 +950,104 @@ impl IoUringDiskLayerBuilder {
 impl Default for IoUringDiskLayerBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, not(feature = "loom")))]
+mod tests {
+    use super::*;
+    use crate::hashtable_impl::MultiChoiceHashtable;
+
+    /// Fill one segment with items and index them, returning keys + segment id.
+    fn fill_one_segment(
+        layer: &IoUringDiskLayer,
+        hashtable: &MultiChoiceHashtable,
+    ) -> (Vec<String>, u32) {
+        let verifier = IoUringPoolVerifier { pool: &layer.pool };
+        let ttl = Duration::from_secs(3600);
+
+        const ITEMS: usize = 5;
+        let mut keys = Vec::new();
+        let mut segment_id = None;
+        for i in 0..ITEMS {
+            let key = format!("key_{i:02}");
+            let location = layer
+                .write_item_with_buffers(key.as_bytes(), b"value", b"", ttl)
+                .expect("write");
+            hashtable
+                .insert(key.as_bytes(), location.to_location(), &verifier)
+                .expect("insert");
+            let id = location.segment_id(layer.pool.layout());
+            assert_eq!(
+                *segment_id.get_or_insert(id),
+                id,
+                "all items must share one segment for this to test the walk"
+            );
+            keys.push(key);
+        }
+        (keys, segment_id.expect("at least one item"))
+    }
+
+    fn assert_all_removed(
+        layer: &IoUringDiskLayer,
+        hashtable: &MultiChoiceHashtable,
+        keys: &[String],
+    ) {
+        let verifier = IoUringPoolVerifier { pool: &layer.pool };
+        for key in keys {
+            assert!(
+                hashtable.lookup(key.as_bytes(), &verifier).is_none(),
+                "{key} survived the walk -- it stopped short of that item"
+            );
+        }
+    }
+
+    fn test_layer() -> IoUringDiskLayer {
+        IoUringDiskLayerBuilder::new()
+            .pool_id(2)
+            .segment_size(64 * 1024)
+            .segment_count(4)
+            .build()
+    }
+
+    /// Draining a pinned segment must visit every item, at the pool's stride.
+    ///
+    /// Disk pools align items to 512 bytes while `BasicHeader::padded_size()`
+    /// rounds to 8. A walk that advances by the latter lands mid-item on its
+    /// second iteration, reads a garbage header and stops -- silently, since
+    /// both quantities are `u32`. Hashtable entries left behind after the
+    /// segment is recycled is what that failure looks like from the outside.
+    #[test]
+    fn test_draining_a_segment_walks_every_item_at_the_disk_stride() {
+        let layer = test_layer();
+        assert_eq!(
+            layer.pool.layout().align_bytes(),
+            512,
+            "disk pools align to a sector"
+        );
+
+        let hashtable = MultiChoiceHashtable::new(10);
+        let (keys, segment_id) = fill_one_segment(&layer, &hashtable);
+
+        layer.drain_segment_from_hashtable(segment_id, &hashtable);
+        assert_all_removed(&layer, &hashtable, &keys);
+    }
+
+    /// The same for the unpinned path, which walks the segment itself rather
+    /// than deferring to `drain_segment_from_hashtable`.
+    #[test]
+    fn test_evicting_a_segment_walks_every_item_at_the_disk_stride() {
+        let layer = test_layer();
+        let hashtable = MultiChoiceHashtable::new(10);
+        let (keys, segment_id) = fill_one_segment(&layer, &hashtable);
+
+        // The eviction path leaves its victim in `Draining`, which is the
+        // state `process_evicted_segment` expects.
+        let segment = layer.pool.get(segment_id).expect("segment");
+        let state = segment.state();
+        assert!(segment.cas_metadata(state, State::Draining, None, None));
+
+        layer.process_evicted_segment(segment_id, &hashtable);
+        assert_all_removed(&layer, &hashtable, &keys);
     }
 }

--- a/cache/core/src/disk/io_uring_pool.rs
+++ b/cache/core/src/disk/io_uring_pool.rs
@@ -13,10 +13,12 @@ use super::disk_segment_meta::DiskSegmentMeta;
 
 /// Offset alignment factor for io_uring disk pools.
 ///
-/// 8, matching the alignment the segment append path pads items to. Coarser
-/// alignment would buy addressable capacity (locations store `offset /
-/// align_bytes`) but the appended offsets would no longer be representable.
-const DEFAULT_ALIGN_BYTES: usize = 8;
+/// 512, a disk sector, matching [`crate::disk::FilePool`]. Locations store
+/// `offset / align_bytes`, so this is what gives a disk pool 32 TiB of
+/// addressable capacity against 512 GiB at 8; it also stops items straddling an
+/// I/O block, which `item_disk_range` would otherwise pay for with a second
+/// block read. Segments append at this stride -- see `Segment::item_stride`.
+const DEFAULT_ALIGN_BYTES: usize = 512;
 
 /// Pool of disk segment metadata entries.
 ///
@@ -78,7 +80,7 @@ impl IoUringPool {
     /// # Panics
     ///
     /// Panics if any argument is out of range, or if `segment_size` and the
-    /// pool's alignment factor (8 bytes) do not yield a usable
+    /// pool's alignment factor (512 bytes) do not yield a usable
     /// [`LocationLayout`] -- for instance a segment so small that more segment
     /// id bits remain than a `u32` id can hold.
     pub fn new(pool_id: u8, segment_count: usize, segment_size: usize, block_size: u32) -> Self {
@@ -124,6 +126,9 @@ impl IoUringPool {
                 segment_size as u32,
                 disk_offset,
                 free_queue_ptr,
+                // From the layout, so the stride a segment appends by and the
+                // alignment a location is packed with cannot drift apart.
+                layout.align_bytes() as usize,
             );
             segments.push(meta);
 
@@ -319,7 +324,10 @@ mod tests {
 
     #[test]
     fn test_reserve_release() {
-        let pool = IoUringPool::new(0, 3, 4096, 4096);
+        // 64 KiB segments, not 4 KiB: at the 512-byte disk alignment a 4 KiB
+        // segment leaves more segment-id bits than a u32 id can hold, and the
+        // layout rejects it. The size was never what this test is about.
+        let pool = IoUringPool::new(0, 3, 64 * 1024, 4096);
         assert_eq!(pool.free_count(), 3);
 
         let id1 = pool.reserve().unwrap();

--- a/cache/core/src/disk/io_uring_pool.rs
+++ b/cache/core/src/disk/io_uring_pool.rs
@@ -5,10 +5,18 @@
 //! segment allocation via a lock-free free queue, and provides disk
 //! offset calculations for reading/writing segment data.
 
+use crate::location_layout::LocationLayout;
 use crate::pool::RamPool;
 use crate::segment::Segment;
 
 use super::disk_segment_meta::DiskSegmentMeta;
+
+/// Offset alignment factor for io_uring disk pools.
+///
+/// 8, matching the alignment the segment append path pads items to. Coarser
+/// alignment would buy addressable capacity (locations store `offset /
+/// align_bytes`) but the appended offsets would no longer be representable.
+const DEFAULT_ALIGN_BYTES: usize = 8;
 
 /// Pool of disk segment metadata entries.
 ///
@@ -48,6 +56,8 @@ pub struct IoUringPool {
     block_size: u32,
     /// Total number of segments.
     segment_count: usize,
+    /// Bit split for locations naming this pool.
+    layout: LocationLayout,
 }
 
 // SAFETY: All internal state is either immutable after construction
@@ -64,6 +74,13 @@ impl IoUringPool {
     /// - `segment_count`: Number of segments
     /// - `segment_size`: Size of each segment in bytes
     /// - `block_size`: I/O block size (typically 4096)
+    ///
+    /// # Panics
+    ///
+    /// Panics if any argument is out of range, or if `segment_size` and the
+    /// pool's alignment factor (8 bytes) do not yield a usable
+    /// [`LocationLayout`] -- for instance a segment so small that more segment
+    /// id bits remain than a `u32` id can hold.
     pub fn new(pool_id: u8, segment_count: usize, segment_size: usize, block_size: u32) -> Self {
         assert!(pool_id <= 3, "pool_id must be 0-3");
         assert!(segment_count > 0, "segment_count must be > 0");
@@ -71,6 +88,24 @@ impl IoUringPool {
         assert!(
             block_size > 0 && block_size.is_power_of_two(),
             "block_size must be a power of two"
+        );
+
+        // Consistent with the surrounding constructor, which asserts rather
+        // than returning a Result: `IoUringPool` has no builder, and
+        // `IoUringDiskLayerBuilder::build` is infallible.
+        let layout = LocationLayout::new(segment_size, DEFAULT_ALIGN_BYTES)
+            .unwrap_or_else(|e| panic!("invalid location layout for this pool: {e}"));
+        assert!(
+            layout.validate_segment_count(segment_count).is_ok(),
+            "segment_count {segment_count} exceeds the {} the layout addresses",
+            layout.max_segment_count()
+        );
+        // Aligning coarser than the I/O block buys nothing on the read path:
+        // `item_disk_range` already rounds reads down to a block boundary.
+        assert!(
+            layout.align_bytes() <= block_size,
+            "align_bytes ({}) must not exceed block_size ({block_size})",
+            layout.align_bytes()
         );
 
         // `Arc`, not `Box`: see `MemoryPool::free_queue`. Segments hold raw
@@ -104,6 +139,7 @@ impl IoUringPool {
             segment_size,
             block_size,
             segment_count,
+            layout,
         }
     }
 
@@ -199,6 +235,11 @@ impl RamPool for IoUringPool {
     #[inline]
     fn segment_size(&self) -> usize {
         self.segment_size
+    }
+
+    #[inline]
+    fn layout(&self) -> &LocationLayout {
+        &self.layout
     }
 
     fn reserve(&self) -> Option<u32> {

--- a/cache/core/src/disk/recovery.rs
+++ b/cache/core/src/disk/recovery.rs
@@ -179,8 +179,13 @@ pub fn warm_from_pool<H: Hashtable>(pool: &FilePool, hashtable: &H, now: u32) ->
 
                             if let Some(key) = segment.data_slice(key_start as u32, key_len) {
                                 // Create location for this item
-                                let location =
-                                    ItemLocation::new(pool.pool_id(), segment_id, offset);
+                                let location = ItemLocation::new(
+                                    pool.layout(),
+                                    pool.pool_id(),
+                                    segment_id,
+                                    segment.incarnation(),
+                                    offset,
+                                );
 
                                 // Insert into hashtable
                                 // Note: We use a dummy verifier since we're rebuilding

--- a/cache/core/src/disk/recovery.rs
+++ b/cache/core/src/disk/recovery.rs
@@ -9,7 +9,7 @@ use crate::hashtable::Hashtable;
 use crate::item::BasicHeader;
 use crate::item_location::ItemLocation;
 use crate::pool::RamPool;
-use crate::segment::Segment;
+use crate::segment::{Segment, SegmentKeyVerify};
 use crate::state::State;
 
 /// Statistics from segment recovery.

--- a/cache/core/src/disk/recovery.rs
+++ b/cache/core/src/disk/recovery.rs
@@ -100,7 +100,10 @@ pub fn recover_segment(
         // Try to parse header at this offset
         if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
             if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                let item_size = header.padded_size() as u32;
+                // The segment's stride, not the 8-byte padded body size: a scan
+                // that advances by anything but what the append advanced by
+                // desyncs after the first item on a coarser-aligned pool.
+                let item_size = segment.item_stride(header.padded_size());
 
                 // Validate item bounds
                 if offset + item_size > write_offset {
@@ -167,7 +170,10 @@ pub fn warm_from_pool<H: Hashtable>(pool: &FilePool, hashtable: &H, now: u32) ->
             while offset < write_offset {
                 if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                     if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                        let item_size = header.padded_size() as u32;
+                        // The segment's stride, not the 8-byte padded body size: a scan
+                        // that advances by anything but what the append advanced by
+                        // desyncs after the first item on a coarser-aligned pool.
+                        let item_size = segment.item_stride(header.padded_size());
 
                         // Skip deleted items
                         if !header.is_deleted() {
@@ -241,12 +247,66 @@ impl crate::hashtable::KeyVerifier for DummyVerifier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "loom")))]
 mod tests {
     use super::*;
+    use crate::disk::file_pool::FilePoolBuilder;
+    use crate::hashtable_impl::MultiChoiceHashtable;
+    use tempfile::tempdir;
 
-    // Note: Tests for recovery require a real FilePool which is tested
-    // in the file_pool and disk_layer modules. Here we test the stats.
+    /// A segment walk must advance by the pool's stride, not `padded_size()`.
+    ///
+    /// Disk pools align items to 512 bytes while `BasicHeader::padded_size()`
+    /// rounds to 8. A scan using the latter lands mid-item on its second
+    /// iteration, reads a garbage header and stops -- silently, since both
+    /// quantities are `u32`. Recovering fewer items than were written is what
+    /// that failure looks like from the outside.
+    #[test]
+    fn test_recovery_walks_every_item_at_the_disk_stride() {
+        let dir = tempdir().expect("temp dir");
+        let pool = FilePoolBuilder::new(2)
+            .path(dir.path().join("recover.dat"))
+            .segment_size(64 * 1024)
+            .size(4 * 64 * 1024)
+            .build()
+            .expect("pool");
+        assert_eq!(
+            pool.layout().align_bytes(),
+            512,
+            "disk pools align to a sector"
+        );
+
+        let id = pool.reserve().expect("a free segment");
+        let segment = pool.get(id).expect("segment");
+        assert!(segment.cas_metadata(State::Reserved, State::Live, None, None));
+
+        const ITEMS: usize = 5;
+        for i in 0..ITEMS {
+            let key = format!("key_{i:02}");
+            segment
+                .append_item(key.as_bytes(), b"value", &[])
+                .expect("append");
+        }
+        // Every item after the first sits far past where an 8-byte walk looks.
+        assert_eq!(segment.write_offset(), (ITEMS * 512) as u32);
+
+        let stats = recover_segment(segment, 0, 0);
+        assert_eq!(
+            stats.items_recovered, ITEMS,
+            "the scan lost items to a stride mismatch"
+        );
+        assert_eq!(stats.items_corrupted, 0);
+
+        let hashtable = MultiChoiceHashtable::new(10);
+        let warm = warm_from_pool(&pool, &hashtable, 0);
+        assert_eq!(
+            warm.items_indexed, ITEMS,
+            "the warm-up walk lost items to a stride mismatch"
+        );
+    }
+
+    // The remaining tests cover the stats types; the scans themselves are
+    // exercised above and in the file_pool and disk_layer modules.
 
     #[test]
     fn test_recovery_stats_default() {

--- a/cache/core/src/hashtable_impl.rs
+++ b/cache/core/src/hashtable_impl.rs
@@ -3448,6 +3448,63 @@ mod loom_tests {
         witness.assert_reached();
     }
 
+    /// A reader holding a location races the recycle of the segment it names,
+    /// which is then REFILLED WITH THE SAME KEY.
+    ///
+    /// This is the hazard the fixture's module header used to record as
+    /// unmodellable, and the same-key refill is the whole point: the occupant
+    /// check has nothing to say, because the bytes really do spell the key
+    /// again. Only the incarnation tag can tell the reader that the item it
+    /// would resolve to belongs to a later incarnation than its location does.
+    ///
+    /// The property is asserted where the decision is made, not on the value
+    /// the reader got back. A location the reader resolved BEFORE the bump was
+    /// legitimately live at that instant, so re-checking it after the join
+    /// would fail for interleavings that are perfectly correct. What must never
+    /// happen is that `verify` accepts a location whose tag has already
+    /// advanced, and the oracle counts exactly that.
+    #[test]
+    fn loom_stale_location_never_resolves_to_the_new_occupant() {
+        let witness = KeyOracle::arm_hazard_witness();
+        loom::model(|| {
+            let ht = Arc::new(MultiChoiceHashtable::new(4));
+            let oracle = Arc::new(KeyOracle::new());
+
+            oracle.place(SRC, KEY);
+            let stale = KeyOracle::location(SRC);
+            ht_insert(&ht, KEY, stale, &*oracle).expect("seed insert must find a slot");
+
+            let oracle_w = oracle.clone();
+            let recycler = thread::spawn(move || {
+                // The order production uses: the tag advances as the segment
+                // leaves `Locked`, and the new item is appended afterwards.
+                oracle_w.bump_incarnation(SRC);
+                oracle_w.place(SRC, KEY);
+            });
+
+            let ht_r = ht.clone();
+            let oracle_r = oracle.clone();
+            let reader = thread::spawn(move || ht_lookup(&ht_r, KEY, &*oracle_r));
+
+            let observed = reader.join().unwrap();
+            recycler.join().unwrap();
+
+            assert_eq!(
+                KeyOracle::stale_accepts(),
+                0,
+                "a location from a superseded incarnation resolved to the new \
+                 occupant"
+            );
+            if let Some((loc, _freq)) = observed {
+                assert_eq!(
+                    loc, stale,
+                    "a resolved location must be the one we published"
+                );
+            }
+        });
+        witness.assert_stale_incarnation_reached();
+    }
+
     #[test]
     fn loom_lookup_survives_relocation() {
         read_survives_relocation(|ht, oracle| ht_lookup(ht, KEY, oracle).is_some());

--- a/cache/core/src/item.rs
+++ b/cache/core/src/item.rs
@@ -810,11 +810,11 @@ impl Drop for BasicItemGuard<'_> {
 
             if meta.state == State::AwaitingRelease {
                 // Transition to Free and push to free queue
-                let new_meta = Metadata {
-                    next: INVALID_SEGMENT_ID,
-                    prev: INVALID_SEGMENT_ID,
-                    state: State::Free,
-                };
+                // Preserve the incarnation carried by the metadata we just
+                // loaded; Task 3 decides which transitions bump.
+                let new_meta = meta
+                    .with_state(State::Free)
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
 
                 if self
                     .metadata

--- a/cache/core/src/item.rs
+++ b/cache/core/src/item.rs
@@ -844,6 +844,39 @@ unsafe impl Send for BasicItemGuard<'_> {}
 mod tests {
     use super::*;
 
+    /// The last guard dropped on a condemned segment frees it -- and must
+    /// carry the incarnation forward while doing so.
+    ///
+    /// This drop path is one of three copies of the `AwaitingRelease -> Free`
+    /// transition, and the only one reachable solely through `Drop`, so it is
+    /// invisible to the segment-level transition tests.
+    #[test]
+    fn test_item_guard_drop_preserves_incarnation() {
+        use crate::state::{INVALID_SEGMENT_ID, Metadata, State};
+
+        const TAG: u8 = 42;
+
+        let ref_count = AtomicU32::new(1);
+        let free_queue = crossbeam_deque::Injector::new();
+        let metadata = crate::sync::AtomicU64::new(
+            Metadata {
+                next: INVALID_SEGMENT_ID,
+                prev: INVALID_SEGMENT_ID,
+                state: State::AwaitingRelease,
+                incarnation: TAG,
+            }
+            .pack(),
+        );
+
+        let guard = BasicItemGuard::new(&ref_count, b"k", b"v", b"", &metadata, &free_queue, 7);
+        drop(guard);
+
+        let meta = Metadata::unpack(metadata.load(Ordering::Acquire));
+        assert_eq!(meta.state, State::Free, "the last guard must free it");
+        assert_eq!(meta.incarnation, TAG, "guard drop reset the tag");
+        assert_eq!(free_queue.len(), 1, "the segment must reach the free queue");
+    }
+
     #[test]
     fn test_basic_header_round_trip() {
         let header = BasicHeader::with_flags(10, 5, 1000, false, true);

--- a/cache/core/src/item.rs
+++ b/cache/core/src/item.rs
@@ -809,12 +809,22 @@ impl Drop for BasicItemGuard<'_> {
             let meta = Metadata::unpack(packed);
 
             if meta.state == State::AwaitingRelease {
-                // Transition to Free and push to free queue
-                // Preserve the incarnation carried by the metadata we just
-                // loaded; Task 3 decides which transitions bump.
+                // AwaitingRelease -> Free ends a used incarnation, so the tag
+                // advances in the same CAS that publishes Free.
+                //
+                // This is the *main* condemned-free path, not an edge case: the
+                // layers condemn a segment with readers outstanding and leave
+                // the last guard drop to free it, calling `release_condemned`
+                // only as a fallback when the last reader vanished during the
+                // condemn window. A reader holding a location across this
+                // recycle is exactly what the tag defends against.
+                //
+                // `with_chain_ids` must stay: returning a freed segment to the
+                // free queue still linked to its neighbours is its own defect.
                 let new_meta = meta
                     .with_state(State::Free)
-                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+                    .bump_incarnation();
 
                 if self
                     .metadata
@@ -844,14 +854,24 @@ unsafe impl Send for BasicItemGuard<'_> {}
 mod tests {
     use super::*;
 
-    /// The last guard dropped on a condemned segment frees it -- and must
-    /// carry the incarnation forward while doing so.
+    /// The last guard dropped on a condemned segment frees it -- ending a used
+    /// incarnation, so the tag must advance.
     ///
-    /// This drop path is one of three copies of the `AwaitingRelease -> Free`
-    /// transition, and the only one reachable solely through `Drop`, so it is
-    /// invisible to the segment-level transition tests.
+    /// This drop path is one of four copies of the `AwaitingRelease -> Free`
+    /// transition (the other three being `SliceSegment::release_condemned`,
+    /// `DiskSegmentMeta::release_condemned` and `ValueRef::drop`), and is
+    /// reachable solely through `Drop`, so it is
+    /// invisible to the segment-level transition tests. It is also the
+    /// *dominant* one: the layers condemn a segment with readers outstanding
+    /// and leave the last guard drop to free it, calling `release_condemned`
+    /// only as a fallback for the race where the last reader vanished during
+    /// the condemn window.
+    ///
+    /// Seeding a nonzero tag rather than starting from 0 is what distinguishes
+    /// a bump from a site that rebuilds `Metadata` from scratch: the latter
+    /// would land on 1, not 43.
     #[test]
-    fn test_item_guard_drop_preserves_incarnation() {
+    fn test_item_guard_drop_bumps_the_incarnation() {
         use crate::state::{INVALID_SEGMENT_ID, Metadata, State};
 
         const TAG: u8 = 42;
@@ -873,7 +893,11 @@ mod tests {
 
         let meta = Metadata::unpack(metadata.load(Ordering::Acquire));
         assert_eq!(meta.state, State::Free, "the last guard must free it");
-        assert_eq!(meta.incarnation, TAG, "guard drop reset the tag");
+        assert_eq!(
+            meta.incarnation,
+            TAG + 1,
+            "guard drop must end the incarnation, carrying the tag forward"
+        );
         assert_eq!(free_queue.len(), 1, "the segment must reach the free queue");
     }
 

--- a/cache/core/src/item_location.rs
+++ b/cache/core/src/item_location.rs
@@ -187,10 +187,15 @@ impl<'a, S> SinglePoolVerifier<'a, S> {
 impl<S: SegmentKeyVerify + Send + Sync> KeyVerifier for SinglePoolVerifier<'_, S> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let segment_id = item_loc.segment_id(&self.layout) as usize;
-        let offset = item_loc.offset(&self.layout);
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(&self.layout);
 
-        if let Some(segment) = self.segments.get(segment_id) {
+        if let Some(segment) = self.segments.get(segment_id as usize) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
             segment.verify_key_at_offset(offset, key, allow_deleted)
         } else {
             false
@@ -241,10 +246,15 @@ impl<S: SegmentKeyVerify + Send + Sync> KeyVerifier for MultiPoolVerifier<'_, S>
             return false;
         };
 
-        let segment_id = item_loc.segment_id(&layout) as usize;
-        let offset = item_loc.offset(&layout);
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(&layout);
 
-        if let Some(segment) = segments.get(segment_id) {
+        if let Some(segment) = segments.get(segment_id as usize) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
             return segment.verify_key_at_offset(offset, key, allow_deleted);
         }
 
@@ -366,10 +376,25 @@ mod tests {
 
     // Mock segment for verifier tests
     struct MockSegment {
+        incarnation: u8,
         keys: Vec<(u32, Vec<u8>, bool)>, // (offset, key, deleted)
     }
 
+    impl MockSegment {
+        /// A segment on its first incarnation, holding one key at one offset.
+        fn new(offset: u32, key: &[u8]) -> Self {
+            Self {
+                incarnation: 0,
+                keys: vec![(offset, key.to_vec(), false)],
+            }
+        }
+    }
+
     impl SegmentKeyVerify for MockSegment {
+        fn incarnation(&self) -> u8 {
+            self.incarnation
+        }
+
         fn verify_key_at_offset(&self, offset: u32, key: &[u8], allow_deleted: bool) -> bool {
             self.keys
                 .iter()
@@ -404,14 +429,7 @@ mod tests {
     #[test]
     fn test_single_pool_verifier() {
         let l = mem_layout();
-        let segments = vec![
-            MockSegment {
-                keys: vec![(0, b"key0".to_vec(), false)],
-            },
-            MockSegment {
-                keys: vec![(8, b"key1".to_vec(), false)],
-            },
-        ];
+        let segments = vec![MockSegment::new(0, b"key0"), MockSegment::new(8, b"key1")];
         let verifier = SinglePoolVerifier::new(l, &segments);
 
         let loc0 = ItemLocation::new(&l, 0, 0, 0, 0);
@@ -432,16 +450,10 @@ mod tests {
         let l2 = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
         assert_ne!(l0.offset_bits(), l2.offset_bits());
 
-        let pool0 = vec![MockSegment {
-            keys: vec![(0, b"pool0_key".to_vec(), false)],
-        }];
+        let pool0 = vec![MockSegment::new(0, b"pool0_key")];
         let pool2 = vec![
-            MockSegment {
-                keys: vec![(0, b"pool2_seg0".to_vec(), false)],
-            },
-            MockSegment {
-                keys: vec![(512, b"pool2_seg1".to_vec(), false)],
-            },
+            MockSegment::new(0, b"pool2_seg0"),
+            MockSegment::new(512, b"pool2_seg1"),
         ];
 
         let verifier = MultiPoolVerifier::new()
@@ -450,13 +462,65 @@ mod tests {
 
         let loc0 = ItemLocation::new(&l0, 0, 0, 0, 0);
         let loc2_0 = ItemLocation::new(&l2, 2, 0, 0, 0);
-        let loc2_1 = ItemLocation::new(&l2, 2, 1, 9, 512);
+        let loc2_1 = ItemLocation::new(&l2, 2, 1, 0, 512);
         let loc1 = ItemLocation::new(&l0, 1, 0, 0, 0); // pool 1 not set
 
         assert!(verifier.verify(b"pool0_key", loc0.to_location(), false));
         assert!(verifier.verify(b"pool2_seg0", loc2_0.to_location(), false));
         assert!(verifier.verify(b"pool2_seg1", loc2_1.to_location(), false));
         assert!(!verifier.verify(b"any", loc1.to_location(), false)); // pool 1 not set
+    }
+
+    /// A location from a previous incarnation must not resolve, even though
+    /// the key really is at that offset.
+    ///
+    /// That is the whole hazard: the segment was drained and refilled, and the
+    /// n-th item of the new incarnation landed where the n-th item of the old
+    /// one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_single_pool_verifier_rejects_a_stale_incarnation() {
+        let l = mem_layout();
+        let segments = vec![MockSegment {
+            incarnation: 1,
+            keys: vec![(0, b"key".to_vec(), false)],
+        }];
+        let verifier = SinglePoolVerifier::new(l, &segments);
+
+        let live = ItemLocation::new(&l, 0, 0, 1, 0);
+        let stale = ItemLocation::new(&l, 0, 0, 0, 0);
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
+    }
+
+    /// The same for the multi-pool verifier, whose per-pool layout decodes the
+    /// tag before it is compared.
+    #[test]
+    fn test_multi_pool_verifier_rejects_a_stale_incarnation() {
+        let l = mem_layout();
+        let pool1 = vec![MockSegment {
+            incarnation: 1,
+            keys: vec![(0, b"key".to_vec(), false)],
+        }];
+        let verifier = MultiPoolVerifier::new().with_pool(1, l, &pool1);
+
+        let live = ItemLocation::new(&l, 1, 0, 1, 0);
+        let stale = ItemLocation::new(&l, 1, 0, 0, 0);
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
     }
 
     #[test]
@@ -479,6 +543,7 @@ mod tests {
     fn test_deleted_handling() {
         let l = mem_layout();
         let segments = vec![MockSegment {
+            incarnation: 0,
             keys: vec![(0, b"deleted_key".to_vec(), true)],
         }];
         let verifier = SinglePoolVerifier::new(l, &segments);

--- a/cache/core/src/item_location.rs
+++ b/cache/core/src/item_location.rs
@@ -1,79 +1,61 @@
 //! Segment-specific location interpretation.
 //!
 //! This module provides `ItemLocation`, which interprets the opaque 44-bit
-//! `Location` as a (pool_id, segment_id, offset) tuple for segment-based caches.
+//! `Location` as a `(pool_id, segment_id, incarnation, offset)` tuple for
+//! segment-based caches.
+//!
+//! Only `pool_id` sits at a fixed position. The rest of the split is per-pool
+//! and described by that pool's [`LocationLayout`], so the decoding accessors
+//! take one.
 
 use crate::hashtable::KeyVerifier;
 use crate::location::Location;
+use crate::location_layout::LocationLayout;
 use crate::segment::SegmentKeyVerify;
 use std::fmt;
 
 /// Segment-specific location interpretation.
 ///
-/// Interprets the 44-bit `Location` as:
-/// - pool_id: 2 bits (0-3) - up to 4 storage pools
-/// - segment_id: 18 bits - up to 256K segments per pool
-/// - offset: 24 bits (stored as offset/8) - up to ~128MB per segment
+/// Interprets the 44-bit `Location` as `(pool_id, segment_id, incarnation,
+/// offset)`. Only `pool_id` sits at a fixed position; the rest of the split is
+/// per-pool and described by that pool's [`LocationLayout`], which is why the
+/// accessors take one.
 ///
 /// ```text
-/// +--------+--------------+----------------+
-/// | 43..42 |    41..24    |     23..0      |
-/// |  pool  |    seg_id    |    offset/8    |
-/// | 2 bits |   18 bits    |    24 bits     |
-/// +--------+--------------+----------------+
+/// +--------+------------+-------------+--------------+
+/// | 43..42 |    ...     |     ...     |     ...      |
+/// |  pool  |  seg_id    | incarnation | offset/align |
+/// | 2 bits |  variable  |   6 bits    |   variable   |
+/// +--------+------------+-------------+--------------+
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ItemLocation(Location);
 
 impl ItemLocation {
-    const POOL_SHIFT: u32 = 42;
-    const POOL_MASK: u64 = 0b11 << 42;
-
-    const SEG_SHIFT: u32 = 24;
-    const SEG_MASK: u64 = 0x3_FFFF << 24; // 18 bits
-
-    const OFFSET_MASK: u64 = 0xFF_FFFF; // 24 bits (lowest bits)
-
-    /// Alignment for offset encoding (offset stored as offset/8).
-    pub const OFFSET_ALIGN: u32 = 8;
-
-    /// Maximum pool ID (2 bits = 0-3).
-    pub const MAX_POOL_ID: u8 = 3;
-
-    /// Maximum segment ID (18 bits).
-    pub const MAX_SEGMENT_ID: u32 = (1 << 18) - 1;
-
-    /// Maximum raw offset value (24 bits * 8 = ~128MB).
-    pub const MAX_OFFSET: u32 = ((1u32 << 24) - 1) * Self::OFFSET_ALIGN;
-
     /// Create a new item location from segment coordinates.
+    ///
+    /// `incarnation` must be the tag the segment carries *at the moment the
+    /// item is written into it* -- read it from the same segment reference the
+    /// append used, not from a later lookup.
     ///
     /// # Panics
     ///
-    /// Panics in debug mode if:
-    /// - pool_id >= 4
-    /// - segment_id >= 2^18
-    /// - offset is not 8-byte aligned
-    /// - offset/8 >= 2^24
+    /// Panics in debug mode if `pool_id`, `segment_id` or `offset` is outside
+    /// what `layout` can represent. See [`LocationLayout::pack`].
     #[inline]
-    pub fn new(pool_id: u8, segment_id: u32, offset: u32) -> Self {
-        debug_assert!(pool_id <= Self::MAX_POOL_ID, "pool_id must be 0-3");
-        debug_assert!(
-            segment_id <= Self::MAX_SEGMENT_ID,
-            "segment_id must fit in 18 bits"
-        );
-        debug_assert!(
-            offset.is_multiple_of(Self::OFFSET_ALIGN),
-            "offset must be 8-byte aligned"
-        );
-        debug_assert!(offset <= Self::MAX_OFFSET, "offset/8 must fit in 24 bits");
-
-        let encoded_offset = (offset / Self::OFFSET_ALIGN) as u64;
-        let raw = ((pool_id as u64) << Self::POOL_SHIFT)
-            | ((segment_id as u64) << Self::SEG_SHIFT)
-            | encoded_offset;
-
-        Self(Location::new(raw))
+    pub fn new(
+        layout: &LocationLayout,
+        pool_id: u8,
+        segment_id: u32,
+        incarnation: u8,
+        offset: u32,
+    ) -> Self {
+        Self(Location::new(layout.pack(
+            pool_id,
+            segment_id,
+            incarnation,
+            offset,
+        )))
     }
 
     /// Create from an opaque `Location`.
@@ -93,37 +75,46 @@ impl ItemLocation {
     }
 
     /// Get the pool ID (0-3).
+    ///
+    /// Layout-independent: this is what a decoder reads first, to find out
+    /// which layout decodes the rest.
     #[inline]
     pub fn pool_id(&self) -> u8 {
-        ((self.0.as_raw() & Self::POOL_MASK) >> Self::POOL_SHIFT) as u8
+        LocationLayout::pool_id(self.0.as_raw())
     }
 
     /// Get the segment ID within the pool.
     #[inline]
-    pub fn segment_id(&self) -> u32 {
-        ((self.0.as_raw() & Self::SEG_MASK) >> Self::SEG_SHIFT) as u32
+    pub fn segment_id(&self, layout: &LocationLayout) -> u32 {
+        layout.segment_id(self.0.as_raw())
+    }
+
+    /// Get the incarnation tag this location was issued under.
+    #[inline]
+    pub fn incarnation(&self, layout: &LocationLayout) -> u8 {
+        layout.incarnation(self.0.as_raw())
     }
 
     /// Get the byte offset within the segment.
     #[inline]
-    pub fn offset(&self) -> u32 {
-        ((self.0.as_raw() & Self::OFFSET_MASK) as u32) * Self::OFFSET_ALIGN
+    pub fn offset(&self, layout: &LocationLayout) -> u32 {
+        layout.offset(self.0.as_raw())
     }
 
     /// Unpack all fields in a single pass.
     ///
-    /// Returns `(pool_id, segment_id, offset)`.
-    ///
-    /// This is more efficient than calling `pool_id()`, `segment_id()`, and
-    /// `offset()` separately when all three values are needed, as it only
-    /// performs one virtual method call to get the raw bits.
+    /// Returns `(pool_id, segment_id, incarnation, offset)`. Cheaper than the
+    /// individual accessors when more than one field is needed, since the raw
+    /// bits are loaded once.
     #[inline]
-    pub fn unpack(&self) -> (u8, u32, u32) {
+    pub fn unpack(&self, layout: &LocationLayout) -> (u8, u32, u8, u32) {
         let raw = self.0.as_raw();
-        let pool_id = ((raw & Self::POOL_MASK) >> Self::POOL_SHIFT) as u8;
-        let segment_id = ((raw & Self::SEG_MASK) >> Self::SEG_SHIFT) as u32;
-        let offset = ((raw & Self::OFFSET_MASK) as u32) * Self::OFFSET_ALIGN;
-        (pool_id, segment_id, offset)
+        (
+            LocationLayout::pool_id(raw),
+            layout.segment_id(raw),
+            layout.incarnation(raw),
+            layout.offset(raw),
+        )
     }
 
     /// Check if this location represents a ghost entry.
@@ -138,10 +129,11 @@ impl fmt::Debug for ItemLocation {
         if self.is_ghost() {
             write!(f, "ItemLocation::GHOST")
         } else {
+            // Decoding requires the owning pool's layout, which a Debug impl
+            // does not have. pool_id is the one field at a fixed position.
             f.debug_struct("ItemLocation")
                 .field("pool_id", &self.pool_id())
-                .field("segment_id", &self.segment_id())
-                .field("offset", &self.offset())
+                .field("raw", &format_args!("0x{:011X}", self.0.as_raw()))
                 .finish()
         }
     }
@@ -152,13 +144,7 @@ impl fmt::Display for ItemLocation {
         if self.is_ghost() {
             write!(f, "GHOST")
         } else {
-            write!(
-                f,
-                "pool{}:seg{}:off{}",
-                self.pool_id(),
-                self.segment_id(),
-                self.offset()
-            )
+            write!(f, "pool{}:0x{:011X}", self.pool_id(), self.0.as_raw())
         }
     }
 }
@@ -181,23 +167,28 @@ impl From<ItemLocation> for Location {
 
 /// Single-pool segment verifier.
 ///
-/// Used when there's only one segment pool (pool_id is ignored).
+/// Used when there's only one segment pool (pool_id is ignored). The layout is
+/// carried alongside the segments because decoding a location needs the owning
+/// pool's bit split.
 pub struct SinglePoolVerifier<'a, S> {
+    layout: LocationLayout,
     segments: &'a [S],
 }
 
 impl<'a, S> SinglePoolVerifier<'a, S> {
     /// Create a new single-pool verifier.
-    pub fn new(segments: &'a [S]) -> Self {
-        Self { segments }
+    ///
+    /// `layout` must be the layout of the pool that owns `segments`.
+    pub fn new(layout: LocationLayout, segments: &'a [S]) -> Self {
+        Self { layout, segments }
     }
 }
 
 impl<S: SegmentKeyVerify + Send + Sync> KeyVerifier for SinglePoolVerifier<'_, S> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let segment_id = item_loc.segment_id() as usize;
-        let offset = item_loc.offset();
+        let segment_id = item_loc.segment_id(&self.layout) as usize;
+        let offset = item_loc.offset(&self.layout);
 
         if let Some(segment) = self.segments.get(segment_id) {
             segment.verify_key_at_offset(offset, key, allow_deleted)
@@ -208,8 +199,12 @@ impl<S: SegmentKeyVerify + Send + Sync> KeyVerifier for SinglePoolVerifier<'_, S
 }
 
 /// Multi-pool segment verifier with up to 4 pools.
+///
+/// Each pool carries its own [`LocationLayout`]: pools with different segment
+/// sizes or alignment factors split the location bits differently, so the
+/// pool_id is read first and its layout decodes the rest.
 pub struct MultiPoolVerifier<'a, S> {
-    pools: [Option<&'a [S]>; 4],
+    pools: [Option<(LocationLayout, &'a [S])>; 4],
 }
 
 impl<'a, S> MultiPoolVerifier<'a, S> {
@@ -218,13 +213,13 @@ impl<'a, S> MultiPoolVerifier<'a, S> {
         Self { pools: [None; 4] }
     }
 
-    /// Add a pool at the specified ID.
+    /// Add a pool at the specified ID, with that pool's layout.
     ///
     /// # Panics
     /// Panics if pool_id >= 4.
-    pub fn with_pool(mut self, pool_id: u8, segments: &'a [S]) -> Self {
+    pub fn with_pool(mut self, pool_id: u8, layout: LocationLayout, segments: &'a [S]) -> Self {
         assert!(pool_id < 4, "pool_id must be 0-3");
-        self.pools[pool_id as usize] = Some(segments);
+        self.pools[pool_id as usize] = Some((layout, segments));
         self
     }
 }
@@ -239,16 +234,17 @@ impl<S: SegmentKeyVerify + Send + Sync> KeyVerifier for MultiPoolVerifier<'_, S>
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
         let pool_id = item_loc.pool_id() as usize;
-        let segment_id = item_loc.segment_id() as usize;
-        let offset = item_loc.offset();
 
-        if pool_id >= 4 {
+        // pool_id is 2 bits, so this cannot be out of range -- but the index is
+        // kept honest rather than unchecked.
+        let Some((layout, segments)) = self.pools.get(pool_id).copied().flatten() else {
             return false;
-        }
+        };
 
-        if let Some(segments) = self.pools[pool_id]
-            && let Some(segment) = segments.get(segment_id)
-        {
+        let segment_id = item_loc.segment_id(&layout) as usize;
+        let offset = item_loc.offset(&layout);
+
+        if let Some(segment) = segments.get(segment_id) {
             return segment.verify_key_at_offset(offset, key, allow_deleted);
         }
 
@@ -281,104 +277,91 @@ where
 mod tests {
     use super::*;
 
+    fn mem_layout() -> LocationLayout {
+        LocationLayout::new(1024 * 1024, 8).unwrap()
+    }
+
     #[test]
     fn test_new_and_accessors() {
-        let loc = ItemLocation::new(2, 1000, 4096);
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 2, 1000, 5, 4096);
         assert_eq!(loc.pool_id(), 2);
-        assert_eq!(loc.segment_id(), 1000);
-        assert_eq!(loc.offset(), 4096);
+        assert_eq!(loc.segment_id(&l), 1000);
+        assert_eq!(loc.incarnation(&l), 5);
+        assert_eq!(loc.offset(&l), 4096);
         assert!(!loc.is_ghost());
     }
 
     #[test]
-    fn test_max_values() {
-        let loc = ItemLocation::new(3, ItemLocation::MAX_SEGMENT_ID, ItemLocation::MAX_OFFSET);
-        assert_eq!(loc.pool_id(), 3);
-        assert_eq!(loc.segment_id(), ItemLocation::MAX_SEGMENT_ID);
-        assert_eq!(loc.offset(), ItemLocation::MAX_OFFSET);
+    fn test_unpack_matches_individual_accessors() {
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 1, 12345, 63, 8192);
+        assert_eq!(
+            loc.unpack(&l),
+            (
+                loc.pool_id(),
+                loc.segment_id(&l),
+                loc.incarnation(&l),
+                loc.offset(&l)
+            )
+        );
+    }
+
+    #[test]
+    fn test_incarnation_survives_a_location_roundtrip() {
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 1, 12345, 42, 8192);
+        let back = ItemLocation::from_location(loc.to_location());
+        assert_eq!(back.incarnation(&l), 42);
+        assert_eq!(back.segment_id(&l), 12345);
+        assert_eq!(back.offset(&l), 8192);
+    }
+
+    #[test]
+    fn test_pool_id_decodes_without_the_layout() {
+        // pool_id must be readable before the layout is known -- that is what
+        // lets pools with different segment sizes share one location space.
+        let mem = LocationLayout::new(1024 * 1024, 8).unwrap();
+        let disk = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
+        assert_eq!(ItemLocation::new(&mem, 1, 5, 0, 0).pool_id(), 1);
+        assert_eq!(ItemLocation::new(&disk, 3, 5, 0, 0).pool_id(), 3);
     }
 
     #[test]
     fn test_min_values() {
-        let loc = ItemLocation::new(0, 0, 0);
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 0, 0, 0, 0);
         assert_eq!(loc.pool_id(), 0);
-        assert_eq!(loc.segment_id(), 0);
-        assert_eq!(loc.offset(), 0);
+        assert_eq!(loc.segment_id(&l), 0);
+        assert_eq!(loc.incarnation(&l), 0);
+        assert_eq!(loc.offset(&l), 0);
         assert!(!loc.is_ghost());
     }
 
     #[test]
-    fn test_location_roundtrip() {
-        let loc = ItemLocation::new(1, 12345, 8192);
-        let raw_location = loc.to_location();
-        let loc2 = ItemLocation::from_location(raw_location);
-        assert_eq!(loc.pool_id(), loc2.pool_id());
-        assert_eq!(loc.segment_id(), loc2.segment_id());
-        assert_eq!(loc.offset(), loc2.offset());
-    }
-
-    #[test]
-    fn test_offset_alignment() {
-        // Offset must be 8-byte aligned
-        for offset in (0..1024).step_by(8) {
-            let loc = ItemLocation::new(0, 0, offset);
-            assert_eq!(loc.offset(), offset);
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "pool_id must be 0-3")]
-    #[cfg(debug_assertions)]
-    fn test_invalid_pool_id() {
-        ItemLocation::new(4, 0, 0);
-    }
-
-    #[test]
-    #[should_panic(expected = "offset must be 8-byte aligned")]
-    #[cfg(debug_assertions)]
-    fn test_unaligned_offset() {
-        ItemLocation::new(0, 0, 7);
-    }
-
-    #[test]
-    fn test_bit_packing() {
-        // Verify bit layout matches documentation
-        // 18-bit segment_id max = 0x3_FFFF, 24-bit offset/8 max * 8 = 0x7FF_FFF8
-        let loc = ItemLocation::new(0b11, 0x3_FFFF, 0x7FF_FFF8);
-
-        // Pool bits should be at position 42-43
-        assert_eq!((loc.to_location().as_raw() >> 42) & 0b11, 0b11);
-
-        // Segment bits should be at position 24-41
-        assert_eq!((loc.to_location().as_raw() >> 24) & 0x3_FFFF, 0x3_FFFF);
-
-        // Offset/8 bits should be at position 0-23
-        assert_eq!(loc.to_location().as_raw() & 0xFF_FFFF, 0x7FF_FFF8 / 8);
-    }
-
-    #[test]
     fn test_display() {
-        let loc = ItemLocation::new(1, 42, 128);
-        assert_eq!(format!("{}", loc), "pool1:seg42:off128");
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 1, 42, 0, 128);
+        let raw = loc.to_location().as_raw();
+        assert_eq!(format!("{}", loc), format!("pool1:0x{raw:011X}"));
     }
 
     #[test]
     fn test_debug() {
-        let loc = ItemLocation::new(0, 1, 8);
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 0, 1, 0, 8);
         let debug_str = format!("{:?}", loc);
         assert!(debug_str.contains("pool_id"));
-        assert!(debug_str.contains("segment_id"));
-        assert!(debug_str.contains("offset"));
+        assert!(debug_str.contains("raw"));
     }
 
     #[test]
     fn test_from_into() {
-        let item_loc = ItemLocation::new(1, 100, 256);
+        let l = mem_layout();
+        let item_loc = ItemLocation::new(&l, 1, 100, 7, 256);
         let location: Location = item_loc.into();
         let back: ItemLocation = location.into();
-        assert_eq!(item_loc.pool_id(), back.pool_id());
-        assert_eq!(item_loc.segment_id(), back.segment_id());
-        assert_eq!(item_loc.offset(), back.offset());
+        assert_eq!(item_loc.unpack(&l), back.unpack(&l));
     }
 
     // Mock segment for verifier tests
@@ -420,6 +403,7 @@ mod tests {
 
     #[test]
     fn test_single_pool_verifier() {
+        let l = mem_layout();
         let segments = vec![
             MockSegment {
                 keys: vec![(0, b"key0".to_vec(), false)],
@@ -428,10 +412,10 @@ mod tests {
                 keys: vec![(8, b"key1".to_vec(), false)],
             },
         ];
-        let verifier = SinglePoolVerifier::new(&segments);
+        let verifier = SinglePoolVerifier::new(l, &segments);
 
-        let loc0 = ItemLocation::new(0, 0, 0);
-        let loc1 = ItemLocation::new(0, 1, 8);
+        let loc0 = ItemLocation::new(&l, 0, 0, 0, 0);
+        let loc1 = ItemLocation::new(&l, 0, 1, 0, 8);
 
         assert!(verifier.verify(b"key0", loc0.to_location(), false));
         assert!(verifier.verify(b"key1", loc1.to_location(), false));
@@ -440,7 +424,14 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_pool_verifier() {
+    fn test_multi_pool_verifier_decodes_each_pool_with_its_own_layout() {
+        // The two pools have different segment sizes, so their bit splits
+        // differ: decoding pool 2's location with pool 0's layout would name a
+        // different segment entirely.
+        let l0 = LocationLayout::new(1024 * 1024, 8).unwrap();
+        let l2 = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
+        assert_ne!(l0.offset_bits(), l2.offset_bits());
+
         let pool0 = vec![MockSegment {
             keys: vec![(0, b"pool0_key".to_vec(), false)],
         }];
@@ -449,18 +440,18 @@ mod tests {
                 keys: vec![(0, b"pool2_seg0".to_vec(), false)],
             },
             MockSegment {
-                keys: vec![(8, b"pool2_seg1".to_vec(), false)],
+                keys: vec![(512, b"pool2_seg1".to_vec(), false)],
             },
         ];
 
         let verifier = MultiPoolVerifier::new()
-            .with_pool(0, &pool0)
-            .with_pool(2, &pool2);
+            .with_pool(0, l0, &pool0)
+            .with_pool(2, l2, &pool2);
 
-        let loc0 = ItemLocation::new(0, 0, 0);
-        let loc2_0 = ItemLocation::new(2, 0, 0);
-        let loc2_1 = ItemLocation::new(2, 1, 8);
-        let loc1 = ItemLocation::new(1, 0, 0); // pool 1 not set
+        let loc0 = ItemLocation::new(&l0, 0, 0, 0, 0);
+        let loc2_0 = ItemLocation::new(&l2, 2, 0, 0, 0);
+        let loc2_1 = ItemLocation::new(&l2, 2, 1, 9, 512);
+        let loc1 = ItemLocation::new(&l0, 1, 0, 0, 0); // pool 1 not set
 
         assert!(verifier.verify(b"pool0_key", loc0.to_location(), false));
         assert!(verifier.verify(b"pool2_seg0", loc2_0.to_location(), false));
@@ -470,13 +461,14 @@ mod tests {
 
     #[test]
     fn test_fn_verifier() {
-        let verifier = FnVerifier::new(|key: &[u8], location: Location, _allow_deleted| {
+        let l = mem_layout();
+        let verifier = FnVerifier::new(move |key: &[u8], location: Location, _allow_deleted| {
             let item_loc = ItemLocation::from_location(location);
-            key == b"magic" && item_loc.segment_id() == 42
+            key == b"magic" && item_loc.segment_id(&l) == 42
         });
 
-        let loc_match = ItemLocation::new(0, 42, 0);
-        let loc_nomatch = ItemLocation::new(0, 99, 0);
+        let loc_match = ItemLocation::new(&l, 0, 42, 0, 0);
+        let loc_nomatch = ItemLocation::new(&l, 0, 99, 0, 0);
 
         assert!(verifier.verify(b"magic", loc_match.to_location(), false));
         assert!(!verifier.verify(b"magic", loc_nomatch.to_location(), false));
@@ -485,12 +477,13 @@ mod tests {
 
     #[test]
     fn test_deleted_handling() {
+        let l = mem_layout();
         let segments = vec![MockSegment {
             keys: vec![(0, b"deleted_key".to_vec(), true)],
         }];
-        let verifier = SinglePoolVerifier::new(&segments);
+        let verifier = SinglePoolVerifier::new(l, &segments);
 
-        let loc = ItemLocation::new(0, 0, 0);
+        let loc = ItemLocation::new(&l, 0, 0, 0, 0);
 
         // allow_deleted=false should not match
         assert!(!verifier.verify(b"deleted_key", loc.to_location(), false));

--- a/cache/core/src/layer/fifo_layer.rs
+++ b/cache/core/src/layer/fifo_layer.rs
@@ -123,8 +123,13 @@ impl FifoLayer {
                         let key_len = header.key_len() as usize;
 
                         if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             let verifier = SinglePoolVerifier { pool: &self.pool };
                             let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -197,8 +202,13 @@ impl FifoLayer {
                         let key_len = header.key_len() as usize;
 
                         if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             let verifier = SinglePoolVerifier { pool: &self.pool };
                             let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -282,8 +292,13 @@ impl FifoLayer {
                         let key_len = header.key_len() as usize;
 
                         if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             // Get frequency from hashtable
                             let verifier = SinglePoolVerifier { pool: &self.pool };
@@ -371,8 +386,13 @@ impl FifoLayer {
                         let value_len = header.value_len() as usize;
 
                         if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             // Get frequency from hashtable
                             let verifier = SinglePoolVerifier { pool: &self.pool };
@@ -470,8 +490,13 @@ impl FifoLayer {
                         let value_len = header.value_len() as usize;
 
                         if let Some(key) = segment.data_slice(key_start as u32, key_len) {
-                            let location =
-                                ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                            let location = ItemLocation::new(
+                                self.pool.layout(),
+                                self.pool.pool_id(),
+                                segment_id,
+                                segment.incarnation(),
+                                offset,
+                            );
 
                             let verifier = SinglePoolVerifier { pool: &self.pool };
                             let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -537,8 +562,9 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        if let Some(segment) = self.pool.get(item_loc.segment_id()) {
-            segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        let layout = self.pool.layout();
+        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
+            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
         } else {
             false
         }
@@ -582,7 +608,13 @@ impl Layer for FifoLayer {
                 // Try to append with per-item TTL
                 if let Some(offset) = segment.append_item_with_ttl(key, value, optional, expire_at)
                 {
-                    return Ok(ItemLocation::new(self.pool.pool_id(), segment_id, offset));
+                    return Ok(ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    ));
                 }
 
                 // Segment is full, need to allocate a new one
@@ -600,7 +632,8 @@ impl Layer for FifoLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
 
         // Check segment state
         let state = segment.state();
@@ -610,12 +643,10 @@ impl Layer for FifoLayer {
 
         // Verify key matches and check expiration in one parse (before acquiring ref count)
         let now = Self::now_secs();
-        let header_info = segment.verify_key_unexpired(location.offset(), key, now)?;
+        let header_info = segment.verify_key_unexpired(offset, key, now)?;
 
         // Get item using pre-verified header info (single parse path)
-        segment
-            .get_item_verified(location.offset(), header_info)
-            .ok()
+        segment.get_item_verified(offset, header_info).ok()
     }
 
     fn mark_deleted(&self, location: ItemLocation) {
@@ -623,11 +654,11 @@ impl Layer for FifoLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
             // We need the key to mark deleted, but we don't have it here.
             // This is a limitation - mark_deleted needs to be called with key.
             // For now, we skip the key verification by getting it from the segment.
-            let offset = location.offset();
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE)
                 && let Some(header) = unsafe { TtlHeader::try_from_ptr(data) }
             {
@@ -645,9 +676,10 @@ impl Layer for FifoLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
         let now = Self::now_secs();
-        segment.item_ttl(location.offset(), now)
+        segment.item_ttl(offset, now)
     }
 
     fn evict<H: Hashtable>(&self, hashtable: &H) -> bool {
@@ -720,7 +752,13 @@ impl Layer for FifoLayer {
                 if let Some((offset, item_size, value_ptr)) =
                     segment.begin_append_with_ttl(key, value_len, optional, expire_at)
                 {
-                    let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                    let location = ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    );
                     return Ok((location, value_ptr, item_size));
                 }
 
@@ -737,7 +775,7 @@ impl Layer for FifoLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        if let Some(segment) = self.pool.get(location.segment_id(self.pool.layout())) {
             segment.finalize_append(item_size);
         }
     }
@@ -747,8 +785,9 @@ impl Layer for FifoLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
-            segment.mark_deleted_at_offset(location.offset());
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            segment.mark_deleted_at_offset(offset);
         }
     }
 
@@ -941,6 +980,41 @@ mod tests {
     }
 
     #[test]
+    fn test_written_location_carries_the_segments_incarnation() {
+        let layer = create_test_layer();
+        let pool = layer.pool();
+
+        // A fresh pool hands out incarnation 0, and a location stamped with a
+        // hardcoded 0 would match that by accident. Cycle every segment through
+        // a used incarnation first, so whichever one the layer picks for the
+        // write carries a non-zero tag.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+            assert_ne!(segment.incarnation(), 0, "leaving Locked must bump the tag");
+        }
+
+        let location = layer
+            .write_item(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write must succeed");
+
+        let (_, segment_id, incarnation, _) = location.unpack(pool.layout());
+        assert_ne!(
+            incarnation, 0,
+            "the published tag must come from the segment, not a constant"
+        );
+        assert_eq!(
+            incarnation,
+            pool.get(segment_id).unwrap().incarnation(),
+            "a location must carry the tag of the segment its item was written into"
+        );
+    }
+
+    #[test]
     fn test_layer_creation() {
         let layer = create_test_layer();
         assert_eq!(layer.layer_id(), 0);
@@ -1048,7 +1122,11 @@ mod tests {
             .unwrap();
 
         // Create a location with wrong pool_id (must be 0-3)
-        let wrong_location = ItemLocation::new(1, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 1, segment_id, incarnation, offset);
 
         let guard = layer.get_item(wrong_location, key);
         assert!(guard.is_none());
@@ -1095,7 +1173,11 @@ mod tests {
             .unwrap();
 
         // Pool_id must be 0-3, use 1 which is different from layer's pool_id of 0
-        let wrong_location = ItemLocation::new(1, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 1, segment_id, incarnation, offset);
         let ttl = layer.item_ttl(wrong_location);
         assert!(ttl.is_none());
     }
@@ -1110,7 +1192,11 @@ mod tests {
             .unwrap();
 
         // Pool_id must be 0-3, use 1 which is different from layer's pool_id of 0
-        let wrong_location = ItemLocation::new(1, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 1, segment_id, incarnation, offset);
         // Should not panic, just be a no-op
         layer.mark_deleted(wrong_location);
     }
@@ -1152,8 +1238,9 @@ mod tests {
         let loc3 = layer.write_item(b"key3", b"value3", b"", ttl).unwrap();
 
         // All items should be in the same segment (FIFO chain)
-        assert_eq!(loc1.segment_id(), loc2.segment_id());
-        assert_eq!(loc2.segment_id(), loc3.segment_id());
+        let layout = layer.pool().layout();
+        assert_eq!(loc1.segment_id(layout), loc2.segment_id(layout));
+        assert_eq!(loc2.segment_id(layout), loc3.segment_id(layout));
 
         // All items should be retrievable
         assert!(layer.get_item(loc1, b"key1").is_some());
@@ -1323,7 +1410,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Create a location with an invalid segment ID
-        let invalid_location = ItemLocation::new(0, 999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 0, 999, 0, 0);
         let guard = layer.get_item(invalid_location, b"key");
         assert!(guard.is_none());
     }
@@ -1333,7 +1420,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Create a location with an invalid segment ID
-        let invalid_location = ItemLocation::new(0, 999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 0, 999, 0, 0);
         let ttl = layer.item_ttl(invalid_location);
         assert!(ttl.is_none());
     }
@@ -1343,7 +1430,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Create a location with an invalid segment ID
-        let invalid_location = ItemLocation::new(0, 999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 0, 999, 0, 0);
         // Should not panic, just be a no-op
         layer.mark_deleted(invalid_location);
     }

--- a/cache/core/src/layer/fifo_layer.rs
+++ b/cache/core/src/layer/fifo_layer.rs
@@ -115,7 +115,10 @@ impl FifoLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE) {
                 if let Some(header) = unsafe { TtlHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     if !header.is_deleted() && !header.is_expired(now) {
                         let key_start =
@@ -194,7 +197,10 @@ impl FifoLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE) {
                 if let Some(header) = unsafe { TtlHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     if !header.is_deleted() && !header.is_expired(now) {
                         let key_start =
@@ -282,7 +288,10 @@ impl FifoLayer {
             // Try to read header at offset
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE) {
                 if let Some(header) = unsafe { TtlHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     // Skip if already deleted or expired
                     if !header.is_deleted() && !header.is_expired(now) {
@@ -373,7 +382,10 @@ impl FifoLayer {
             // Try to read header at offset
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE) {
                 if let Some(header) = unsafe { TtlHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     // Skip if already deleted or expired
                     if !header.is_deleted() && !header.is_expired(now) {
@@ -479,7 +491,10 @@ impl FifoLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, TtlHeader::SIZE) {
                 if let Some(header) = unsafe { TtlHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     if !header.is_deleted() && !header.is_expired(now) {
                         let optional_start = offset as usize + TtlHeader::SIZE;

--- a/cache/core/src/layer/fifo_layer.rs
+++ b/cache/core/src/layer/fifo_layer.rs
@@ -577,9 +577,15 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let layout = self.pool.layout();
-        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
-            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
+            segment.verify_key_at_offset(offset, key, allow_deleted)
         } else {
             false
         }
@@ -1026,6 +1032,49 @@ mod tests {
             incarnation,
             pool.get(segment_id).unwrap().incarnation(),
             "a location must carry the tag of the segment its item was written into"
+        );
+    }
+
+    /// A location from a previous incarnation must not resolve, even though
+    /// the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_verifier_rejects_a_stale_incarnation() {
+        let layer = create_test_layer();
+        let pool = layer.pool();
+
+        // Age every segment through a used incarnation, so the tag the write
+        // stamps is non-zero and a predecessor tag exists to test against.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+        }
+
+        let live = layer
+            .write_item(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write");
+        let layout = pool.layout();
+        let (pool_id, segment_id, tag, offset) = live.unpack(layout);
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        // Same segment, same offset, previous tag.
+        let stale = ItemLocation::new(layout, pool_id, segment_id, tag - 1, offset);
+        let verifier = SinglePoolVerifier { pool };
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
         );
     }
 

--- a/cache/core/src/layer/ttl_layer.rs
+++ b/cache/core/src/layer/ttl_layer.rs
@@ -66,9 +66,15 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        let layout = self.pool.layout();
-        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
-            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            // A location naming a previous incarnation of this segment is not ours
+            // to resolve: the segment was drained and refilled, and this offset now
+            // holds a different item. Checked before touching any item bytes.
+            if segment.incarnation() != incarnation {
+                return false;
+            }
+            segment.verify_key_at_offset(offset, key, allow_deleted)
         } else {
             false
         }
@@ -1716,6 +1722,49 @@ mod tests {
             incarnation,
             pool.get(segment_id).unwrap().incarnation(),
             "a location must carry the tag of the segment its item was written into"
+        );
+    }
+
+    /// A location from a previous incarnation must not resolve, even though
+    /// the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_verifier_rejects_a_stale_incarnation() {
+        let layer = create_test_layer();
+        let pool = layer.pool();
+
+        // Age every segment through a used incarnation, so the tag the write
+        // stamps is non-zero and a predecessor tag exists to test against.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+        }
+
+        let live = layer
+            .write_item(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write");
+        let layout = pool.layout();
+        let (pool_id, segment_id, tag, offset) = live.unpack(layout);
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        // Same segment, same offset, previous tag.
+        let stale = ItemLocation::new(layout, pool_id, segment_id, tag - 1, offset);
+        let verifier = SinglePoolVerifier { pool };
+
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
         );
     }
 

--- a/cache/core/src/layer/ttl_layer.rs
+++ b/cache/core/src/layer/ttl_layer.rs
@@ -179,7 +179,10 @@ impl TtlLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let key_start =
                         offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -253,7 +256,10 @@ impl TtlLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let key_start =
                         offset as usize + BasicHeader::SIZE + header.optional_len() as usize;
@@ -333,7 +339,10 @@ impl TtlLayer {
         while offset < write_offset {
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     let optional_start = offset as usize + BasicHeader::SIZE;
                     let optional_len = header.optional_len() as usize;
@@ -455,7 +464,10 @@ impl TtlLayer {
             // Get header at offset
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     // Get key for this item
                     let key_start =
@@ -633,7 +645,10 @@ impl TtlLayer {
             while offset < write_offset {
                 if let Some(data) = src.header_ptr(offset, header_size) {
                     if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                        let item_size = header.padded_size() as u32;
+                        // The segment's stride, not the 8-byte padded body size: a scan
+                        // that advances by anything but what the append advanced by
+                        // desyncs after the first item on a coarser-aligned pool.
+                        let item_size = src.item_stride(header.padded_size());
 
                         // Skip deleted items
                         if !header.is_deleted() {
@@ -816,7 +831,10 @@ impl TtlLayer {
             // Get header at offset
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE) {
                 if let Some(header) = unsafe { BasicHeader::try_from_ptr(data) } {
-                    let item_size = header.padded_size() as u32;
+                    // The segment's stride, not the 8-byte padded body size: a scan
+                    // that advances by anything but what the append advanced by
+                    // desyncs after the first item on a coarser-aligned pool.
+                    let item_size = segment.item_stride(header.padded_size());
 
                     // Calculate offsets for key, value, optional
                     let optional_start = offset as usize + BasicHeader::SIZE;
@@ -1067,7 +1085,10 @@ impl TtlLayer {
                     Some(h) => h,
                     None => break,
                 };
-                let item_size = header.padded_size() as u32;
+                // The segment's stride, not the 8-byte padded body size: a scan
+                // that advances by anything but what the append advanced by
+                // desyncs after the first item on a coarser-aligned pool.
+                let item_size = segment.item_stride(header.padded_size());
 
                 if header.is_deleted() {
                     offset += item_size;

--- a/cache/core/src/layer/ttl_layer.rs
+++ b/cache/core/src/layer/ttl_layer.rs
@@ -66,8 +66,9 @@ struct SinglePoolVerifier<'a> {
 impl KeyVerifier for SinglePoolVerifier<'_> {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let item_loc = ItemLocation::from_location(location);
-        if let Some(segment) = self.pool.get(item_loc.segment_id()) {
-            segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        let layout = self.pool.layout();
+        if let Some(segment) = self.pool.get(item_loc.segment_id(layout)) {
+            segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
         } else {
             false
         }
@@ -187,7 +188,13 @@ impl TtlLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         let verifier = SinglePoolVerifier { pool: &self.pool };
                         let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -255,7 +262,13 @@ impl TtlLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         let verifier = SinglePoolVerifier { pool: &self.pool };
                         let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -332,7 +345,13 @@ impl TtlLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         let verifier = SinglePoolVerifier { pool: &self.pool };
                         let freq = hashtable.get_frequency(key, &verifier).unwrap_or(0);
@@ -446,7 +465,13 @@ impl TtlLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         // Get frequency from hashtable
                         let verifier = SinglePoolVerifier { pool: &self.pool };
@@ -625,10 +650,20 @@ impl TtlLayer {
                                 src.data_slice(optional_start as u32, optional_len),
                             ) && let Some(new_offset) = spare.append_item(key, value, optional)
                             {
-                                let old_loc =
-                                    ItemLocation::new(self.pool.pool_id(), src_id, offset);
-                                let new_loc =
-                                    ItemLocation::new(self.pool.pool_id(), spare_id, new_offset);
+                                let old_loc = ItemLocation::new(
+                                    self.pool.layout(),
+                                    self.pool.pool_id(),
+                                    src_id,
+                                    src.incarnation(),
+                                    offset,
+                                );
+                                let new_loc = ItemLocation::new(
+                                    self.pool.layout(),
+                                    self.pool.pool_id(),
+                                    spare_id,
+                                    spare.incarnation(),
+                                    new_offset,
+                                );
 
                                 // Update hashtable (preserve frequency)
                                 if !hashtable.cas_location(
@@ -794,7 +829,13 @@ impl TtlLayer {
                     if let Some(key) = segment.data_slice(key_start as u32, key_len)
                         && !header.is_deleted()
                     {
-                        let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            segment_id,
+                            segment.incarnation(),
+                            offset,
+                        );
 
                         // Get frequency from hashtable
                         let verifier = SinglePoolVerifier { pool: &self.pool };
@@ -1057,8 +1098,20 @@ impl TtlLayer {
                         .unwrap_or(&[]);
 
                     if let Some(new_offset) = spare.append_item(key, value, optional) {
-                        let old_loc = ItemLocation::new(self.pool.pool_id(), cand_id, offset);
-                        let new_loc = ItemLocation::new(self.pool.pool_id(), spare_id, new_offset);
+                        let old_loc = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            cand_id,
+                            segment.incarnation(),
+                            offset,
+                        );
+                        let new_loc = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            spare_id,
+                            spare.incarnation(),
+                            new_offset,
+                        );
 
                         // Update hashtable (preserve frequency)
                         if !hashtable.cas_location(
@@ -1073,7 +1126,13 @@ impl TtlLayer {
                         seg_retained += 1;
                     } else {
                         // Spare is full — discard remaining items
-                        let location = ItemLocation::new(self.pool.pool_id(), cand_id, offset);
+                        let location = ItemLocation::new(
+                            self.pool.layout(),
+                            self.pool.pool_id(),
+                            cand_id,
+                            segment.incarnation(),
+                            offset,
+                        );
                         if self.config.create_ghosts {
                             hashtable.convert_to_ghost(key, location.to_location());
                         } else {
@@ -1083,7 +1142,13 @@ impl TtlLayer {
                     }
                 } else {
                     // Frequency too low — discard (convert to ghost or remove)
-                    let location = ItemLocation::new(self.pool.pool_id(), cand_id, offset);
+                    let location = ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        cand_id,
+                        segment.incarnation(),
+                        offset,
+                    );
                     if self.config.create_ghosts {
                         hashtable.convert_to_ghost(key, location.to_location());
                     } else {
@@ -1161,7 +1226,13 @@ impl Layer for TtlLayer {
             if let Some(segment) = self.pool.get(segment_id) {
                 // Try to append
                 if let Some(offset) = segment.append_item(key, value, optional) {
-                    return Ok(ItemLocation::new(self.pool.pool_id(), segment_id, offset));
+                    return Ok(ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    ));
                 }
 
                 // Segment is full, need to allocate a new one
@@ -1186,7 +1257,8 @@ impl Layer for TtlLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        let segment = self.pool.get(segment_id)?;
 
         // Check segment state
         let state = segment.state();
@@ -1202,12 +1274,10 @@ impl Layer for TtlLayer {
         }
 
         // Verify key matches (before acquiring ref count)
-        let header_info = segment.verify_key_unexpired(location.offset(), key, now)?;
+        let header_info = segment.verify_key_unexpired(offset, key, now)?;
 
         // Get item using pre-verified header info (single parse path)
-        segment
-            .get_item_verified(location.offset(), header_info)
-            .ok()
+        segment.get_item_verified(offset, header_info).ok()
     }
 
     fn mark_deleted(&self, location: ItemLocation) {
@@ -1215,10 +1285,10 @@ impl Layer for TtlLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
             // We need the key to mark deleted.
             // Get it from the segment header.
-            let offset = location.offset();
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE)
                 && let Some(header) = unsafe { BasicHeader::try_from_ptr(data) }
             {
@@ -1229,7 +1299,7 @@ impl Layer for TtlLayer {
                     let _ = segment.mark_deleted(offset, key);
 
                     // Try to free segment if now empty
-                    self.try_free_empty_segment(location.segment_id());
+                    self.try_free_empty_segment(segment_id);
                 }
             }
         }
@@ -1240,7 +1310,7 @@ impl Layer for TtlLayer {
             return None;
         }
 
-        let segment = self.pool.get(location.segment_id())?;
+        let segment = self.pool.get(location.segment_id(self.pool.layout()))?;
         let now = Self::now_secs();
         segment.segment_ttl(now)
     }
@@ -1311,7 +1381,13 @@ impl Layer for TtlLayer {
                 if let Some((offset, item_size, value_ptr)) =
                     segment.begin_append(key, value_len, optional)
                 {
-                    let location = ItemLocation::new(self.pool.pool_id(), segment_id, offset);
+                    let location = ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    );
                     return Ok((location, value_ptr, item_size));
                 }
 
@@ -1335,7 +1411,7 @@ impl Layer for TtlLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        if let Some(segment) = self.pool.get(location.segment_id(self.pool.layout())) {
             segment.finalize_append(item_size);
         }
     }
@@ -1345,8 +1421,9 @@ impl Layer for TtlLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
-            segment.mark_deleted_at_offset(location.offset());
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
+            segment.mark_deleted_at_offset(offset);
         }
     }
 
@@ -1355,9 +1432,9 @@ impl Layer for TtlLayer {
             return;
         }
 
-        if let Some(segment) = self.pool.get(location.segment_id()) {
+        let (_, segment_id, _, offset) = location.unpack(self.pool.layout());
+        if let Some(segment) = self.pool.get(segment_id) {
             // Mark the item as deleted (same as mark_deleted)
-            let offset = location.offset();
             if let Some(data) = segment.header_ptr(offset, BasicHeader::SIZE)
                 && let Some(header) = unsafe { BasicHeader::try_from_ptr(data) }
             {
@@ -1368,12 +1445,12 @@ impl Layer for TtlLayer {
                     let _ = segment.mark_deleted(offset, key);
 
                     // Try to free segment if now empty
-                    if self.try_free_empty_segment(location.segment_id()) {
+                    if self.try_free_empty_segment(segment_id) {
                         return;
                     }
 
                     // Try compaction with predecessor
-                    self.try_compact_segment(location.segment_id(), hashtable);
+                    self.try_compact_segment(segment_id, hashtable);
                 }
             }
         }
@@ -1587,6 +1664,41 @@ mod tests {
     }
 
     #[test]
+    fn test_written_location_carries_the_segments_incarnation() {
+        let layer = create_test_layer();
+        let pool = layer.pool();
+
+        // A fresh pool hands out incarnation 0, and a location stamped with a
+        // hardcoded 0 would match that by accident. Cycle every segment through
+        // a used incarnation first, so whichever one the layer picks for the
+        // write carries a non-zero tag.
+        let ids: Vec<u32> = (0..pool.segment_count())
+            .map(|_| pool.reserve().expect("pool must have a free segment"))
+            .collect();
+        for &id in &ids {
+            let segment = pool.get(id).expect("segment id came from the pool");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            pool.release(id);
+            assert_ne!(segment.incarnation(), 0, "leaving Locked must bump the tag");
+        }
+
+        let location = layer
+            .write_item(b"key", b"value", b"", Duration::from_secs(3600))
+            .expect("write must succeed");
+
+        let (_, segment_id, incarnation, _) = location.unpack(pool.layout());
+        assert_ne!(
+            incarnation, 0,
+            "the published tag must come from the segment, not a constant"
+        );
+        assert_eq!(
+            incarnation,
+            pool.get(segment_id).unwrap().incarnation(),
+            "a location must carry the tag of the segment its item was written into"
+        );
+    }
+
+    #[test]
     fn test_layer_creation() {
         let layer = create_test_layer();
         assert_eq!(layer.layer_id(), 1);
@@ -1727,7 +1839,11 @@ mod tests {
             .unwrap();
 
         // Create a location with wrong pool_id (must be 0-3)
-        let wrong_location = ItemLocation::new(0, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 0, segment_id, incarnation, offset);
 
         let guard = layer.get_item(wrong_location, key);
         assert!(guard.is_none());
@@ -1758,7 +1874,11 @@ mod tests {
             .unwrap();
 
         // Pool_id must be 0-3, use 0 which is different from layer's pool_id of 1
-        let wrong_location = ItemLocation::new(0, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 0, segment_id, incarnation, offset);
         let ttl = layer.item_ttl(wrong_location);
         assert!(ttl.is_none());
     }
@@ -1773,7 +1893,11 @@ mod tests {
             .unwrap();
 
         // Pool_id must be 0-3, use 0 which is different from layer's pool_id of 1
-        let wrong_location = ItemLocation::new(0, location.segment_id(), location.offset());
+        // Same segment, same incarnation -- only the pool is wrong, which is
+        // what this test is about.
+        let layout = layer.pool().layout();
+        let (_, segment_id, incarnation, offset) = location.unpack(layout);
+        let wrong_location = ItemLocation::new(layout, 0, segment_id, incarnation, offset);
         // Should not panic, just be a no-op
         layer.mark_deleted(wrong_location);
     }
@@ -1815,8 +1939,9 @@ mod tests {
         let loc3 = layer.write_item(b"key3", b"value3", b"", ttl).unwrap();
 
         // All items should be in the same segment (same TTL bucket)
-        assert_eq!(loc1.segment_id(), loc2.segment_id());
-        assert_eq!(loc2.segment_id(), loc3.segment_id());
+        let layout = layer.pool().layout();
+        assert_eq!(loc1.segment_id(layout), loc2.segment_id(layout));
+        assert_eq!(loc2.segment_id(layout), loc3.segment_id(layout));
 
         // All items should be retrievable
         assert!(layer.get_item(loc1, b"key1").is_some());
@@ -2019,7 +2144,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Try to get from an invalid segment ID
-        let invalid_location = ItemLocation::new(1, 9999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 1, 9999, 0, 0);
         let guard = layer.get_item(invalid_location, b"key");
         assert!(guard.is_none());
     }
@@ -2029,7 +2154,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Try to get TTL from an invalid segment ID
-        let invalid_location = ItemLocation::new(1, 9999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 1, 9999, 0, 0);
         let ttl = layer.item_ttl(invalid_location);
         assert!(ttl.is_none());
     }
@@ -2039,7 +2164,7 @@ mod tests {
         let layer = create_test_layer();
 
         // Try to mark deleted on an invalid segment
-        let invalid_location = ItemLocation::new(1, 9999, 0);
+        let invalid_location = ItemLocation::new(layer.pool().layout(), 1, 9999, 0, 0);
         // Should not panic
         layer.mark_deleted(invalid_location);
     }
@@ -2081,10 +2206,11 @@ mod tests {
 
         // Delete all items in the first segment
         // Find items from the first segment (should all have segment_id of the first allocated)
-        let first_segment_id = locations[0].1.segment_id();
+        let layout = layer.pool().layout();
+        let first_segment_id = locations[0].1.segment_id(layout);
         let items_in_first: Vec<_> = locations
             .iter()
-            .filter(|(_, loc)| loc.segment_id() == first_segment_id)
+            .filter(|(_, loc)| loc.segment_id(layout) == first_segment_id)
             .collect();
 
         // Delete all items in first segment

--- a/cache/core/src/lib.rs
+++ b/cache/core/src/lib.rs
@@ -66,7 +66,7 @@
 mod config;
 mod error;
 mod location;
-pub mod location_layout;
+mod location_layout;
 pub mod sync;
 
 // Segment-specific location interpretation
@@ -84,6 +84,7 @@ pub use error::{CacheError, CacheResult};
 // Location re-exports
 pub use item_location::{FnVerifier, ItemLocation, MultiPoolVerifier, SinglePoolVerifier};
 pub use location::Location;
+pub use location_layout::{LayoutError, LocationLayout, TAG_BITS, TAG_MASK};
 
 // Phase 2 re-exports
 pub use item::{BasicHeader, BasicItemGuard, ItemGuard, TtlHeader};

--- a/cache/core/src/lib.rs
+++ b/cache/core/src/lib.rs
@@ -66,6 +66,7 @@
 mod config;
 mod error;
 mod location;
+pub mod location_layout;
 pub mod sync;
 
 // Segment-specific location interpretation

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -395,17 +395,34 @@ mod tests {
     fn every_accepted_layout_can_represent_its_own_widest_offset() {
         // Guards the truncation the u32 bound exists to prevent: if `new`
         // accepts a layout, packing its widest offset must round-trip.
+        //
+        // The list MUST contain a size past the 4 GiB boundary. 4 GiB is where
+        // offset_bits + align_shift == 32 exactly -- still representable -- so a
+        // list stopping there never constructs a truncating layout and the test
+        // cannot go red when the bound is removed. 8 GiB is the first size that
+        // `new` would wrongly accept without it.
         for segment_size in [
             1024 * 1024usize,
             8 * 1024 * 1024,
             128 * 1024 * 1024,
             4 * 1024 * 1024 * 1024,
+            8 * 1024 * 1024 * 1024,
         ] {
             for align in [8usize, 512] {
                 let Ok(layout) = LocationLayout::new(segment_size, align) else {
                     continue;
                 };
-                let widest = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+
+                // Computed in u64 on purpose: in u32 this multiply would itself
+                // overflow and panic, reddening the test for the wrong reason.
+                let widest = ((1u64 << layout.offset_bits()) - 1) * layout.align_bytes() as u64;
+                assert!(
+                    widest <= u32::MAX as u64,
+                    "segment_size {segment_size} align {align} was accepted but \
+                     addresses past u32 (widest offset {widest})"
+                );
+
+                let widest = widest as u32;
                 assert_eq!(
                     layout.offset(layout.pack(0, 0, 0, widest)),
                     widest,

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -599,6 +599,11 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "exceeds this layout's 17-bit offset field")]
+    // `pack` guards with `debug_assert!`, which is compiled out in release, so
+    // there is no panic to expect there. Same gate as `location.rs`'s
+    // `test_overflow_panics`, and the reason `cargo test --release` exists as
+    // a separate CI job.
+    #[cfg(debug_assertions)]
     fn pack_rejects_an_offset_past_the_offset_field() {
         // One byte past a 1 MiB segment, and still 8-aligned, so the alignment
         // assert waves it through. Without the range check this silently
@@ -609,6 +614,8 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "is outside the issuable range")]
+    // Compiled out in release; see the note on the test above.
+    #[cfg(debug_assertions)]
     fn pack_rejects_the_unissuable_top_segment_id() {
         // The id reserved so Location::GHOST cannot be aliased. A pool must
         // never issue it, and pack must say so rather than encode it.

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -153,7 +153,17 @@ impl LocationLayout {
         let units = segment_size.div_ceil(align_bytes);
         let offset_bits = units.next_power_of_two().trailing_zeros();
 
-        if offset_bits + TAG_BITS >= PAYLOAD_BITS {
+        let align_shift = align_bytes.trailing_zeros();
+
+        // Two independent ceilings, both reported as SegmentTooLarge:
+        //
+        // 1. The offset field must leave room for segment ids.
+        // 2. The widest offset must fit in u32. Offsets are u32 throughout the
+        //    crate -- `SliceSegment::capacity`, `write_offset`, and
+        //    `ItemLocation::new` all use it -- so a layout that addresses past
+        //    u32 would truncate in `pack`/`offset` rather than error, and the
+        //    round trip would silently lose the high bits.
+        if offset_bits + TAG_BITS >= PAYLOAD_BITS || offset_bits + align_shift > 32 {
             return Err(LayoutError::SegmentTooLarge {
                 segment_size,
                 align: align_bytes,
@@ -162,7 +172,7 @@ impl LocationLayout {
         }
 
         Ok(Self {
-            align_shift: align_bytes.trailing_zeros() as u8,
+            align_shift: align_shift as u8,
             offset_bits: offset_bits as u8,
         })
     }
@@ -361,13 +371,48 @@ mod tests {
 
     #[test]
     fn rejects_segment_too_large_to_address() {
-        // offset_bits + 6 must leave room for segment ids, so at 8-byte
-        // alignment the ceiling is a 512 GiB segment (offset_bits == 36).
-        assert!(LocationLayout::new(256 * 1024 * 1024 * 1024, 8).is_ok());
+        // Offsets are u32 throughout the crate (`SliceSegment::capacity`,
+        // `write_offset`, `ItemLocation::new`), so the real ceiling is a layout
+        // whose widest offset still fits in u32: offset_bits + align_shift <= 32.
+        // At 8-byte alignment that is a 4 GiB segment, an order of magnitude
+        // above the 128 MB the tests exercise.
+        assert!(LocationLayout::new(4 * 1024 * 1024 * 1024, 8).is_ok());
         assert!(matches!(
-            LocationLayout::new(512 * 1024 * 1024 * 1024, 8),
+            LocationLayout::new(8 * 1024 * 1024 * 1024, 8),
             Err(LayoutError::SegmentTooLarge { .. })
         ));
+
+        // Coarser alignment does not buy past it: the offset field shifts left
+        // by align_shift, so the two trade off exactly.
+        assert!(LocationLayout::new(4 * 1024 * 1024 * 1024, 512).is_ok());
+        assert!(matches!(
+            LocationLayout::new(512 * 1024 * 1024 * 1024, 512),
+            Err(LayoutError::SegmentTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn every_accepted_layout_can_represent_its_own_widest_offset() {
+        // Guards the truncation the u32 bound exists to prevent: if `new`
+        // accepts a layout, packing its widest offset must round-trip.
+        for segment_size in [
+            1024 * 1024usize,
+            8 * 1024 * 1024,
+            128 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ] {
+            for align in [8usize, 512] {
+                let Ok(layout) = LocationLayout::new(segment_size, align) else {
+                    continue;
+                };
+                let widest = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+                assert_eq!(
+                    layout.offset(layout.pack(0, 0, 0, widest)),
+                    widest,
+                    "segment_size {segment_size} align {align} truncates its widest offset"
+                );
+            }
+        }
     }
 
     #[test]

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -65,6 +65,16 @@ pub enum LayoutError {
         /// The offset field width this combination would require.
         offset_bits: u32,
     },
+    /// `segment_size / align_bytes` yields so few offset units that more than
+    /// 31 segment-id bits remain, which a `u32` segment id cannot hold.
+    SegmentTooSmall {
+        /// The rejected segment size.
+        segment_size: usize,
+        /// The alignment factor in force.
+        align: usize,
+        /// Segment-id bits the split would have left.
+        seg_bits: u32,
+    },
     /// The pool has more segments than the layout can address.
     TooManySegments {
         /// The number of segments the pool needs.
@@ -97,9 +107,21 @@ impl fmt::Display for LayoutError {
                 offset_bits,
             } => write!(
                 f,
-                "segment_size ({segment_size}) needs {offset_bits} offset bits at \
-                 align_bytes ({align}), leaving none for segment ids; \
-                 reduce segment_size or raise align_bytes"
+                "segment_size ({segment_size}) at align_bytes ({align}) needs \
+                 {offset_bits} offset bits, and offsets past u32 cannot be \
+                 represented; reduce segment_size. Raising align_bytes does not \
+                 help -- it lowers offset_bits by exactly as much as it raises \
+                 the shift"
+            ),
+            Self::SegmentTooSmall {
+                segment_size,
+                align,
+                seg_bits,
+            } => write!(
+                f,
+                "segment_size ({segment_size}) at align_bytes ({align}) addresses \
+                 too few slots, leaving {seg_bits} segment-id bits -- more than the \
+                 31 a u32 segment id can hold; raise segment_size or lower align_bytes"
             ),
             Self::TooManySegments { requested, max } => write!(
                 f,
@@ -114,7 +136,7 @@ impl std::error::Error for LayoutError {}
 
 impl From<LayoutError> for std::io::Error {
     fn from(e: LayoutError) -> Self {
-        std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, e)
     }
 }
 
@@ -131,7 +153,7 @@ pub struct LocationLayout {
 
 impl LocationLayout {
     /// Position of the 2-bit `pool_id`, identical for every pool.
-    pub const POOL_SHIFT: u32 = 42;
+    pub const POOL_SHIFT: u32 = PAYLOAD_BITS;
 
     /// Build the layout for a pool.
     pub fn new(segment_size: usize, align_bytes: usize) -> Result<Self, LayoutError> {
@@ -155,19 +177,29 @@ impl LocationLayout {
 
         let align_shift = align_bytes.trailing_zeros();
 
-        // Two independent ceilings, both reported as SegmentTooLarge:
+        // Both fields are u32 in every consumer -- `SliceSegment::capacity`,
+        // `write_offset` and `ItemLocation::new` for the offset, and `segment_id`
+        // for the id -- so a layout that addresses past u32 on either end is
+        // meaningless and must be rejected rather than silently truncated.
         //
-        // 1. The offset field must leave room for segment ids.
-        // 2. The widest offset must fit in u32. Offsets are u32 throughout the
-        //    crate -- `SliceSegment::capacity`, `write_offset`, and
-        //    `ItemLocation::new` all use it -- so a layout that addresses past
-        //    u32 would truncate in `pack`/`offset` rather than error, and the
-        //    round trip would silently lose the high bits.
-        if offset_bits + TAG_BITS >= PAYLOAD_BITS || offset_bits + align_shift > 32 {
+        // Note the id-space bound (`offset_bits + TAG_BITS >= PAYLOAD_BITS`) is
+        // NOT checked: it is unreachable. `align_bytes >= 8` forces
+        // `align_shift >= 3`, so the offset ceiling below caps `offset_bits` at
+        // 29, well under the 36 that bound would need.
+        if offset_bits + align_shift > 32 {
             return Err(LayoutError::SegmentTooLarge {
                 segment_size,
                 align: align_bytes,
                 offset_bits,
+            });
+        }
+
+        let seg_bits = PAYLOAD_BITS - TAG_BITS - offset_bits;
+        if seg_bits > 31 {
+            return Err(LayoutError::SegmentTooSmall {
+                segment_size,
+                align: align_bytes,
+                seg_bits,
             });
         }
 
@@ -178,19 +210,19 @@ impl LocationLayout {
     }
 
     /// Width of the offset field.
-    #[inline(always)]
+    #[inline]
     pub fn offset_bits(&self) -> u32 {
         self.offset_bits as u32
     }
 
     /// Width of the segment id field.
-    #[inline(always)]
+    #[inline]
     pub fn seg_bits(&self) -> u32 {
         PAYLOAD_BITS - TAG_BITS - self.offset_bits as u32
     }
 
     /// Alignment factor in bytes.
-    #[inline(always)]
+    #[inline]
     pub fn align_bytes(&self) -> u32 {
         1 << self.align_shift
     }
@@ -199,7 +231,7 @@ impl LocationLayout {
     ///
     /// One below the field's capacity: leaving the top id unissuable is what
     /// keeps `Location::GHOST` (all 44 bits set) unaliasable by construction.
-    #[inline(always)]
+    #[inline]
     pub fn max_segment_count(&self) -> u32 {
         (1u32 << self.seg_bits()) - 1
     }
@@ -215,26 +247,32 @@ impl LocationLayout {
         Ok(())
     }
 
-    #[inline(always)]
+    #[inline]
     fn seg_shift(&self) -> u32 {
         self.offset_bits as u32 + TAG_BITS
     }
 
     /// Pack the four fields into raw location bits.
-    #[inline(always)]
+    ///
+    /// `incarnation` is masked to 6 bits; the other three are `debug_assert`ed
+    /// in range.
+    #[inline]
     pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
         debug_assert!(pool_id <= 3, "pool_id must be 0-3");
-        // `<=` not `<`: pack is a pure bit function, and the top id is a
-        // representable value -- it is `validate_segment_count` that keeps a
-        // pool from ever issuing it, which is what protects GHOST.
         debug_assert!(
-            segment_id <= self.max_segment_count(),
-            "segment_id exceeds this layout"
+            segment_id < (1u32 << self.seg_bits()),
+            "segment_id {segment_id} exceeds this layout's {}-bit field",
+            self.seg_bits()
         );
         debug_assert!(
             offset.is_multiple_of(self.align_bytes()),
             "offset must be {}-byte aligned",
             self.align_bytes()
+        );
+        debug_assert!(
+            (offset >> self.align_shift) < (1u32 << self.offset_bits as u32),
+            "offset {offset} exceeds this layout's {}-bit offset field",
+            self.offset_bits
         );
 
         ((pool_id as u64) << Self::POOL_SHIFT)
@@ -243,26 +281,27 @@ impl LocationLayout {
             | ((offset >> self.align_shift) as u64)
     }
 
-    /// Extract `pool_id`. Layout-independent by design.
-    #[inline(always)]
-    pub fn pool_id(&self, raw: u64) -> u8 {
+    /// Extract `pool_id`. Layout-independent by design: this is what a decoder
+    /// reads first, to find out which layout decodes the rest.
+    #[inline]
+    pub fn pool_id(raw: u64) -> u8 {
         ((raw >> Self::POOL_SHIFT) & 0b11) as u8
     }
 
     /// Extract `segment_id`.
-    #[inline(always)]
+    #[inline]
     pub fn segment_id(&self, raw: u64) -> u32 {
         ((raw >> self.seg_shift()) & ((1 << self.seg_bits()) - 1)) as u32
     }
 
     /// Extract the incarnation tag.
-    #[inline(always)]
+    #[inline]
     pub fn incarnation(&self, raw: u64) -> u8 {
         ((raw >> self.offset_bits as u32) as u8) & TAG_MASK
     }
 
     /// Extract the byte offset.
-    #[inline(always)]
+    #[inline]
     pub fn offset(&self, raw: u64) -> u32 {
         ((raw & ((1u64 << self.offset_bits as u32) - 1)) as u32) << self.align_shift
     }
@@ -326,7 +365,7 @@ mod tests {
                     for incarnation in 0u8..64 {
                         for &offset in &[0u32, align as u32, segment_size as u32 - align as u32] {
                             let raw = layout.pack(3, seg, incarnation, offset);
-                            assert_eq!(layout.pool_id(raw), 3);
+                            assert_eq!(LocationLayout::pool_id(raw), 3);
                             assert_eq!(layout.segment_id(raw), seg);
                             assert_eq!(layout.incarnation(raw), incarnation);
                             assert_eq!(layout.offset(raw), offset);
@@ -349,7 +388,12 @@ mod tests {
         assert_ne!(highest, crate::location::Location::MAX_RAW);
 
         // And the reason it cannot: only the unissuable top id reaches GHOST.
-        let unissuable = layout.pack(3, layout.max_segment_count(), 0x3F, max_offset);
+        // Built directly, not via pack: this id is out of the layout's field
+        // range by construction, which is the whole point.
+        let unissuable = ((3u64) << LocationLayout::POOL_SHIFT)
+            | ((layout.max_segment_count() as u64) << (layout.offset_bits() + 6))
+            | (0x3Fu64 << layout.offset_bits())
+            | ((max_offset >> 3) as u64);
         assert_eq!(unissuable, crate::location::Location::MAX_RAW);
     }
 
@@ -445,5 +489,105 @@ mod tests {
                 .validate_segment_count(layout.max_segment_count() as usize + 1)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn rejects_segments_with_too_few_addressable_slots() {
+        // The floor, mirroring the u32 ceiling. `segment_id` is a u32
+        // throughout the crate, so a layout leaving more than 31 segment-id
+        // bits is meaningless -- and `1u32 << seg_bits` overflows computing
+        // `max_segment_count()`. A 4 KiB disk segment at the 512-byte disk
+        // default lands here, and 4 KiB is exactly the block size the design
+        // names, so this is reachable rather than theoretical.
+        assert!(matches!(
+            LocationLayout::new(4096, 512),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(8192, 512),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+        assert!(LocationLayout::new(16 * 1024, 512).is_ok());
+
+        // The degenerate align == segment_size case is subsumed by the same
+        // floor: it derives offset_bits 0, hence seg_bits 36.
+        assert!(matches!(
+            LocationLayout::new(4 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn every_accepted_layout_has_computable_fields() {
+        // Companion to `every_accepted_layout_can_represent_its_own_widest_offset`
+        // at the other end: if `new` accepts a layout, every derived quantity
+        // must be computable rather than overflowing a shift.
+        for segment_size in [
+            4096usize,
+            8192,
+            16 * 1024,
+            64 * 1024,
+            1024 * 1024,
+            8 * 1024 * 1024,
+            128 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ] {
+            for align in [8usize, 512, 4096] {
+                let Ok(layout) = LocationLayout::new(segment_size, align) else {
+                    continue;
+                };
+                assert!(
+                    layout.seg_bits() <= 31,
+                    "segment_size {segment_size} align {align} was accepted with \
+                     {} segment-id bits, which overflows a u32 shift",
+                    layout.seg_bits()
+                );
+                assert!(layout.max_segment_count() > 0);
+                assert_eq!(layout.align_bytes() as usize, align);
+                assert_eq!(layout.offset(layout.pack(0, 0, 0, 0)), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn derives_offset_bits_for_non_power_of_two_segment_sizes() {
+        // `segment_size` is an arbitrary usize from the pool builder, and the
+        // div_ceil/next_power_of_two derivation exists solely for this case --
+        // nothing else pins it. The naive
+        // `segment_size.trailing_zeros() - align_shift` gives 16 here and would
+        // silently truncate most of the segment.
+        let layout = LocationLayout::new(1536 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 18);
+
+        let last = 1536 * 1024 - 8;
+        assert_eq!(layout.offset(layout.pack(0, 0, 0, last)), last);
+    }
+
+    #[test]
+    fn segment_too_large_names_the_ceiling_that_actually_fired() {
+        // The message must not advise raising align_bytes: for a power-of-two
+        // segment_size, offset_bits + align_shift is invariant, so coarser
+        // alignment provably cannot get past this ceiling. Advising it sends an
+        // operator down a dead end.
+        let err = LocationLayout::new(8 * 1024 * 1024 * 1024, 8).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("u32"),
+            "message should name the real limit: {msg}"
+        );
+        assert!(
+            !msg.contains("raise align_bytes"),
+            "message advises a remedy that cannot work: {msg}"
+        );
+    }
+
+    #[test]
+    fn pool_id_decodes_without_a_layout_instance() {
+        // The module's premise: pool_id is read to CHOOSE a layout, so reading
+        // it must not require already having one.
+        let raw = LocationLayout::new(1024 * 1024, 8)
+            .unwrap()
+            .pack(2, 5, 0, 0);
+        assert_eq!(LocationLayout::pool_id(raw), 2);
     }
 }

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -1,0 +1,387 @@
+//! Per-pool bit split for `Location`.
+//!
+//! A `Location` is 44 bits. `pool_id` occupies the top 2 at a fixed position so
+//! a decoder can read it before knowing anything else, then select that pool's
+//! layout to decode the rest. The remaining 42 bits split three ways:
+//!
+//! ```text
+//! [43..42] pool_id      2 bits, fixed
+//! [41..  ] segment_id   42 - 6 - offset_bits
+//! [  ..  ] incarnation  6 bits
+//! [  ..0 ] offset/align offset_bits
+//! ```
+//!
+//! # Capacity is invariant under `segment_size`
+//!
+//! With a fixed tag width, offset bits gained are segment bits lost, exactly:
+//!
+//! ```text
+//! capacity/pool = 2^(42 - TAG_BITS) * align_bytes = 2^36 * align_bytes
+//! ```
+//!
+//! `segment_size` does not appear. The alignment factor is the only capacity
+//! lever, which is why disk pools default to 512-byte alignment (32 TiB/pool)
+//! while memory pools stay at 8 (512 GiB/pool).
+
+use std::fmt;
+
+/// Bits available below `pool_id`.
+const PAYLOAD_BITS: u32 = 42;
+
+/// Width of the incarnation tag. Fixed: see the module docs on why widening it
+/// would cost capacity rather than segment size.
+pub const TAG_BITS: u32 = 6;
+
+/// Mask for a 6-bit incarnation tag.
+pub const TAG_MASK: u8 = (1 << TAG_BITS) - 1;
+
+/// Why a pool's location layout could not be built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutError {
+    /// `align_bytes` was not a power of two.
+    AlignNotPowerOfTwo {
+        /// The rejected `align_bytes` value.
+        align: usize,
+    },
+    /// `align_bytes` was below the 8-byte item alignment.
+    AlignTooSmall {
+        /// The rejected `align_bytes` value.
+        align: usize,
+    },
+    /// `align_bytes` exceeded `segment_size`.
+    AlignExceedsSegment {
+        /// The rejected `align_bytes` value.
+        align: usize,
+        /// The pool's segment size.
+        segment_size: usize,
+    },
+    /// `segment_size / align_bytes` needs so many offset bits that no segment
+    /// ids are left.
+    SegmentTooLarge {
+        /// The pool's segment size.
+        segment_size: usize,
+        /// The pool's `align_bytes` value.
+        align: usize,
+        /// The offset field width this combination would require.
+        offset_bits: u32,
+    },
+    /// The pool has more segments than the layout can address.
+    TooManySegments {
+        /// The number of segments the pool needs.
+        requested: usize,
+        /// The most segments this layout can address.
+        max: u32,
+    },
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlignNotPowerOfTwo { align } => {
+                write!(f, "align_bytes ({align}) must be a power of two")
+            }
+            Self::AlignTooSmall { align } => write!(
+                f,
+                "align_bytes ({align}) must be at least 8, the item alignment"
+            ),
+            Self::AlignExceedsSegment {
+                align,
+                segment_size,
+            } => write!(
+                f,
+                "align_bytes ({align}) must not exceed segment_size ({segment_size})"
+            ),
+            Self::SegmentTooLarge {
+                segment_size,
+                align,
+                offset_bits,
+            } => write!(
+                f,
+                "segment_size ({segment_size}) needs {offset_bits} offset bits at \
+                 align_bytes ({align}), leaving none for segment ids; \
+                 reduce segment_size or raise align_bytes"
+            ),
+            Self::TooManySegments { requested, max } => write!(
+                f,
+                "pool needs {requested} segments but the layout addresses at most \
+                 {max}; reduce heap_size, raise segment_size, or raise align_bytes"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
+impl From<LayoutError> for std::io::Error {
+    fn from(e: LayoutError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
+    }
+}
+
+/// How one pool splits the 44 location bits.
+///
+/// Small and `Copy`: two shifts is all that is stored, everything else derives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocationLayout {
+    /// `log2(align_bytes)`.
+    align_shift: u8,
+    /// Width of the offset field.
+    offset_bits: u8,
+}
+
+impl LocationLayout {
+    /// Position of the 2-bit `pool_id`, identical for every pool.
+    pub const POOL_SHIFT: u32 = 42;
+
+    /// Build the layout for a pool.
+    pub fn new(segment_size: usize, align_bytes: usize) -> Result<Self, LayoutError> {
+        if !align_bytes.is_power_of_two() {
+            return Err(LayoutError::AlignNotPowerOfTwo { align: align_bytes });
+        }
+        if align_bytes < 8 {
+            return Err(LayoutError::AlignTooSmall { align: align_bytes });
+        }
+        if align_bytes > segment_size {
+            return Err(LayoutError::AlignExceedsSegment {
+                align: align_bytes,
+                segment_size,
+            });
+        }
+
+        // Offset units needed to address the segment. `segment_size` need not be
+        // a power of two, so round the unit count up before taking its width.
+        let units = segment_size.div_ceil(align_bytes);
+        let offset_bits = units.next_power_of_two().trailing_zeros();
+
+        if offset_bits + TAG_BITS >= PAYLOAD_BITS {
+            return Err(LayoutError::SegmentTooLarge {
+                segment_size,
+                align: align_bytes,
+                offset_bits,
+            });
+        }
+
+        Ok(Self {
+            align_shift: align_bytes.trailing_zeros() as u8,
+            offset_bits: offset_bits as u8,
+        })
+    }
+
+    /// Width of the offset field.
+    #[inline(always)]
+    pub fn offset_bits(&self) -> u32 {
+        self.offset_bits as u32
+    }
+
+    /// Width of the segment id field.
+    #[inline(always)]
+    pub fn seg_bits(&self) -> u32 {
+        PAYLOAD_BITS - TAG_BITS - self.offset_bits as u32
+    }
+
+    /// Alignment factor in bytes.
+    #[inline(always)]
+    pub fn align_bytes(&self) -> u32 {
+        1 << self.align_shift
+    }
+
+    /// How many segments a pool may hold, so ids run `0..max_segment_count()`.
+    ///
+    /// One below the field's capacity: leaving the top id unissuable is what
+    /// keeps `Location::GHOST` (all 44 bits set) unaliasable by construction.
+    #[inline(always)]
+    pub fn max_segment_count(&self) -> u32 {
+        (1u32 << self.seg_bits()) - 1
+    }
+
+    /// Reject a pool that has more segments than this layout can address.
+    pub fn validate_segment_count(&self, count: usize) -> Result<(), LayoutError> {
+        if count > self.max_segment_count() as usize {
+            return Err(LayoutError::TooManySegments {
+                requested: count,
+                max: self.max_segment_count(),
+            });
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn seg_shift(&self) -> u32 {
+        self.offset_bits as u32 + TAG_BITS
+    }
+
+    /// Pack the four fields into raw location bits.
+    #[inline(always)]
+    pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
+        debug_assert!(pool_id <= 3, "pool_id must be 0-3");
+        // `<=` not `<`: pack is a pure bit function, and the top id is a
+        // representable value -- it is `validate_segment_count` that keeps a
+        // pool from ever issuing it, which is what protects GHOST.
+        debug_assert!(
+            segment_id <= self.max_segment_count(),
+            "segment_id exceeds this layout"
+        );
+        debug_assert!(
+            offset.is_multiple_of(self.align_bytes()),
+            "offset must be {}-byte aligned",
+            self.align_bytes()
+        );
+
+        ((pool_id as u64) << Self::POOL_SHIFT)
+            | ((segment_id as u64) << self.seg_shift())
+            | (((incarnation & TAG_MASK) as u64) << self.offset_bits as u32)
+            | ((offset >> self.align_shift) as u64)
+    }
+
+    /// Extract `pool_id`. Layout-independent by design.
+    #[inline(always)]
+    pub fn pool_id(&self, raw: u64) -> u8 {
+        ((raw >> Self::POOL_SHIFT) & 0b11) as u8
+    }
+
+    /// Extract `segment_id`.
+    #[inline(always)]
+    pub fn segment_id(&self, raw: u64) -> u32 {
+        ((raw >> self.seg_shift()) & ((1 << self.seg_bits()) - 1)) as u32
+    }
+
+    /// Extract the incarnation tag.
+    #[inline(always)]
+    pub fn incarnation(&self, raw: u64) -> u8 {
+        ((raw >> self.offset_bits as u32) as u8) & TAG_MASK
+    }
+
+    /// Extract the byte offset.
+    #[inline(always)]
+    pub fn offset(&self, raw: u64) -> u32 {
+        ((raw & ((1u64 << self.offset_bits as u32) - 1)) as u32) << self.align_shift
+    }
+}
+
+#[cfg(all(test, not(feature = "loom")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_defaults_split_as_documented() {
+        // 1 MB segments, 8-byte alignment: offset needs log2(1MB/8) = 17 bits.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 17);
+        assert_eq!(layout.seg_bits(), 19); // 42 - 6 - 17
+        // A count, not a max id: ids run 0..max_segment_count(), so the top
+        // field value is never issued.
+        assert_eq!(layout.max_segment_count(), (1 << 19) - 1);
+
+        // 8 MB segments: offset needs 20 bits.
+        let layout = LocationLayout::new(8 * 1024 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 20);
+        assert_eq!(layout.seg_bits(), 16);
+    }
+
+    #[test]
+    fn disk_default_alignment_buys_capacity() {
+        // 8 MB segments at 512-byte alignment: offset needs log2(8MB/512) = 14 bits.
+        let layout = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
+        assert_eq!(layout.offset_bits(), 14);
+        assert_eq!(layout.seg_bits(), 22);
+    }
+
+    #[test]
+    fn capacity_is_invariant_under_segment_size() {
+        // The design's central claim: offset bits gained are segment bits lost,
+        // so capacity depends only on the alignment factor. If this ever fails,
+        // the justification for the disk alignment change is gone.
+        for segment_size in [
+            1024 * 1024,
+            8 * 1024 * 1024,
+            32 * 1024 * 1024,
+            128 * 1024 * 1024,
+        ] {
+            let layout = LocationLayout::new(segment_size, 8).unwrap();
+            let capacity = (1u64 << layout.seg_bits()) * segment_size as u64;
+            assert_eq!(
+                capacity,
+                512 * 1024 * 1024 * 1024,
+                "segment_size {segment_size} should still yield 512 GiB"
+            );
+        }
+    }
+
+    #[test]
+    fn roundtrips_every_field() {
+        for segment_size in [1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024] {
+            for align in [8, 64, 512] {
+                let layout = LocationLayout::new(segment_size, align).unwrap();
+                for &seg in &[0u32, 1, 7, layout.max_segment_count() - 1] {
+                    for incarnation in 0u8..64 {
+                        for &offset in &[0u32, align as u32, segment_size as u32 - align as u32] {
+                            let raw = layout.pack(3, seg, incarnation, offset);
+                            assert_eq!(layout.pool_id(raw), 3);
+                            assert_eq!(layout.segment_id(raw), seg);
+                            assert_eq!(layout.incarnation(raw), incarnation);
+                            assert_eq!(layout.offset(raw), offset);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ghost_is_unaliasable() {
+        // The top segment id is never issued, so no issuable location can
+        // collide with Location::GHOST (all 44 bits set).
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        let max_offset = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+
+        // The highest location any pool can actually issue.
+        let highest = layout.pack(3, layout.max_segment_count() - 1, 0x3F, max_offset);
+        assert_ne!(highest, crate::location::Location::MAX_RAW);
+
+        // And the reason it cannot: only the unissuable top id reaches GHOST.
+        let unissuable = layout.pack(3, layout.max_segment_count(), 0x3F, max_offset);
+        assert_eq!(unissuable, crate::location::Location::MAX_RAW);
+    }
+
+    #[test]
+    fn rejects_bad_alignment() {
+        assert!(matches!(
+            LocationLayout::new(1024 * 1024, 3),
+            Err(LayoutError::AlignNotPowerOfTwo { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(1024 * 1024, 4),
+            Err(LayoutError::AlignTooSmall { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(1024, 4096),
+            Err(LayoutError::AlignExceedsSegment { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_segment_too_large_to_address() {
+        // offset_bits + 6 must leave room for segment ids, so at 8-byte
+        // alignment the ceiling is a 512 GiB segment (offset_bits == 36).
+        assert!(LocationLayout::new(256 * 1024 * 1024 * 1024, 8).is_ok());
+        assert!(matches!(
+            LocationLayout::new(512 * 1024 * 1024 * 1024, 8),
+            Err(LayoutError::SegmentTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_more_segments_than_fit() {
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        assert!(
+            layout
+                .validate_segment_count(layout.max_segment_count() as usize)
+                .is_ok()
+        );
+        assert!(
+            layout
+                .validate_segment_count(layout.max_segment_count() as usize + 1)
+                .is_err()
+        );
+    }
+}

--- a/cache/core/src/location_layout.rs
+++ b/cache/core/src/location_layout.rs
@@ -194,6 +194,8 @@ impl LocationLayout {
             });
         }
 
+        // Safe from underflow only because the ceiling above already capped
+        // offset_bits at 29 (align_shift >= 3). This ordering is load-bearing.
         let seg_bits = PAYLOAD_BITS - TAG_BITS - offset_bits;
         if seg_bits > 31 {
             return Err(LayoutError::SegmentTooSmall {
@@ -260,9 +262,9 @@ impl LocationLayout {
     pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
         debug_assert!(pool_id <= 3, "pool_id must be 0-3");
         debug_assert!(
-            segment_id < (1u32 << self.seg_bits()),
-            "segment_id {segment_id} exceeds this layout's {}-bit field",
-            self.seg_bits()
+            segment_id < self.max_segment_count(),
+            "segment_id {segment_id} is outside the issuable range 0..{}",
+            self.max_segment_count()
         );
         debug_assert!(
             offset.is_multiple_of(self.align_bytes()),
@@ -390,10 +392,10 @@ mod tests {
         // And the reason it cannot: only the unissuable top id reaches GHOST.
         // Built directly, not via pack: this id is out of the layout's field
         // range by construction, which is the whole point.
-        let unissuable = ((3u64) << LocationLayout::POOL_SHIFT)
-            | ((layout.max_segment_count() as u64) << (layout.offset_bits() + 6))
+        let unissuable = (3u64 << LocationLayout::POOL_SHIFT)
+            | ((layout.max_segment_count() as u64) << (layout.offset_bits() + TAG_BITS))
             | (0x3Fu64 << layout.offset_bits())
-            | ((max_offset >> 3) as u64);
+            | ((max_offset / layout.align_bytes()) as u64);
         assert_eq!(unissuable, crate::location::Location::MAX_RAW);
     }
 
@@ -561,6 +563,10 @@ mod tests {
 
         let last = 1536 * 1024 - 8;
         assert_eq!(layout.offset(layout.pack(0, 0, 0, last)), last);
+
+        // Pins div_ceil specifically: with plain division this is 7 bits, which
+        // cannot address the last 9 bytes of the segment.
+        assert_eq!(LocationLayout::new(1025, 8).unwrap().offset_bits(), 8);
     }
 
     #[test]
@@ -589,5 +595,35 @@ mod tests {
             .unwrap()
             .pack(2, 5, 0, 0);
         assert_eq!(LocationLayout::pool_id(raw), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds this layout's 17-bit offset field")]
+    fn pack_rejects_an_offset_past_the_offset_field() {
+        // One byte past a 1 MiB segment, and still 8-aligned, so the alignment
+        // assert waves it through. Without the range check this silently
+        // overflows into the incarnation field and returns a corrupted tag.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        layout.pack(0, 5, 0, 1024 * 1024);
+    }
+
+    #[test]
+    #[should_panic(expected = "is outside the issuable range")]
+    fn pack_rejects_the_unissuable_top_segment_id() {
+        // The id reserved so Location::GHOST cannot be aliased. A pool must
+        // never issue it, and pack must say so rather than encode it.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        layout.pack(0, layout.max_segment_count(), 0, 0);
+    }
+
+    #[test]
+    fn io_error_conversion_preserves_the_structured_error() {
+        let err = LocationLayout::new(4096, 512).unwrap_err();
+        let io: std::io::Error = err.into();
+        assert_eq!(io.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(matches!(
+            io.get_ref().and_then(|e| e.downcast_ref::<LayoutError>()),
+            Some(LayoutError::SegmentTooSmall { .. })
+        ));
     }
 }

--- a/cache/core/src/loom_oracle.rs
+++ b/cache/core/src/loom_oracle.rs
@@ -32,16 +32,19 @@
 //!   in place ([`KeyOracle::drain_relocate`]);
 //! - **recycle + refill** — the source segment is recycled and rewritten by
 //!   another writer, so the old location now holds an unrelated key ([`OTHER`]);
+//! - **recycle + refill with the SAME key at the SAME address**
+//!   ([`KeyOracle::bump_incarnation`]).
 //!
-//! # What it deliberately cannot model
-//!
-//! **Recycle + refill with the SAME key at the SAME address.** In cache-rs
-//! that hazard is caught by an incarnation tag packed inside the location
-//! word, so a stale location fails validation even when the bytes really do
-//! spell the key again. `cache-core`'s [`Location`] is opaque — the backend
-//! owns all 44 bits and no generation rides in them — so there is nothing for
-//! such a model to assert against. Modelling it here would only prove the
-//! oracle can lie.
+//! That last one used to be out of reach. `cache-core`'s [`Location`] was
+//! opaque — the backend owned all 44 bits and no generation rode in them — so
+//! a model had nothing to assert against, and modelling it would only have
+//! proved the oracle could lie. Segment locations now carry a 6-bit
+//! incarnation tag, bumped when a used incarnation ends and compared by every
+//! verifier before item bytes are touched, so the oracle models it too: a
+//! cell's occupant and its incarnation live in SEPARATE atomics, exactly as
+//! the item bytes and the segment's metadata word do in production. That
+//! separation is what makes the race real — a reader can load one and be
+//! preempted before the other.
 //!
 //! # Faithfulness rules
 //!
@@ -72,6 +75,12 @@ const OTHER_ID: u64 = 2;
 /// Set in a cell word when the occupant is delete-marked in place.
 const DELETED: u64 = 1 << 32;
 
+/// Width of the modeled incarnation tag, matching
+/// [`crate::location_layout::TAG_BITS`].
+const TAG_BITS: u32 = 6;
+/// Mask for a modeled incarnation tag.
+const TAG_MASK: u64 = (1 << TAG_BITS) - 1;
+
 /// How many times a model's reader was handed a location that no longer held
 /// its key, counted across every loom execution of the current model.
 ///
@@ -81,6 +90,19 @@ const DELETED: u64 = 1 << 32;
 /// [`KeyOracle::assert_hazard_reached`].
 static OCCUPANT_MISS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 static TOMBSTONE_MISS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// How many times the verifier was handed a location whose incarnation had
+/// already advanced — the hazard witness for the recycle models. Same
+/// rationale as the two above for being `std` rather than model atomics.
+static STALE_REJECT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// How many times the verifier ACCEPTED such a location. Must stay zero: it
+/// can only move if the tag comparison is missing, which is precisely what
+/// `loom_stale_location_never_resolves_to_the_new_occupant` asserts.
+///
+/// Counted separately from the guard rather than inside it, so that neutering
+/// the guard (the model's proof that it can fail) still records the accept.
+static STALE_ACCEPT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Serializes witness-bearing models against each other; see
 /// [`KeyOracle::arm_hazard_witness`].
@@ -123,6 +145,22 @@ impl HazardWitness {
     }
 
     /// As [`HazardWitness::assert_reached`], but for a model whose hazard is
+    /// specifically a location from a SUPERSEDED INCARNATION of its segment.
+    ///
+    /// The occupant and tombstone witnesses cannot stand in for this one: the
+    /// recycle model refills the cell with the SAME key, precisely so the
+    /// occupant check has nothing to say and only the tag can reject. If this
+    /// counter stays at zero the reader never raced the bump, and the model is
+    /// asserting that a quiet table stays quiet.
+    pub(crate) fn assert_stale_incarnation_reached(self) {
+        assert!(
+            STALE_REJECT.load(std::sync::atomic::Ordering::Relaxed) > 0,
+            "model never handed the verifier a location from a superseded \
+             incarnation, so it would pass against a missing tag check"
+        );
+    }
+
+    /// As [`HazardWitness::assert_reached`], but for a model whose hazard is
     /// specifically a DELETE-MARKED occupant rather than a replaced one.
     pub(crate) fn assert_tombstone_reached(self) {
         assert!(
@@ -161,7 +199,15 @@ fn key_id(key: &[u8]) -> u64 {
 /// One cell per modeled storage location: a cell holds the id of the key whose
 /// bytes currently live there, or `0` for "nothing this model knows about".
 pub(crate) struct KeyOracle {
+    /// The occupant of each cell: the id of the key whose bytes live there,
+    /// plus [`DELETED`]. The model's stand-in for ITEM BYTES.
     cells: [AtomicU64; NUM_CELLS],
+
+    /// The incarnation each cell currently carries. The model's stand-in for
+    /// the SEGMENT METADATA WORD, and a separate atomic for the same reason it
+    /// is a separate word in production: a reader loads the tag and the bytes
+    /// at two different instants, and everything interesting lives in the gap.
+    tags: [AtomicU64; NUM_CELLS],
 }
 
 impl KeyOracle {
@@ -169,16 +215,27 @@ impl KeyOracle {
     pub(crate) fn new() -> Self {
         Self {
             cells: std::array::from_fn(|_| AtomicU64::new(0)),
+            tags: std::array::from_fn(|_| AtomicU64::new(0)),
         }
     }
 
-    /// The [`Location`] naming `cell`.
+    /// The [`Location`] naming `cell` under its FIRST incarnation.
     ///
-    /// Offset by one so no cell maps to the all-zero location word, which the
-    /// slot encoding reserves for "empty".
+    /// Equivalent to `location_tagged(cell, 0)`. Every model that predates the
+    /// incarnation tag uses this and stays on tag 0 throughout, so their
+    /// behaviour is unchanged.
     pub(crate) fn location(cell: usize) -> Location {
+        Self::location_tagged(cell, 0)
+    }
+
+    /// The [`Location`] naming `cell` under a specific incarnation.
+    ///
+    /// The cell index is offset by one so no cell maps to the all-zero
+    /// location word, which the slot encoding reserves for "empty", and shifted
+    /// above the tag so `location(cell)` keeps a stable value per cell.
+    pub(crate) fn location_tagged(cell: usize, incarnation: u8) -> Location {
         debug_assert!(cell < NUM_CELLS);
-        Location::new(cell as u64 + 1)
+        Location::new(((cell as u64 + 1) << TAG_BITS) | (incarnation as u64 & TAG_MASK))
     }
 
     /// Write `key`'s bytes at `cell` — a segment write (reserve + define, or a
@@ -218,6 +275,25 @@ impl KeyOracle {
     /// model reddens against broken code.
     pub(crate) fn tombstone(&self, cell: usize) {
         self.cells[cell].fetch_or(DELETED, Ordering::Release);
+    }
+
+    /// End the incarnation `cell` is currently on.
+    ///
+    /// The model's stand-in for a segment leaving `Locked` — the point at
+    /// which every [`Location`] issued against the old incarnation must stop
+    /// resolving. The refill that follows is an ordinary [`KeyOracle::place`],
+    /// because in production the tag advances first and items are appended
+    /// under the new one afterwards.
+    ///
+    /// # This MUST be one atomic read-modify-write
+    ///
+    /// Splitting it into a load and a store collapses loom's interleaving
+    /// space: the hazard this models stops being reachable, and the model goes
+    /// green while proving nothing. The same trap cost this fixture 183 hazard
+    /// observations once already — see [`KeyOracle::tombstone`].
+    pub(crate) fn bump_incarnation(&self, cell: usize) {
+        debug_assert!(cell < NUM_CELLS);
+        self.tags[cell].fetch_add(1, Ordering::AcqRel);
     }
 
     /// One merge-drain relocation of [`KEY`], in the order production performs
@@ -282,6 +358,8 @@ impl KeyOracle {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         OCCUPANT_MISS.store(0, std::sync::atomic::Ordering::Relaxed);
         TOMBSTONE_MISS.store(0, std::sync::atomic::Ordering::Relaxed);
+        STALE_REJECT.store(0, std::sync::atomic::Ordering::Relaxed);
+        STALE_ACCEPT.store(0, std::sync::atomic::Ordering::Relaxed);
         HazardWitness(guard)
     }
 }
@@ -289,13 +367,26 @@ impl KeyOracle {
 impl KeyVerifier for KeyOracle {
     fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
         let raw = location.as_raw();
+        let index = raw >> TAG_BITS;
         // Locations the oracle never issued (GHOST, or a backend-shaped word a
         // model handed in by mistake) match nothing.
-        if raw == 0 || raw > NUM_CELLS as u64 {
+        if index == 0 || index > NUM_CELLS as u64 {
             return false;
         }
-        let word = self.cells[(raw - 1) as usize].load(Ordering::Acquire);
+        let cell = (index - 1) as usize;
         use std::sync::atomic::Ordering as O;
+
+        // The tag first, before any "item bytes" are read: that is the order
+        // every production verifier uses, and the point of the check is to
+        // avoid resolving into a later incarnation's item at all.
+        let stale = (self.tags[cell].load(Ordering::Acquire) & TAG_MASK) != (raw & TAG_MASK);
+        if stale {
+            STALE_REJECT.fetch_add(1, O::Relaxed);
+            // NEUTER THIS `return` to prove the recycle model can fail.
+            return false;
+        }
+
+        let word = self.cells[cell].load(Ordering::Acquire);
         if word & !DELETED != key_id(key) {
             let n = OCCUPANT_MISS.fetch_add(1, O::Relaxed) + 1;
             eprintln!(
@@ -314,6 +405,20 @@ impl KeyVerifier for KeyOracle {
             );
             return false;
         }
+        if stale {
+            // Only reachable with the guard above neutered. Recorded here
+            // rather than inside the guard so the model still has something to
+            // assert on when the guard is removed.
+            STALE_ACCEPT.fetch_add(1, O::Relaxed);
+        }
         true
+    }
+}
+
+impl KeyOracle {
+    /// How many times the verifier accepted a location from a superseded
+    /// incarnation. Zero unless the tag comparison is missing.
+    pub(crate) fn stale_accepts() -> usize {
+        STALE_ACCEPT.load(std::sync::atomic::Ordering::Relaxed)
     }
 }

--- a/cache/core/src/loom_oracle.rs
+++ b/cache/core/src/loom_oracle.rs
@@ -388,21 +388,11 @@ impl KeyVerifier for KeyOracle {
 
         let word = self.cells[cell].load(Ordering::Acquire);
         if word & !DELETED != key_id(key) {
-            let n = OCCUPANT_MISS.fetch_add(1, O::Relaxed) + 1;
-            eprintln!(
-                "MISS occupant={} tombstone={}",
-                n,
-                TOMBSTONE_MISS.load(O::Relaxed)
-            );
+            OCCUPANT_MISS.fetch_add(1, O::Relaxed);
             return false;
         }
         if !allow_deleted && (word & DELETED) != 0 {
-            let n = TOMBSTONE_MISS.fetch_add(1, O::Relaxed) + 1;
-            eprintln!(
-                "MISS occupant={} tombstone={}",
-                OCCUPANT_MISS.load(O::Relaxed),
-                n
-            );
+            TOMBSTONE_MISS.fetch_add(1, O::Relaxed);
             return false;
         }
         if stale {

--- a/cache/core/src/memory_pool.rs
+++ b/cache/core/src/memory_pool.rs
@@ -14,6 +14,7 @@
 //! even under high memory pressure from normal allocation.
 
 use crate::hugepage::{HugepageAllocation, HugepageSize, allocate_on_node};
+use crate::location_layout::LocationLayout;
 use crate::pool::RamPool;
 use crate::segment::Segment;
 use crate::slice_segment::SliceSegment;
@@ -70,6 +71,9 @@ pub struct MemoryPool {
 
     /// Size of each segment in bytes.
     segment_size: usize,
+
+    /// Bit split for locations naming this pool.
+    layout: LocationLayout,
 }
 
 // SAFETY: MemoryPool is safe to send/share between threads because:
@@ -226,6 +230,10 @@ impl RamPool for MemoryPool {
         self.segment_size
     }
 
+    fn layout(&self) -> &LocationLayout {
+        &self.layout
+    }
+
     fn reserve(&self) -> Option<u32> {
         // Normal allocation only uses free_queue, never spare_queue.
         //
@@ -342,6 +350,7 @@ pub struct MemoryPoolBuilder {
     hugepage_size: HugepageSize,
     numa_node: Option<u32>,
     spare_capacity: u32,
+    align_bytes: usize,
 }
 
 impl MemoryPoolBuilder {
@@ -358,6 +367,7 @@ impl MemoryPoolBuilder {
             hugepage_size: HugepageSize::None,
             numa_node: None,
             spare_capacity: 4, // Default: 4 spare segments for compaction
+            align_bytes: 8,    // Default: the item alignment
         }
     }
 
@@ -385,6 +395,22 @@ impl MemoryPoolBuilder {
     /// Set the segment size in bytes (default: 1MB).
     pub fn segment_size(mut self, size: usize) -> Self {
         self.segment_size = size;
+        self
+    }
+
+    /// Set the offset alignment factor in bytes.
+    ///
+    /// Locations store `offset / align_bytes`, so this is the only lever on a
+    /// pool's addressable capacity: `2^36 * align_bytes`. Memory pools default
+    /// to 8, matching the item alignment, because a minimal item is 8 bytes and
+    /// coarser alignment would round small items up. Must be a power of two, at
+    /// least 8, and no larger than `segment_size`.
+    ///
+    /// Raising it above 8 is only sound once the segment append path pads items
+    /// to the same factor -- it pads to 8 today, so a coarser value would
+    /// produce item offsets this layout cannot represent.
+    pub fn align_bytes(mut self, align: usize) -> Self {
+        self.align_bytes = align;
         self
     }
 
@@ -434,6 +460,9 @@ impl MemoryPoolBuilder {
                 "heap_size must be >= segment_size",
             ));
         }
+
+        let layout = LocationLayout::new(self.segment_size, self.align_bytes)?;
+        layout.validate_segment_count(num_segments)?;
 
         // Ensure spare_capacity doesn't consume all segments.
         // We need at least 3 segments in free_queue for the cache to function:
@@ -499,6 +528,7 @@ impl MemoryPoolBuilder {
             pool_id: self.pool_id,
             is_per_item_ttl: self.is_per_item_ttl,
             segment_size: self.segment_size,
+            layout,
         })
     }
 }
@@ -515,6 +545,45 @@ mod tests {
             .spare_capacity(0) // No spare capacity for tests
             .build()
             .expect("Failed to create test pool")
+    }
+
+    #[test]
+    fn test_pool_exposes_a_layout_matching_its_segment_size() {
+        let pool = MemoryPoolBuilder::new(0)
+            .heap_size(4 * 1024 * 1024)
+            .segment_size(1024 * 1024)
+            .build()
+            .unwrap();
+        assert_eq!(pool.layout().offset_bits(), 17);
+        assert_eq!(pool.layout().align_bytes(), 8);
+    }
+
+    #[test]
+    fn test_pool_rejects_more_segments_than_the_layout_addresses() {
+        // 128 MB segments leave 12 segment bits (4095 issuable ids). Ask for
+        // more and construction must fail by name rather than alias silently.
+        let err = MemoryPoolBuilder::new(0)
+            .heap_size(5000 * 128 * 1024 * 1024)
+            .segment_size(128 * 1024 * 1024)
+            .build()
+            .err()
+            .expect("layout must reject a pool with more segments than it addresses");
+        assert!(
+            err.to_string().contains("addresses at most"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pool_rejects_alignment_below_item_alignment() {
+        let err = MemoryPoolBuilder::new(0)
+            .heap_size(4 * 1024 * 1024)
+            .segment_size(1024 * 1024)
+            .align_bytes(4)
+            .build()
+            .err()
+            .expect("layout must reject alignment below the item alignment");
+        assert!(err.to_string().contains("at least 8"), "unexpected: {err}");
     }
 
     #[test]

--- a/cache/core/src/memory_pool.rs
+++ b/cache/core/src/memory_pool.rs
@@ -159,13 +159,15 @@ impl MemoryPool {
 
     /// Release a segment back to the appropriate queue with automatic balancing.
     ///
-    /// This method is called by guard Drop when a segment in AwaitingRelease
-    /// state has its last reader drop. It automatically replenishes the spare
-    /// queue if below target capacity.
+    /// Like [`RamPool::release`], but replenishes the spare queue first when it
+    /// is below target capacity. It has no production callers today: the
+    /// guard-drop path a previous version of this doc described goes through
+    /// `SliceSegment::release_condemned`, not here.
     ///
-    /// # Safety
-    /// The segment must be in a releasable state (Free or AwaitingRelease with
-    /// ref_count == 0).
+    /// # Panics
+    ///
+    /// Calls `try_release`, which panics on any state but `Free`, `Reserved`,
+    /// `Linking` or `Locked` -- `AwaitingRelease` included, despite the name.
     pub fn release_segment(&self, id: u32) {
         let id_usize = id as usize;
 

--- a/cache/core/src/memory_pool.rs
+++ b/cache/core/src/memory_pool.rs
@@ -406,9 +406,10 @@ impl MemoryPoolBuilder {
     /// coarser alignment would round small items up. Must be a power of two, at
     /// least 8, and no larger than `segment_size`.
     ///
-    /// Raising it above 8 is only sound once the segment append path pads items
-    /// to the same factor -- it pads to 8 today, so a coarser value would
-    /// produce item offsets this layout cannot represent.
+    /// Segments append at this stride and every scan advances by it -- see
+    /// `Segment::item_stride` -- so raising it costs up to `align_bytes - 1`
+    /// bytes of padding per item. Disk pools take that trade for the block
+    /// alignment it buys; RAM pools have nothing to gain from it.
     pub fn align_bytes(mut self, align: usize) -> Self {
         self.align_bytes = align;
         self
@@ -505,6 +506,10 @@ impl MemoryPoolBuilder {
                     segment_ptr,
                     self.segment_size,
                     free_queue_ptr,
+                    // From the layout, not the builder field, so the stride a
+                    // segment appends by and the alignment a location is
+                    // packed with cannot drift apart.
+                    layout.align_bytes() as usize,
                 )
             };
 

--- a/cache/core/src/pool.rs
+++ b/cache/core/src/pool.rs
@@ -50,6 +50,12 @@ pub trait RamPool: Send + Sync {
     /// Get the size of each segment in bytes.
     fn segment_size(&self) -> usize;
 
+    /// Get this pool's location layout.
+    ///
+    /// Locations naming this pool must be packed and unpacked with it; pools
+    /// with different segment sizes or alignment factors have different splits.
+    fn layout(&self) -> &crate::location_layout::LocationLayout;
+
     /// Reserve a segment from the pool.
     ///
     /// The segment transitions from `Free` to `Reserved` state.

--- a/cache/core/src/segment.rs
+++ b/cache/core/src/segment.rs
@@ -21,6 +21,22 @@ use std::time::Duration;
 /// minimal trait, types that don't provide full segment access (like SSD-backed
 /// segments that require async I/O) can still work with the hashtable.
 pub trait SegmentKeyVerify {
+    /// The incarnation tag this segment currently carries.
+    ///
+    /// A location whose tag differs names a previous incarnation of this
+    /// segment and must not be resolved: the segment has been drained and
+    /// refilled, and the offset now holds a different item.
+    ///
+    /// This lives here rather than on [`Segment`] because it is part of
+    /// deciding whether a location verifies, and the hashtable's verifiers are
+    /// generic over this trait alone. Widening them to [`Segment`] would defeat
+    /// the point of this trait being minimal.
+    ///
+    /// Distinct from [`Segment::generation`]: that is a 16-bit counter bumped
+    /// on `Free -> Reserved` and consumed by `CasToken`. This one is 6 bits and
+    /// advances only when a *used* incarnation ends.
+    fn incarnation(&self) -> u8;
+
     /// Verify that the key at the given offset matches.
     ///
     /// Used by hashtables to verify tag matches against actual keys.
@@ -115,17 +131,6 @@ pub trait Segment: SegmentKeyVerify + Send + Sync {
 
     /// Increment the generation counter (wraps at u16::MAX).
     fn increment_generation(&self);
-
-    /// Get the incarnation tag (6 bits) currently stamped on this segment.
-    ///
-    /// This is the value carried inside every `Location` issued while the
-    /// segment holds it. A location whose tag differs names a previous
-    /// incarnation and must not be resolved.
-    ///
-    /// Distinct from [`Segment::generation`]: that is a 16-bit counter bumped
-    /// on `Free -> Reserved` and consumed by `CasToken`. This one is 6 bits and
-    /// advances only when a *used* incarnation ends.
-    fn incarnation(&self) -> u8;
 
     // ========== Capacity ==========
 

--- a/cache/core/src/segment.rs
+++ b/cache/core/src/segment.rs
@@ -459,6 +459,13 @@ pub trait Segment: SegmentKeyVerify + Send + Sync {
     ///
     /// Clears all data and statistics. Should only be called when
     /// the segment is in `Locked` state with ref_count == 0.
+    ///
+    /// The implementations are asymmetric, and the difference now carries
+    /// meaning: `DiskSegmentMeta::reset` publishes `Free` and advances the
+    /// incarnation, ending the segment's lifecycle, while `SliceSegment::reset`
+    /// touches only statistics and leaves both state and tag alone. A caller
+    /// that needs the RAM equivalent of the disk behaviour wants
+    /// `SliceSegment::force_free`.
     fn reset(&self);
 }
 

--- a/cache/core/src/segment.rs
+++ b/cache/core/src/segment.rs
@@ -129,6 +129,36 @@ pub trait Segment: SegmentKeyVerify + Send + Sync {
 
     // ========== Capacity ==========
 
+    /// Get the offset alignment factor of the pool that owns this segment.
+    ///
+    /// Always a power of two and at least 8. Item offsets are multiples of it,
+    /// because a `Location` stores `offset / align_bytes` and cannot represent
+    /// anything finer -- see `LocationLayout`.
+    fn align_bytes(&self) -> u32;
+
+    /// Round an item size up to this segment's offset alignment.
+    ///
+    /// This is the segment's *stride*: appends advance the write offset by it,
+    /// and **every scan must advance by it too**. A scan that advances by
+    /// `header.padded_size()` -- which rounds to 8 regardless of the pool --
+    /// desyncs after the first item on a coarser-aligned pool and then reads
+    /// garbage headers. Both sides are `u32`, so the compiler cannot catch the
+    /// mismatch; this method exists so there is only one definition to get
+    /// right.
+    ///
+    /// Safe to apply to an already-8-padded size: `align_bytes` is a power of
+    /// two and at least 8, so rounding twice is the same as rounding once.
+    ///
+    /// Note this is *not* the size of the item's bytes. A bounds check against
+    /// `capacity` should use `header.padded_size()`, since the padding beyond
+    /// it is dead space that the last item in a segment need not own.
+    #[inline]
+    fn item_stride(&self, item_size: usize) -> u32 {
+        let align = self.align_bytes() as usize;
+        debug_assert!(align.is_power_of_two() && align >= 8);
+        ((item_size + align - 1) & !(align - 1)) as u32
+    }
+
     /// Get the total data capacity in bytes.
     fn capacity(&self) -> usize;
 

--- a/cache/core/src/segment.rs
+++ b/cache/core/src/segment.rs
@@ -116,6 +116,17 @@ pub trait Segment: SegmentKeyVerify + Send + Sync {
     /// Increment the generation counter (wraps at u16::MAX).
     fn increment_generation(&self);
 
+    /// Get the incarnation tag (6 bits) currently stamped on this segment.
+    ///
+    /// This is the value carried inside every `Location` issued while the
+    /// segment holds it. A location whose tag differs names a previous
+    /// incarnation and must not be resolved.
+    ///
+    /// Distinct from [`Segment::generation`]: that is a 16-bit counter bumped
+    /// on `Free -> Reserved` and consumed by `CasToken`. This one is 6 bits and
+    /// advances only when a *used* incarnation ends.
+    fn incarnation(&self) -> u8;
+
     // ========== Capacity ==========
 
     /// Get the total data capacity in bytes.

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -824,6 +824,10 @@ impl Segment for SliceSegment<'_> {
         self.generation.fetch_add(1, Ordering::AcqRel);
     }
 
+    fn incarnation(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
+    }
+
     fn capacity(&self) -> usize {
         self.capacity as usize
     }
@@ -898,10 +902,23 @@ impl Segment for SliceSegment<'_> {
                 }
             }
 
-            // Preserve the incarnation; Task 3 decides which transitions bump.
+            // Leaving `Locked` ends a used incarnation: the segment has been
+            // drained and cleared, so every `Location` issued against it must
+            // stop resolving. `Reserved` and `Linking` must NOT bump --
+            // `MemoryPool::release_segment`, `MemoryPool::release` and lost
+            // chain-extension elections all return never-used segments through
+            // here, and bumping there would advance a 6-bit tag at a rate
+            // decoupled from segment lifecycles.
+            let ends_incarnation = current_meta.state == State::Locked;
+
             let new_meta = current_meta
                 .with_state(State::Free)
                 .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            let new_meta = if ends_incarnation {
+                new_meta.bump_incarnation()
+            } else {
+                new_meta
+            };
 
             match self.metadata.compare_exchange(
                 current_packed,
@@ -937,11 +954,23 @@ impl Segment for SliceSegment<'_> {
             return false;
         }
 
-        // Preserve the incarnation: a chain/state CAS never ends one.
         let new_meta = current_meta.with_state(new_state).with_chain_ids(
             new_next.unwrap_or(current_meta.next),
             new_prev.unwrap_or(current_meta.prev),
         );
+
+        // Leaving `Locked` ends a used incarnation: the segment has been
+        // drained and cleared, and the layers recycle it as
+        // `Locked -> Reserved` before releasing it `Reserved -> Free`. Bumping
+        // here, inside the same CAS that publishes the new state, is what makes
+        // a stale location stop resolving -- and no thread can observe the new
+        // state paired with the old tag. Every other transition is mid-life and
+        // carries the tag forward unchanged.
+        let new_meta = if current_meta.state == State::Locked {
+            new_meta.bump_incarnation()
+        } else {
+            new_meta
+        };
 
         self.metadata
             .compare_exchange(
@@ -1339,11 +1368,14 @@ impl SliceSegment<'_> {
             .store(Self::INVALID_BUCKET_ID, Ordering::Relaxed);
         self.merge_count.store(0, Ordering::Relaxed);
 
-        // Set state to Free with invalid chain pointers, preserving the
-        // incarnation carried by the current metadata.
+        // Set state to Free with invalid chain pointers, advancing the
+        // incarnation: a flush recycles every segment at once, so locations
+        // issued before it must stop resolving just as they would after any
+        // other end-of-life transition.
         let free_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire))
             .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
         self.metadata.store(free_meta.pack(), Ordering::Release);
     }
 
@@ -1363,10 +1395,13 @@ impl SliceSegment<'_> {
             return false;
         }
 
-        // Preserve the incarnation; Task 3 decides which transitions bump.
+        // `AwaitingRelease -> Free` is unconditionally the end of a used
+        // incarnation: the segment was condemned while live and its last reader
+        // has just dropped. Always bump.
         let new_meta = current_meta
             .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
 
         if self
             .metadata
@@ -1652,6 +1687,137 @@ mod tests {
         }
     }
 
+    /// The incarnation advances on exactly the transitions that end a *used*
+    /// incarnation, and on no others.
+    ///
+    /// This is not a tidiness test, and the table is not the obvious one. The
+    /// eviction path recycles a drained segment as `Locked -> Reserved` and
+    /// only then releases it `Reserved -> Free`, so keying the bump on
+    /// `Locked -> Free` -- which the layers never drive -- leaves the tag at 0
+    /// forever with the whole suite still green. Keying on *leaving Locked* is
+    /// what makes it fire.
+    ///
+    /// The exclusions matter just as much. `MemoryPool::release_segment`,
+    /// `MemoryPool::release` and `FilePool::release` all return never-used
+    /// segments through `try_release`. If the bump fired there too, a burst of
+    /// reserve/release with no item lifecycle at all would drain the 6-bit
+    /// tag's collision hardness for free.
+    #[test]
+    fn test_incarnation_bumps_on_exactly_the_used_incarnation_transitions() {
+        let (segment, ptr, layout) = create_test_segment(0, false, 0, 4096);
+        assert_eq!(segment.incarnation(), 0);
+
+        // Free -> Reserved starts an incarnation. Must NOT bump.
+        assert!(segment.try_reserve());
+        assert_eq!(segment.incarnation(), 0, "try_reserve must not bump");
+
+        // Reserved -> Free: reserved but never used. Must NOT bump.
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            0,
+            "Reserved -> Free is a never-used release and must not bump"
+        );
+
+        // Linking -> Free: lost a chain-extension election. Must NOT bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Linking, None, None));
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            0,
+            "Linking -> Free is a lost election and must not bump"
+        );
+
+        // Locked -> Reserved: THE REAL RECYCLE PATH. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(segment.cas_metadata(State::Locked, State::Reserved, None, None));
+        assert_eq!(
+            segment.incarnation(),
+            1,
+            "Locked -> Reserved is how a drained segment is recycled and must bump"
+        );
+
+        // The Reserved -> Free that follows must not bump again -- one
+        // incarnation ending is one bump, not two.
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            1,
+            "the release following a recycle must not double-bump"
+        );
+
+        // Locked -> Free: the other way out of Locked. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            2,
+            "Locked -> Free also ends a used incarnation and must bump"
+        );
+
+        // AwaitingRelease -> Free: condemned. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert!(SliceSegment::release_condemned(&segment));
+        assert_eq!(
+            segment.incarnation(),
+            3,
+            "AwaitingRelease -> Free ends a used incarnation and must bump"
+        );
+
+        // Sealed -> Draining and Draining -> Locked are mid-life. Must NOT bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Sealed, None, None));
+        assert!(segment.cas_metadata(State::Sealed, State::Draining, None, None));
+        assert!(segment.cas_metadata(State::Draining, State::Locked, None, None));
+        assert_eq!(
+            segment.incarnation(),
+            3,
+            "transitions into Locked are mid-life and must not bump"
+        );
+
+        unsafe {
+            free_test_segment(ptr, layout);
+        }
+    }
+
+    /// Flush recycles every segment at once, so locations issued before it must
+    /// stop resolving: `force_free` ends an incarnation like any other exit.
+    #[test]
+    fn test_force_free_bumps_the_incarnation() {
+        let (segment, ptr, layout) = create_test_segment(0, false, 0, 4096);
+        assert!(segment.try_reserve());
+        let before = segment.incarnation();
+        segment.force_free();
+        assert_eq!(segment.incarnation(), (before + 1) & 0x3F);
+        assert_eq!(segment.state(), State::Free);
+
+        unsafe {
+            free_test_segment(ptr, layout);
+        }
+    }
+
+    /// The tag is 6 bits: it must wrap rather than spill into the state byte.
+    #[test]
+    fn test_incarnation_wraps_at_64_and_stays_in_range() {
+        let (segment, ptr, layout) = create_test_segment(0, false, 0, 4096);
+        for _ in 0..70 {
+            assert!(segment.try_reserve());
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            assert!(segment.cas_metadata(State::Locked, State::Reserved, None, None));
+            assert!(segment.try_release());
+            assert!(segment.incarnation() < 64, "tag must stay within 6 bits");
+        }
+        assert_eq!(segment.incarnation(), 70 % 64);
+
+        unsafe {
+            free_test_segment(ptr, layout);
+        }
+    }
+
     /// Every metadata transition must carry the incarnation forward.
     ///
     /// Seeds a nonzero tag and drives each transition site. A site that rebuilt
@@ -1659,13 +1825,16 @@ mod tests {
     /// `Location`s naming this segment would start resolving again -- exactly
     /// the aliasing the tag exists to prevent. Nothing bumps the tag yet, so a
     /// reset is invisible without seeding one first.
+    ///
+    /// This pins *preservation* for the transitions that do not end an
+    /// incarnation. `release_condemned` and `force_free` do end one and now
+    /// bump; they are still checked here, relative to the seeded tag, because a
+    /// site that rebuilt `Metadata` from scratch and then bumped would land on
+    /// 1 rather than `TAG + 1`. Which transitions bump is pinned separately by
+    /// `test_incarnation_bumps_on_exactly_the_used_incarnation_transitions`.
     #[test]
     fn test_segment_transitions_preserve_incarnation() {
         const TAG: u8 = 0x2A;
-
-        fn incarnation_of(seg: &SliceSegment<'_>) -> u8 {
-            Metadata::unpack(seg.metadata.load(Ordering::Acquire)).incarnation
-        }
 
         fn seed(seg: &SliceSegment<'_>, tag: u8) {
             let cur = Metadata::unpack(seg.metadata.load(Ordering::Acquire));
@@ -1680,34 +1849,40 @@ mod tests {
         }
 
         let (segment, ptr, layout) = create_test_segment(0, false, 0, 1024);
-        assert_eq!(incarnation_of(&segment), 0, "a fresh segment starts at 0");
+        assert_eq!(segment.incarnation(), 0, "a fresh segment starts at 0");
 
         seed(&segment, TAG);
 
         // Free -> Reserved
         assert!(segment.try_reserve());
-        assert_eq!(incarnation_of(&segment), TAG, "try_reserve reset the tag");
+        assert_eq!(segment.incarnation(), TAG, "try_reserve reset the tag");
 
         // Reserved -> Linking, with chain pointers rewritten
         assert!(segment.cas_metadata(State::Reserved, State::Linking, Some(7), Some(9)));
-        assert_eq!(incarnation_of(&segment), TAG, "cas_metadata reset the tag");
+        assert_eq!(segment.incarnation(), TAG, "cas_metadata reset the tag");
 
         // Linking -> Free
         assert!(segment.try_release());
-        assert_eq!(incarnation_of(&segment), TAG, "try_release reset the tag");
+        assert_eq!(segment.incarnation(), TAG, "try_release reset the tag");
 
-        // AwaitingRelease -> Free
+        // AwaitingRelease -> Free. This one ends a used incarnation, so it
+        // bumps; what is pinned here is that it bumps *from the seeded tag*
+        // rather than rebuilding the word from scratch, which would land on 1.
         assert!(segment.cas_metadata(State::Free, State::AwaitingRelease, None, None));
         assert!(SliceSegment::release_condemned(&segment));
         assert_eq!(
-            incarnation_of(&segment),
-            TAG,
-            "release_condemned reset the tag"
+            segment.incarnation(),
+            TAG + 1,
+            "release_condemned did not carry the tag forward"
         );
 
-        // Bulk pool reset
+        // Bulk pool reset. Also incarnation-ending, so it bumps again.
         segment.force_free();
-        assert_eq!(incarnation_of(&segment), TAG, "force_free reset the tag");
+        assert_eq!(
+            segment.incarnation(),
+            TAG + 2,
+            "force_free did not carry the tag forward"
+        );
 
         unsafe {
             free_test_segment(ptr, layout);

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -156,11 +156,9 @@ impl<'a> SliceSegment<'a> {
                 0
             };
 
-        let initial_meta = Metadata {
-            next: INVALID_SEGMENT_ID,
-            prev: INVALID_SEGMENT_ID,
-            state: State::Free,
-        };
+        // A brand-new segment: this is the one site that legitimately starts
+        // the incarnation counter at zero.
+        let initial_meta = Metadata::new(State::Free);
 
         Self {
             metadata: AtomicU64::new(initial_meta.pack()),
@@ -859,11 +857,10 @@ impl Segment for SliceSegment<'_> {
             return false;
         }
 
-        let new_meta = Metadata {
-            next: INVALID_SEGMENT_ID,
-            prev: INVALID_SEGMENT_ID,
-            state: State::Reserved,
-        };
+        // Preserve the incarnation: reserving does not end one.
+        let new_meta = current_meta
+            .with_state(State::Reserved)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
 
         match self.metadata.compare_exchange(
             current_packed,
@@ -901,11 +898,10 @@ impl Segment for SliceSegment<'_> {
                 }
             }
 
-            let new_meta = Metadata {
-                next: INVALID_SEGMENT_ID,
-                prev: INVALID_SEGMENT_ID,
-                state: State::Free,
-            };
+            // Preserve the incarnation; Task 3 decides which transitions bump.
+            let new_meta = current_meta
+                .with_state(State::Free)
+                .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
 
             match self.metadata.compare_exchange(
                 current_packed,
@@ -941,11 +937,11 @@ impl Segment for SliceSegment<'_> {
             return false;
         }
 
-        let new_meta = Metadata {
-            state: new_state,
-            next: new_next.unwrap_or(current_meta.next),
-            prev: new_prev.unwrap_or(current_meta.prev),
-        };
+        // Preserve the incarnation: a chain/state CAS never ends one.
+        let new_meta = current_meta.with_state(new_state).with_chain_ids(
+            new_next.unwrap_or(current_meta.next),
+            new_prev.unwrap_or(current_meta.prev),
+        );
 
         self.metadata
             .compare_exchange(
@@ -1343,12 +1339,11 @@ impl SliceSegment<'_> {
             .store(Self::INVALID_BUCKET_ID, Ordering::Relaxed);
         self.merge_count.store(0, Ordering::Relaxed);
 
-        // Set state to Free with invalid chain pointers
-        let free_meta = Metadata {
-            next: INVALID_SEGMENT_ID,
-            prev: INVALID_SEGMENT_ID,
-            state: State::Free,
-        };
+        // Set state to Free with invalid chain pointers, preserving the
+        // incarnation carried by the current metadata.
+        let free_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire))
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
         self.metadata.store(free_meta.pack(), Ordering::Release);
     }
 
@@ -1368,11 +1363,10 @@ impl SliceSegment<'_> {
             return false;
         }
 
-        let new_meta = Metadata {
-            next: INVALID_SEGMENT_ID,
-            prev: INVALID_SEGMENT_ID,
-            state: State::Free,
-        };
+        // Preserve the incarnation; Task 3 decides which transitions bump.
+        let new_meta = current_meta
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
 
         if self
             .metadata
@@ -1652,6 +1646,68 @@ mod tests {
         assert!(segment.try_release());
         assert!(segment.try_reserve());
         assert_eq!(segment.generation(), 2);
+
+        unsafe {
+            free_test_segment(ptr, layout);
+        }
+    }
+
+    /// Every metadata transition must carry the incarnation forward.
+    ///
+    /// Seeds a nonzero tag and drives each transition site. A site that rebuilt
+    /// `Metadata` from scratch would silently reset the tag to 0, and stale
+    /// `Location`s naming this segment would start resolving again -- exactly
+    /// the aliasing the tag exists to prevent. Nothing bumps the tag yet, so a
+    /// reset is invisible without seeding one first.
+    #[test]
+    fn test_segment_transitions_preserve_incarnation() {
+        const TAG: u8 = 0x2A;
+
+        fn incarnation_of(seg: &SliceSegment<'_>) -> u8 {
+            Metadata::unpack(seg.metadata.load(Ordering::Acquire)).incarnation
+        }
+
+        fn seed(seg: &SliceSegment<'_>, tag: u8) {
+            let cur = Metadata::unpack(seg.metadata.load(Ordering::Acquire));
+            seg.metadata.store(
+                Metadata {
+                    incarnation: tag,
+                    ..cur
+                }
+                .pack(),
+                Ordering::Release,
+            );
+        }
+
+        let (segment, ptr, layout) = create_test_segment(0, false, 0, 1024);
+        assert_eq!(incarnation_of(&segment), 0, "a fresh segment starts at 0");
+
+        seed(&segment, TAG);
+
+        // Free -> Reserved
+        assert!(segment.try_reserve());
+        assert_eq!(incarnation_of(&segment), TAG, "try_reserve reset the tag");
+
+        // Reserved -> Linking, with chain pointers rewritten
+        assert!(segment.cas_metadata(State::Reserved, State::Linking, Some(7), Some(9)));
+        assert_eq!(incarnation_of(&segment), TAG, "cas_metadata reset the tag");
+
+        // Linking -> Free
+        assert!(segment.try_release());
+        assert_eq!(incarnation_of(&segment), TAG, "try_release reset the tag");
+
+        // AwaitingRelease -> Free
+        assert!(segment.cas_metadata(State::Free, State::AwaitingRelease, None, None));
+        assert!(SliceSegment::release_condemned(&segment));
+        assert_eq!(
+            incarnation_of(&segment),
+            TAG,
+            "release_condemned reset the tag"
+        );
+
+        // Bulk pool reset
+        segment.force_free();
+        assert_eq!(incarnation_of(&segment), TAG, "force_free reset the tag");
 
         unsafe {
             free_test_segment(ptr, layout);

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -926,7 +926,7 @@ impl Segment for SliceSegment<'_> {
             // Leaving `Locked` ends a used incarnation: the segment has been
             // drained and cleared, so every `Location` issued against it must
             // stop resolving. `Reserved` and `Linking` must NOT bump --
-            // `MemoryPool::release_segment`, `MemoryPool::release` and lost
+            // `MemoryPool::release`, `FilePool::release` and lost
             // chain-extension elections all return never-used segments through
             // here, and bumping there would advance a 6-bit tag at a rate
             // decoupled from segment lifecycles.
@@ -980,14 +980,20 @@ impl Segment for SliceSegment<'_> {
             new_prev.unwrap_or(current_meta.prev),
         );
 
-        // Leaving `Locked` ends a used incarnation: the segment has been
-        // drained and cleared, and the layers recycle it as
-        // `Locked -> Reserved` before releasing it `Reserved -> Free`. Bumping
-        // here, inside the same CAS that publishes the new state, is what makes
-        // a stale location stop resolving -- and no thread can observe the new
-        // state paired with the old tag. Every other transition is mid-life and
-        // carries the tag forward unchanged.
-        let new_meta = if current_meta.state == State::Locked {
+        // *Leaving* `Locked` ends a used incarnation -- not merely being
+        // `Locked`. The segment has been drained and cleared, and the layers
+        // recycle it as `Locked -> Reserved` before releasing it
+        // `Reserved -> Free`. Bumping here, inside the same CAS that publishes
+        // the new state, is what makes a stale location stop resolving -- and
+        // no thread can observe the new state paired with the old tag.
+        //
+        // The `new_state != Locked` half is load-bearing: a chain-pointer-only
+        // rewrite that stays in `Locked` is mid-life, and eleven identity CASes
+        // in `organization/` take exactly that shape. Keying on the source
+        // state alone would advance the tag twice in one lifetime, halving the
+        // space the collision argument rests on. Every other transition is
+        // mid-life and carries the tag forward unchanged.
+        let new_meta = if current_meta.state == State::Locked && new_state != State::Locked {
             new_meta.bump_incarnation()
         } else {
             new_meta
@@ -1376,6 +1382,11 @@ impl SliceSegment<'_> {
     /// This should only be called when the cache is being flushed and no
     /// concurrent operations are accessing the segments (e.g., after the
     /// hashtable has been cleared).
+    ///
+    /// The flush-only requirement is stronger than it looks now that this ends
+    /// an incarnation: the bump goes through a plain load-modify-`store`, not a
+    /// CAS. Racing a concurrent `BasicItemGuard::drop`, which bumps through a
+    /// CAS, would drop or duplicate one of the two bumps.
     pub fn force_free(&self) {
         // Reset all data fields
         self.write_offset.store(0, Ordering::Relaxed);
@@ -1717,11 +1728,12 @@ mod tests {
     /// forever with the whole suite still green. Keying on *leaving Locked* is
     /// what makes it fire.
     ///
-    /// The exclusions matter just as much. `MemoryPool::release_segment`,
-    /// `MemoryPool::release` and `FilePool::release` all return never-used
-    /// segments through `try_release`. If the bump fired there too, a burst of
-    /// reserve/release with no item lifecycle at all would drain the 6-bit
-    /// tag's collision hardness for free.
+    /// The exclusions matter just as much. `MemoryPool::release` and
+    /// `FilePool::release` both return never-used segments through
+    /// `try_release`. If the bump fired there too, a burst of reserve/release
+    /// with no item lifecycle at all would drain the 6-bit tag's collision
+    /// hardness for free. The last arm covers the other half of the rule: a
+    /// chain rewrite that stays in `Locked` is not a departure from it.
     #[test]
     fn test_incarnation_bumps_on_exactly_the_used_incarnation_transitions() {
         let (segment, ptr, layout) = create_test_segment(0, false, 0, 4096);
@@ -1797,6 +1809,30 @@ mod tests {
             segment.incarnation(),
             3,
             "transitions into Locked are mid-life and must not bump"
+        );
+
+        // A chain-pointer-only rewrite that stays in Locked is mid-life, not
+        // the end of an incarnation. Eleven identity CASes in organization/
+        // take this shape; if one ever ran against a Locked neighbour, keying
+        // the bump on the source state alone would advance the tag twice in
+        // one lifetime.
+        let before = segment.incarnation();
+        assert!(segment.cas_metadata(State::Locked, State::Locked, Some(7), None));
+        assert_eq!(
+            segment.incarnation(),
+            before,
+            "a Locked -> Locked chain rewrite must not bump"
+        );
+        assert_eq!(
+            segment.next(),
+            Some(7),
+            "the chain pointer must still be written"
+        );
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            before + 1,
+            "leaving Locked must still bump exactly once"
         );
 
         unsafe {

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -66,7 +66,7 @@ impl Default for CasRetryConfig {
 /// - `true`: Per-item TTL using [`TtlHeader`] (each item has individual expire_at)
 #[repr(C, align(64))]
 pub struct SliceSegment<'a> {
-    /// Packed metadata: [8 unused][8 state][24 prev][24 next]
+    /// Packed metadata: [2 unused][6 incarnation][8 state][24 prev][24 next]
     metadata: AtomicU64,
 
     /// Next write position in the segment.

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -756,6 +756,10 @@ impl<'a> SliceSegment<'a> {
 
 // Implement SegmentKeyVerify
 impl SegmentKeyVerify for SliceSegment<'_> {
+    fn incarnation(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
+    }
+
     #[inline(always)]
     fn verify_key_at_offset(&self, offset: u32, key: &[u8], allow_deleted: bool) -> bool {
         self.verify_key_with_header(offset, key, allow_deleted)
@@ -839,10 +843,6 @@ impl Segment for SliceSegment<'_> {
 
     fn increment_generation(&self) {
         self.generation.fetch_add(1, Ordering::AcqRel);
-    }
-
-    fn incarnation(&self) -> u8 {
-        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
     }
 
     fn align_bytes(&self) -> u32 {

--- a/cache/core/src/slice_segment.rs
+++ b/cache/core/src/slice_segment.rs
@@ -100,6 +100,12 @@ pub struct SliceSegment<'a> {
     /// Packed: [2 bits pool_id][1 bit is_per_item_ttl][5 bits reserved]
     pool_flags: u8,
 
+    /// `log2` of the owning pool's offset alignment factor.
+    ///
+    /// Appends stride by `1 << align_shift`, because a `Location` stores
+    /// `offset / align_bytes` and cannot name a finer offset.
+    align_shift: u8,
+
     /// Number of times this segment was a merge destination.
     merge_count: AtomicU16,
 
@@ -138,6 +144,9 @@ impl<'a> SliceSegment<'a> {
     /// - `data`: Pointer to segment memory
     /// - `len`: Size of segment memory in bytes
     /// - `free_queue`: Pointer to pool's main free queue for async release
+    /// - `align_bytes`: The owning pool's offset alignment factor. Items are
+    ///   appended at multiples of it, so it must match the `LocationLayout`
+    ///   the pool packs locations with. A power of two, at least 8.
     pub unsafe fn new(
         pool_id: u8,
         is_per_item_ttl: bool,
@@ -145,9 +154,14 @@ impl<'a> SliceSegment<'a> {
         data: *mut u8,
         len: usize,
         free_queue: *const crossbeam_deque::Injector<u32>,
+        align_bytes: usize,
     ) -> Self {
         debug_assert!(pool_id <= 3, "pool_id {} exceeds 2-bit limit", pool_id);
         debug_assert!(len <= u32::MAX as usize, "segment too large");
+        debug_assert!(
+            align_bytes.is_power_of_two() && align_bytes >= 8,
+            "align_bytes {align_bytes} must be a power of two and at least 8"
+        );
 
         let pool_flags = (pool_id & Self::POOL_ID_MASK)
             | if is_per_item_ttl {
@@ -172,6 +186,7 @@ impl<'a> SliceSegment<'a> {
             expire_at: AtomicU32::new(0),
             bucket_id: AtomicU16::new(Self::INVALID_BUCKET_ID),
             pool_flags,
+            align_shift: align_bytes.trailing_zeros() as u8,
             merge_count: AtomicU16::new(0),
             generation: AtomicU16::new(0),
             free_queue,
@@ -232,7 +247,9 @@ impl<'a> SliceSegment<'a> {
         header_size: usize,
     ) -> Option<u32> {
         let item_size = header_size + optional.len() + key.len() + value.len();
-        let padded_size = (item_size + 7) & !7; // 8-byte alignment
+        // The pool's stride, not a hardcoded 8: every scan advances by the same
+        // quantity, and a `Location` cannot name a finer offset.
+        let padded_size = self.item_stride(item_size) as usize;
 
         let offset = self.reserve_space(padded_size as u32)?;
 
@@ -828,6 +845,10 @@ impl Segment for SliceSegment<'_> {
         Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
     }
 
+    fn align_bytes(&self) -> u32 {
+        1 << self.align_shift
+    }
+
     fn capacity(&self) -> usize {
         self.capacity as usize
     }
@@ -1137,7 +1158,7 @@ impl Segment for SliceSegment<'_> {
         header.to_bytes(&mut header_bytes);
 
         let item_size = TtlHeader::SIZE + optional.len() + key.len() + value_len;
-        let padded_size = (item_size + 7) & !7; // 8-byte alignment
+        let padded_size = self.item_stride(item_size) as usize;
 
         let offset = self.reserve_space(padded_size as u32)?;
 
@@ -1184,7 +1205,7 @@ impl Segment for SliceSegment<'_> {
         header.to_bytes(&mut header_bytes);
 
         let item_size = BasicHeader::SIZE + optional.len() + key.len() + value_len;
-        let padded_size = (item_size + 7) & !7; // 8-byte alignment
+        let padded_size = self.item_stride(item_size) as usize;
 
         let offset = self.reserve_space(padded_size as u32)?;
 
@@ -1284,13 +1305,11 @@ impl Segment for SliceSegment<'_> {
                 None => return Err(CacheError::KeyMismatch),
             };
 
-        // Compute padded item size from header info
-        let item_size = ((header_size
-            + optional_len as usize
-            + key_len as usize
-            + value_len as usize
-            + 7)
-            & !7) as u32;
+        // Must be the stride the append charged to `live_bytes`, not the
+        // 8-padded body size, or the accounting drifts on a coarser pool.
+        let item_size = self.item_stride(
+            header_size + optional_len as usize + key_len as usize + value_len as usize,
+        );
 
         // Set deleted flag (byte 1, bit 6)
         let data_ptr = unsafe { self.data.as_ptr().add(offset as usize) };
@@ -1557,8 +1576,9 @@ mod tests {
             std::ptr::write_bytes(ptr, 0, size);
         }
         let free_queue_ptr: *const crossbeam_deque::Injector<u32> = &*TEST_FREE_QUEUE;
-        let segment =
-            unsafe { SliceSegment::new(pool_id, is_per_item_ttl, id, ptr, size, free_queue_ptr) };
+        let segment = unsafe {
+            SliceSegment::new(pool_id, is_per_item_ttl, id, ptr, size, free_queue_ptr, 8)
+        };
         (segment, ptr, layout)
     }
 
@@ -2599,10 +2619,11 @@ impl SegmentPrune for SliceSegment<'_> {
                 }
             };
 
-            // Calculate padded item size
+            // Calculate the item's stride -- what the append advanced the
+            // write offset by. Advancing by anything else desyncs this walk.
             let item_size =
                 header_size + optional_len as usize + key_len as usize + value_len as usize;
-            let padded_size = ((item_size + 7) & !7) as u32;
+            let padded_size = self.item_stride(item_size);
 
             // Skip if already deleted
             if is_deleted {
@@ -2696,10 +2717,11 @@ impl SegmentPrune for SliceSegment<'_> {
                     }
                 };
 
-            // Calculate padded item size
+            // Calculate the item's stride -- what the append advanced the
+            // write offset by. Advancing by anything else desyncs this walk.
             let item_size =
                 header_size + optional_len as usize + key_len as usize + value_len as usize;
-            let padded_size = ((item_size + 7) & !7) as u32;
+            let padded_size = self.item_stride(item_size);
 
             // Skip if already deleted
             if is_deleted {
@@ -2805,10 +2827,11 @@ impl SegmentIter for SliceSegment<'_> {
                 }
             };
 
-            // Calculate padded item size
+            // Calculate the item's stride -- what the append advanced the
+            // write offset by. Advancing by anything else desyncs this walk.
             let item_size =
                 header_size + optional_len as usize + key_len as usize + value_len as usize;
-            let padded_size = ((item_size + 7) & !7) as u32;
+            let padded_size = self.item_stride(item_size);
 
             // Extract key, value, optional
             let optional_start = offset as usize + header_size;

--- a/cache/core/src/state.rs
+++ b/cache/core/src/state.rs
@@ -270,12 +270,13 @@ impl Metadata {
     ///
     /// Call this on exactly the transitions that end a *used* incarnation:
     ///
-    /// - **Leaving `Locked`**, whatever the destination. The layers recycle a
+    /// - **Leaving `Locked`** for a *different* state. The layers recycle a
     ///   drained segment as `Locked -> Reserved` and only then release it
     ///   `Reserved -> Free`, so keying on `Locked -> Free` alone would never
     ///   fire on the live eviction path. `Locked -> Free` is reachable through
     ///   `try_release` directly and bumps too; keying on the *source* state is
-    ///   what covers both.
+    ///   what covers both. A `Locked -> Locked` chain-pointer rewrite is not a
+    ///   departure and must NOT bump -- see `cas_metadata`.
     /// - **`AwaitingRelease -> Free`**, in all four places it occurs:
     ///   `release_condemned` on each segment type, and the last-reader drop in
     ///   `BasicItemGuard::drop` / `ValueRef::drop`. The drop paths are the
@@ -285,8 +286,8 @@ impl Metadata {
     ///   `DiskSegmentMeta::reset`, which flush every segment at once.
     ///
     /// Do NOT call it on `Reserved | Linking -> Free`. Those return never-used
-    /// segments — `MemoryPool::release_segment`, `MemoryPool::release`,
-    /// `FilePool::release`, and lost chain-extension elections — and bumping
+    /// segments — `MemoryPool::release`, `FilePool::release`,
+    /// `IoUringPool::release` and lost chain-extension elections — and bumping
     /// there would advance a 6-bit tag at a rate decoupled from segment
     /// lifecycles, draining its collision hardness for nothing.
     #[inline]

--- a/cache/core/src/state.rs
+++ b/cache/core/src/state.rs
@@ -180,10 +180,24 @@ impl State {
 
 /// Packed representation of segment metadata in a single AtomicU64.
 ///
-/// Layout: `[8 bits unused][8 bits state][24 bits prev][24 bits next]`
+/// Layout: `[2 unused][6 bits incarnation][8 bits state][24 prev][24 next]`
 ///
 /// This packing allows atomic updates to state and chain pointers together,
 /// which is essential for lock-free chain operations.
+///
+/// # Why the incarnation lives here
+///
+/// The incarnation tag is the low 6 bits of a per-segment counter that rides
+/// inside every `Location` issued during that incarnation. It must be bumped
+/// *atomically with the state transition that ends the incarnation*. Keeping it
+/// in a separate atomic would leave a window where the segment is already
+/// `Free` but still carries the old counter, and a thread reserving inside that
+/// window would refill under the old tag -- exactly the aliasing the tag exists
+/// to prevent.
+///
+/// This is distinct from `Segment::generation()`, a 16-bit counter bumped on
+/// `Free -> Reserved` that feeds `CasToken`. The two answer different questions
+/// and have different bump sites on purpose.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Metadata {
     /// Next segment ID in the chain (24 bits, INVALID_SEGMENT_ID if none).
@@ -192,24 +206,68 @@ pub struct Metadata {
     pub prev: u32,
     /// Current state of the segment.
     pub state: State,
+    /// Incarnation tag (6 bits). See the struct docs.
+    pub incarnation: u8,
 }
 
 impl Metadata {
-    /// Create new metadata with the given state and no chain links.
+    /// Bits of incarnation stored in the packed word.
+    ///
+    /// Shared with `Location`'s tag field so the two cannot drift apart.
+    const INCARNATION_BITS: u32 = crate::location_layout::TAG_BITS;
+    /// Mask covering [`Self::INCARNATION_BITS`].
+    const INCARNATION_MASK: u8 = crate::location_layout::TAG_MASK;
+    /// Bit position of the incarnation within the packed word.
+    const INCARNATION_SHIFT: u32 = 56;
+
+    /// Create new metadata with the given state, no chain links, incarnation 0.
+    ///
+    /// Only correct at segment construction. Every *transition* must carry the
+    /// incarnation forward -- use `with_state` or `bump_incarnation`.
     pub fn new(state: State) -> Self {
         Self {
             next: INVALID_SEGMENT_ID,
             prev: INVALID_SEGMENT_ID,
             state,
+            incarnation: 0,
         }
     }
 
-    /// Create metadata with state and chain pointers.
+    /// Create metadata with state and chain pointers, incarnation 0.
+    ///
+    /// Only correct at segment construction; see `new`.
     pub fn with_chain(state: State, next: Option<u32>, prev: Option<u32>) -> Self {
         Self {
             next: next.unwrap_or(INVALID_SEGMENT_ID),
             prev: prev.unwrap_or(INVALID_SEGMENT_ID),
             state,
+            incarnation: 0,
+        }
+    }
+
+    /// This metadata with a different state, preserving the incarnation.
+    ///
+    /// The correct helper for a transition that does not end an incarnation.
+    #[inline]
+    pub fn with_state(self, state: State) -> Self {
+        Self { state, ..self }
+    }
+
+    /// This metadata with different chain pointers, preserving everything else.
+    #[inline]
+    pub fn with_chain_ids(self, next: u32, prev: u32) -> Self {
+        Self { next, prev, ..self }
+    }
+
+    /// This metadata with the incarnation advanced by one, wrapping at 6 bits.
+    ///
+    /// Call this on exactly the transitions that end a *used* incarnation --
+    /// `Locked -> Free` and `AwaitingRelease -> Free`.
+    #[inline]
+    pub fn bump_incarnation(self) -> Self {
+        Self {
+            incarnation: self.incarnation.wrapping_add(1) & Self::INCARNATION_MASK,
+            ..self
         }
     }
 
@@ -220,9 +278,10 @@ impl Metadata {
         let next_24 = (self.next & 0xFF_FFFF) as u64;
         let prev_24 = (self.prev & 0xFF_FFFF) as u64;
         let state_8 = self.state as u64;
+        let inc = ((self.incarnation & Self::INCARNATION_MASK) as u64) << Self::INCARNATION_SHIFT;
 
-        // Pack: [8 unused][8 state][24 prev][24 next]
-        (state_8 << 48) | (prev_24 << 24) | next_24
+        // Pack: [2 unused][6 incarnation][8 state][24 prev][24 next]
+        inc | (state_8 << 48) | (prev_24 << 24) | next_24
     }
 
     /// Unpack metadata from a u64.
@@ -235,6 +294,7 @@ impl Metadata {
             next: (packed & 0xFF_FFFF) as u32,
             prev: ((packed >> 24) & 0xFF_FFFF) as u32,
             state,
+            incarnation: ((packed >> Self::INCARNATION_SHIFT) as u8) & Self::INCARNATION_MASK,
         }
     }
 
@@ -258,6 +318,15 @@ impl Metadata {
         }
     }
 }
+
+/// The incarnation must sit strictly above the state byte (bits 48..56) and
+/// still fit inside the 64-bit packed word. Widening `TAG_BITS` past 8 would
+/// break this, so fail the build rather than corrupt `state`.
+const _: () = assert!(
+    Metadata::INCARNATION_SHIFT >= 56
+        && Metadata::INCARNATION_SHIFT + Metadata::INCARNATION_BITS <= 64,
+    "incarnation tag does not fit above the state byte in the packed metadata word"
+);
 
 #[cfg(all(test, not(feature = "loom")))]
 mod tests {
@@ -324,6 +393,7 @@ mod tests {
             next: 123,
             prev: 456,
             state: State::Live,
+            incarnation: 0,
         };
 
         let packed = meta.pack();
@@ -340,6 +410,7 @@ mod tests {
             next: INVALID_SEGMENT_ID,
             prev: INVALID_SEGMENT_ID,
             state: State::Free,
+            incarnation: 0,
         };
 
         let packed = meta.pack();
@@ -358,6 +429,7 @@ mod tests {
             next: 0xFFFF_FFFF, // 32 bits set
             prev: 0xFFFF_FFFF,
             state: State::Sealed,
+            incarnation: 0,
         };
 
         let packed = meta.pack();
@@ -377,5 +449,101 @@ mod tests {
             let unpacked = Metadata::unpack(packed);
             assert_eq!(unpacked.state, state);
         }
+    }
+
+    #[test]
+    fn test_metadata_incarnation_roundtrip() {
+        for incarnation in 0u8..64 {
+            let meta = Metadata {
+                next: 123,
+                prev: 456,
+                state: State::Live,
+                incarnation,
+            };
+            let unpacked = Metadata::unpack(meta.pack());
+            assert_eq!(unpacked.incarnation, incarnation);
+            assert_eq!(unpacked.next, 123);
+            assert_eq!(unpacked.prev, 456);
+            assert_eq!(unpacked.state, State::Live);
+        }
+    }
+
+    #[test]
+    fn test_metadata_incarnation_masks_to_six_bits() {
+        let meta = Metadata {
+            next: 0,
+            prev: 0,
+            state: State::Free,
+            incarnation: 0xFF,
+        };
+        assert_eq!(Metadata::unpack(meta.pack()).incarnation, 0x3F);
+    }
+
+    #[test]
+    fn test_metadata_incarnation_does_not_disturb_other_fields() {
+        // The tag lives in the byte above `state`; a full-width tag must not
+        // bleed into the state or chain pointers.
+        let meta = Metadata {
+            next: INVALID_SEGMENT_ID,
+            prev: INVALID_SEGMENT_ID,
+            state: State::AwaitingRelease,
+            incarnation: 0x3F,
+        };
+        let unpacked = Metadata::unpack(meta.pack());
+        assert_eq!(unpacked.state, State::AwaitingRelease);
+        assert_eq!(unpacked.next, INVALID_SEGMENT_ID);
+        assert_eq!(unpacked.prev, INVALID_SEGMENT_ID);
+    }
+
+    #[test]
+    fn test_metadata_with_state_and_chain_ids_preserve_incarnation() {
+        // These are the helpers every transition site uses. If either dropped
+        // the tag, stale locations naming the segment would resolve again.
+        let meta = Metadata {
+            next: 1,
+            prev: 2,
+            state: State::Live,
+            incarnation: 0x2A,
+        };
+
+        let restated = meta.with_state(State::Sealed);
+        assert_eq!(restated.incarnation, 0x2A);
+        assert_eq!(restated.state, State::Sealed);
+        assert_eq!(restated.next, 1);
+        assert_eq!(restated.prev, 2);
+
+        let rechained = meta.with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+        assert_eq!(rechained.incarnation, 0x2A);
+        assert_eq!(rechained.state, State::Live);
+        assert_eq!(rechained.next, INVALID_SEGMENT_ID);
+        assert_eq!(rechained.prev, INVALID_SEGMENT_ID);
+    }
+
+    #[test]
+    fn test_metadata_bump_incarnation_advances_and_preserves_fields() {
+        let meta = Metadata {
+            next: 7,
+            prev: 8,
+            state: State::AwaitingRelease,
+            incarnation: 0,
+        };
+        let bumped = meta.bump_incarnation();
+        assert_eq!(bumped.incarnation, 1);
+        assert_eq!(bumped.state, State::AwaitingRelease);
+        assert_eq!(bumped.next, 7);
+        assert_eq!(bumped.prev, 8);
+        // And it survives a pack/unpack round trip.
+        assert_eq!(Metadata::unpack(bumped.pack()).incarnation, 1);
+    }
+
+    #[test]
+    fn test_metadata_bump_incarnation_wraps_at_six_bits() {
+        let meta = Metadata {
+            next: 0,
+            prev: 0,
+            state: State::Locked,
+            incarnation: 0x3F,
+        };
+        assert_eq!(meta.bump_incarnation().incarnation, 0);
     }
 }

--- a/cache/core/src/state.rs
+++ b/cache/core/src/state.rs
@@ -268,8 +268,27 @@ impl Metadata {
 
     /// This metadata with the incarnation advanced by one, wrapping at 6 bits.
     ///
-    /// Call this on exactly the transitions that end a *used* incarnation --
-    /// `Locked -> Free` and `AwaitingRelease -> Free`.
+    /// Call this on exactly the transitions that end a *used* incarnation:
+    ///
+    /// - **Leaving `Locked`**, whatever the destination. The layers recycle a
+    ///   drained segment as `Locked -> Reserved` and only then release it
+    ///   `Reserved -> Free`, so keying on `Locked -> Free` alone would never
+    ///   fire on the live eviction path. `Locked -> Free` is reachable through
+    ///   `try_release` directly and bumps too; keying on the *source* state is
+    ///   what covers both.
+    /// - **`AwaitingRelease -> Free`**, in all four places it occurs:
+    ///   `release_condemned` on each segment type, and the last-reader drop in
+    ///   `BasicItemGuard::drop` / `ValueRef::drop`. The drop paths are the
+    ///   dominant ones — the layers condemn a segment with readers outstanding
+    ///   and leave the last guard to free it.
+    /// - **Bulk recycles**: `SliceSegment::force_free` and
+    ///   `DiskSegmentMeta::reset`, which flush every segment at once.
+    ///
+    /// Do NOT call it on `Reserved | Linking -> Free`. Those return never-used
+    /// segments — `MemoryPool::release_segment`, `MemoryPool::release`,
+    /// `FilePool::release`, and lost chain-extension elections — and bumping
+    /// there would advance a 6-bit tag at a rate decoupled from segment
+    /// lifecycles, draining its collision hardness for nothing.
     #[inline]
     pub fn bump_incarnation(self) -> Self {
         Self {

--- a/cache/core/src/state.rs
+++ b/cache/core/src/state.rs
@@ -220,10 +220,15 @@ impl Metadata {
     /// Bit position of the incarnation within the packed word.
     const INCARNATION_SHIFT: u32 = 56;
 
-    /// Create new metadata with the given state, no chain links, incarnation 0.
+    /// Create metadata for a brand-new segment: no chain links, incarnation 0.
     ///
-    /// Only correct at segment construction. Every *transition* must carry the
-    /// incarnation forward -- use `with_state` or `bump_incarnation`.
+    /// # This is not a transition
+    ///
+    /// Zeroing the incarnation is correct **only** when constructing a segment
+    /// that has never been used, or when seeding a test's metadata word.
+    /// Calling this on a live segment silently resets its tag, which
+    /// resurrects every stale location naming it -- and unlike a struct
+    /// literal, it compiles clean. For a state change use `with_state`.
     pub fn new(state: State) -> Self {
         Self {
             next: INVALID_SEGMENT_ID,
@@ -235,7 +240,9 @@ impl Metadata {
 
     /// Create metadata with state and chain pointers, incarnation 0.
     ///
-    /// Only correct at segment construction; see `new`.
+    /// Zeroes the incarnation and carries the same hazard as [`Self::new`];
+    /// see the warning there. For a state or chain change on a live segment
+    /// use `with_state` / `with_chain_ids`.
     pub fn with_chain(state: State, next: Option<u32>, prev: Option<u32>) -> Self {
         Self {
             next: next.unwrap_or(INVALID_SEGMENT_ID),

--- a/cache/heap/Cargo.toml
+++ b/cache/heap/Cargo.toml
@@ -19,3 +19,6 @@ loom = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 smallvec = { workspace = true }
 tikv-jemalloc-ctl = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/cache/heap/src/verifier.rs
+++ b/cache/heap/src/verifier.rs
@@ -123,12 +123,15 @@ impl<'a> HeapTieredVerifier<'a> {
         };
 
         let item_loc = ItemLocation::from_location(location);
-        let segment = match disk_pool.get(item_loc.segment_id()) {
+        // The disk pool's own layout: pools with different segment sizes split
+        // the location bits differently.
+        let layout = disk_pool.layout();
+        let segment = match disk_pool.get(item_loc.segment_id(layout)) {
             Some(s) => s,
             None => return false,
         };
 
-        segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
     }
 }
 

--- a/cache/heap/src/verifier.rs
+++ b/cache/heap/src/verifier.rs
@@ -125,13 +125,20 @@ impl<'a> HeapTieredVerifier<'a> {
         let item_loc = ItemLocation::from_location(location);
         // The disk pool's own layout: pools with different segment sizes split
         // the location bits differently.
-        let layout = disk_pool.layout();
-        let segment = match disk_pool.get(item_loc.segment_id(layout)) {
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(disk_pool.layout());
+        let segment = match disk_pool.get(segment_id) {
             Some(s) => s,
             None => return false,
         };
 
-        segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        // A location naming a previous incarnation of this segment is not ours
+        // to resolve: the segment was drained and refilled, and this offset now
+        // holds a different item. Checked before touching any item bytes.
+        if segment.incarnation() != incarnation {
+            return false;
+        }
+
+        segment.verify_key_at_offset(offset, key, allow_deleted)
     }
 }
 
@@ -235,6 +242,64 @@ mod tests {
     use super::*;
     use crate::entry::HeapEntry;
     use std::time::Duration;
+
+    /// A disk location from a previous incarnation must not resolve, even
+    /// though the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_tiered_verifier_rejects_a_stale_disk_incarnation() {
+        use cache_core::{FilePoolBuilder, ItemLocation, Segment, State};
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let disk_pool = FilePoolBuilder::new(2)
+            .path(dir.path().join("disk.dat"))
+            .segment_size(64 * 1024)
+            .size(256 * 1024)
+            .build()
+            .expect("disk pool");
+
+        // Age every segment through a used incarnation, so the tag on the item
+        // written below is non-zero and a predecessor tag exists.
+        for _ in 0..disk_pool.segment_count() {
+            let id = disk_pool.reserve().expect("free segment");
+            let segment = disk_pool.get(id).expect("segment");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            disk_pool.release(id);
+        }
+
+        let id = disk_pool.reserve().expect("free segment");
+        let segment = disk_pool.get(id).expect("segment");
+        assert!(segment.cas_metadata(State::Reserved, State::Live, None, None));
+        let offset = segment.append_item(b"key", b"value", &[]).expect("append");
+        let tag = segment.incarnation();
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        let layout = *disk_pool.layout();
+        let live = ItemLocation::new(&layout, 2, id, tag, offset);
+        let stale = ItemLocation::new(&layout, 2, id, tag - 1, offset);
+
+        let storage = SlotStorage::new(10);
+        let verifier = HeapTieredVerifier::with_disk(&storage, 0, &disk_pool, 2);
+
+        // `verify_disk` is called directly rather than through `verify`.
+        // `SlotLocation::pool_id_from_location` is hardcoded to return 0, so
+        // `verify`'s dispatch sends every location to `verify_ram` and the disk
+        // arm is unreachable whenever `ram_pool_id == 0` -- which is how
+        // `HeapCache` builds it. That is a pre-existing defect in the heap
+        // disk tier, not one this check introduces; going through `verify`
+        // here would only test the dead dispatch.
+        assert!(
+            verifier.verify_disk(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify_disk(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
+    }
 
     #[test]
     fn test_verifier_key_match() {

--- a/cache/slab/Cargo.toml
+++ b/cache/slab/Cargo.toml
@@ -20,6 +20,7 @@ parking_lot = { workspace = true }
 loom = { workspace = true, optional = true }
 
 [dev-dependencies]
+tempfile = "3"
 criterion = { workspace = true }
 
 [[bench]]

--- a/cache/slab/src/verifier.rs
+++ b/cache/slab/src/verifier.rs
@@ -217,12 +217,15 @@ impl<'a> SlabTieredVerifier<'a> {
         };
 
         let item_loc = ItemLocation::from_location(location);
-        let segment = match disk_pool.get(item_loc.segment_id()) {
+        // The disk pool's own layout: pools with different segment sizes split
+        // the location bits differently.
+        let layout = disk_pool.layout();
+        let segment = match disk_pool.get(item_loc.segment_id(layout)) {
             Some(s) => s,
             None => return false,
         };
 
-        segment.verify_key_at_offset(item_loc.offset(), key, allow_deleted)
+        segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
     }
 }
 

--- a/cache/slab/src/verifier.rs
+++ b/cache/slab/src/verifier.rs
@@ -219,13 +219,20 @@ impl<'a> SlabTieredVerifier<'a> {
         let item_loc = ItemLocation::from_location(location);
         // The disk pool's own layout: pools with different segment sizes split
         // the location bits differently.
-        let layout = disk_pool.layout();
-        let segment = match disk_pool.get(item_loc.segment_id(layout)) {
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(disk_pool.layout());
+        let segment = match disk_pool.get(segment_id) {
             Some(s) => s,
             None => return false,
         };
 
-        segment.verify_key_at_offset(item_loc.offset(layout), key, allow_deleted)
+        // A location naming a previous incarnation of this segment is not ours
+        // to resolve: the segment was drained and refilled, and this offset now
+        // holds a different item. Checked before touching any item bytes.
+        if segment.incarnation() != incarnation {
+            return false;
+        }
+
+        segment.verify_key_at_offset(offset, key, allow_deleted)
     }
 }
 
@@ -298,6 +305,56 @@ mod tests {
             hugepage_size: HugepageSize::None,
             ..Default::default()
         }
+    }
+
+    /// A disk location from a previous incarnation must not resolve, even
+    /// though the key really is at that offset.
+    ///
+    /// That is the whole hazard: segments are append-only from a fixed start,
+    /// so the n-th item of the new incarnation lands where the n-th item of the
+    /// old one was. The key compare alone says yes; only the tag says no.
+    #[test]
+    fn test_tiered_verifier_rejects_a_stale_disk_incarnation() {
+        use cache_core::{FilePoolBuilder, ItemLocation, Segment, State};
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let disk_pool = FilePoolBuilder::new(2)
+            .path(dir.path().join("disk.dat"))
+            .segment_size(64 * 1024)
+            .size(256 * 1024)
+            .build()
+            .expect("disk pool");
+
+        // Age every segment through a used incarnation, so the tag on the item
+        // written below is non-zero and a predecessor tag exists.
+        for _ in 0..disk_pool.segment_count() {
+            let id = disk_pool.reserve().expect("free segment");
+            let segment = disk_pool.get(id).expect("segment");
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            disk_pool.release(id);
+        }
+
+        let id = disk_pool.reserve().expect("free segment");
+        let segment = disk_pool.get(id).expect("segment");
+        assert!(segment.cas_metadata(State::Reserved, State::Live, None, None));
+        let offset = segment.append_item(b"key", b"value", &[]).expect("append");
+        let tag = segment.incarnation();
+        assert_ne!(tag, 0, "the segment must be past its first incarnation");
+
+        let layout = *disk_pool.layout();
+        let live = ItemLocation::new(&layout, 2, id, tag, offset);
+        let stale = ItemLocation::new(&layout, 2, id, tag - 1, offset);
+
+        let allocator = SlabAllocator::new(&test_config()).expect("allocator");
+        let verifier = SlabTieredVerifier::with_disk(&allocator, 0, &disk_pool, 2);
+        assert!(
+            verifier.verify(b"key", live.to_location(), false),
+            "the current incarnation must resolve"
+        );
+        assert!(
+            !verifier.verify(b"key", stale.to_location(), false),
+            "a location from a previous incarnation must not resolve"
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -1368,57 +1368,67 @@ bump cannot be introduced on top of a silent reset."
 
 ### Task 3: Bump sites, and a transition table that pins them
 
+> **Rewritten 2026-09-06.** The original version keyed the bump on
+> `Locked -> Free`, a transition that does not occur on crucible's main eviction
+> path. Implementing it literally would have left the tag at 0 forever -- the
+> feature inert, every test green. See the corrected table in the design doc.
+
+The real recycle path is:
+
+```text
+Sealed -> Draining -> Locked -> Reserved      (cas_metadata, in the layers)
+                                  |
+                                  v
+                      pool.release() -> try_release  =>  Reserved -> Free
+```
+
+So the bump keys on **leaving `Locked`**, not on a destination state. `Locked` is
+reached only after a drain, so any exit from it ends a used incarnation
+whichever path took it. Keying on the source state rather than enumerating
+destination pairs is what makes this robust to the paths not yet enumerated.
+
 **Files:**
 - Modify: `cache/core/src/segment.rs` (trait method)
-- Modify: `cache/core/src/slice_segment.rs:888-921` (`try_release`), `:1363-1400` (`release_condemned`), `:1334-1353` (`force_free`)
-- Modify: `cache/core/src/disk/file_segment.rs`, `cache/core/src/disk/disk_segment_meta.rs` (trait impls)
+- Modify: `cache/core/src/slice_segment.rs` (`cas_metadata`, `try_release`, `release_condemned`, `force_free`)
+- Modify: `cache/core/src/disk/disk_segment_meta.rs` (same four)
+- Modify: `cache/core/src/disk/file_segment.rs` (delegating trait impl)
 
 - [ ] **Step 1: Write the failing test**
 
-Add to the `tests` module in `cache/core/src/slice_segment.rs`:
+Add to the `tests` module in `cache/core/src/slice_segment.rs`. Adapt to
+whatever segment-construction helper the neighbouring tests use.
 
 ```rust
     /// The incarnation advances on exactly the transitions that end a *used*
     /// incarnation, and on no others.
     ///
-    /// This is not a tidiness test. `MemoryPool::release_segment`,
+    /// This is not a tidiness test, and the table is not the obvious one. The
+    /// eviction path recycles a drained segment as `Locked -> Reserved` and
+    /// only then releases it `Reserved -> Free`, so keying the bump on
+    /// `Locked -> Free` -- which never happens -- leaves the tag at 0 forever
+    /// with the whole suite still green. Keying on *leaving Locked* is what
+    /// makes it fire.
+    ///
+    /// The exclusions matter just as much. `MemoryPool::release_segment`,
     /// `MemoryPool::release` and `FilePool::release` all return never-used
     /// segments through `try_release`. If the bump fired there too, a burst of
     /// reserve/release with no item lifecycle at all would drain the 6-bit
-    /// tag's collision hardness for free. A future change moving the bump would
-    /// look locally harmless and break exactly that.
+    /// tag's collision hardness for free.
     #[test]
     fn test_incarnation_bumps_on_exactly_the_used_incarnation_transitions() {
-        // Reserved -> Free: reserved but never used. Must NOT bump.
         let (segment, _mem) = make_segment(4096);
         assert_eq!(segment.incarnation(), 0);
+
+        // Free -> Reserved starts an incarnation. Must NOT bump.
         assert!(segment.try_reserve());
         assert_eq!(segment.incarnation(), 0, "try_reserve must not bump");
+
+        // Reserved -> Free: reserved but never used. Must NOT bump.
         assert!(segment.try_release());
         assert_eq!(
             segment.incarnation(),
             0,
             "Reserved -> Free is a never-used release and must not bump"
-        );
-
-        // Locked -> Free: drained and cleared. Must bump.
-        assert!(segment.try_reserve());
-        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
-        assert!(segment.try_release());
-        assert_eq!(
-            segment.incarnation(),
-            1,
-            "Locked -> Free ends a used incarnation and must bump"
-        );
-
-        // AwaitingRelease -> Free: condemned. Must bump.
-        assert!(segment.try_reserve());
-        assert!(segment.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
-        assert!(segment.release_condemned());
-        assert_eq!(
-            segment.incarnation(),
-            2,
-            "AwaitingRelease -> Free ends a used incarnation and must bump"
         );
 
         // Linking -> Free: lost a chain-extension election. Must NOT bump.
@@ -1427,9 +1437,71 @@ Add to the `tests` module in `cache/core/src/slice_segment.rs`:
         assert!(segment.try_release());
         assert_eq!(
             segment.incarnation(),
-            2,
+            0,
             "Linking -> Free is a lost election and must not bump"
         );
+
+        // Locked -> Reserved: THE REAL RECYCLE PATH. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(segment.cas_metadata(State::Locked, State::Reserved, None, None));
+        assert_eq!(
+            segment.incarnation(),
+            1,
+            "Locked -> Reserved is how a drained segment is recycled and must bump"
+        );
+
+        // The Reserved -> Free that follows must not bump again -- one
+        // incarnation ending is one bump, not two.
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            1,
+            "the release following a recycle must not double-bump"
+        );
+
+        // Locked -> Free: the other way out of Locked. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            2,
+            "Locked -> Free also ends a used incarnation and must bump"
+        );
+
+        // AwaitingRelease -> Free: condemned. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert!(segment.release_condemned());
+        assert_eq!(
+            segment.incarnation(),
+            3,
+            "AwaitingRelease -> Free ends a used incarnation and must bump"
+        );
+
+        // Sealed -> Draining and Draining -> Locked are mid-life. Must NOT bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Sealed, None, None));
+        assert!(segment.cas_metadata(State::Sealed, State::Draining, None, None));
+        assert!(segment.cas_metadata(State::Draining, State::Locked, None, None));
+        assert_eq!(
+            segment.incarnation(),
+            3,
+            "transitions into Locked are mid-life and must not bump"
+        );
+    }
+
+    #[test]
+    fn test_force_free_bumps_the_incarnation() {
+        // Flush recycles every segment at once, so locations issued before it
+        // must stop resolving: it ends an incarnation like any other.
+        let (segment, _mem) = make_segment(4096);
+        assert!(segment.try_reserve());
+        let before = segment.incarnation();
+        segment.force_free();
+        assert_eq!(segment.incarnation(), (before + 1) & 0x3F);
+        assert_eq!(segment.state(), State::Free);
     }
 
     #[test]
@@ -1438,38 +1510,25 @@ Add to the `tests` module in `cache/core/src/slice_segment.rs`:
         for _ in 0..70 {
             assert!(segment.try_reserve());
             assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            assert!(segment.cas_metadata(State::Locked, State::Reserved, None, None));
             assert!(segment.try_release());
             assert!(segment.incarnation() < 64, "tag must stay within 6 bits");
         }
         assert_eq!(segment.incarnation(), 70 % 64);
     }
-
-    #[test]
-    fn test_force_free_bumps_the_incarnation() {
-        // Flush recycles every segment. Locations issued before the flush must
-        // not resolve afterwards, so this ends an incarnation like any other.
-        let (segment, _mem) = make_segment(4096);
-        assert!(segment.try_reserve());
-        let before = segment.incarnation();
-        segment.force_free();
-        assert_eq!(segment.incarnation(), (before + 1) & 0x3F);
-        assert_eq!(segment.state(), State::Free);
-    }
 ```
 
-If a `make_segment(capacity) -> (SliceSegment<'static>, Vec<u8>)` helper does not
-already exist in that test module, reuse whatever the neighbouring tests use to
-build a segment (`test_segment_generation` at `slice_segment.rs:1823` shows the
-established pattern) and adapt these tests to it rather than inventing a helper.
+Add the disk twin of the first test to `disk_segment_meta.rs`, using the
+`segment_with_item` helper the tests there already use.
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run it to verify it fails**
 
-Run: `cargo test -p cache-core --lib slice_segment::tests::test_incarnation`
+Run: `cargo test -p cache-core --lib test_incarnation_bumps_on_exactly`
 Expected: FAIL to compile, `no method named incarnation found`.
 
 - [ ] **Step 3: Add the trait method**
 
-In `cache/core/src/segment.rs`, in `pub trait Segment`, immediately after
+In `cache/core/src/segment.rs`, in `pub trait Segment`, after
 `fn increment_generation(&self);`:
 
 ```rust
@@ -1481,139 +1540,88 @@ In `cache/core/src/segment.rs`, in `pub trait Segment`, immediately after
     ///
     /// Distinct from `generation()`: that is a 16-bit counter bumped on
     /// `Free -> Reserved` and consumed by `CasToken`. This one is 6 bits and
-    /// bumps only on the transitions that end a *used* incarnation.
+    /// advances only when a *used* incarnation ends.
     fn incarnation(&self) -> u8;
 ```
 
-- [ ] **Step 4: Write the implementation**
+Implement on `SliceSegment` and `DiskSegmentMeta` as
+`Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation`, and on
+`FileSegment` by delegating to `self.inner.incarnation()`. The two `#[cfg(test)]`
+`incarnation_for_test` helpers Task 2b added are now redundant -- delete them and
+point their callers at the trait method.
 
-In `cache/core/src/slice_segment.rs`, in `impl Segment for SliceSegment<'_>`,
-next to `fn generation`:
+- [ ] **Step 4: Bump on leaving `Locked`**
 
-```rust
-    #[inline(always)]
-    fn incarnation(&self) -> u8 {
-        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
-    }
-```
-
-Replace the body of `try_release` (`slice_segment.rs:888`) with:
+In `cas_metadata` (both `slice_segment.rs` and `disk_segment_meta.rs`), after
+building `new_meta` from `current_meta`:
 
 ```rust
-    fn try_release(&self) -> bool {
-        loop {
-            let current_packed = self.metadata.load(Ordering::Acquire);
-            let current_meta = Metadata::unpack(current_packed);
-
-            // `Locked` is the drained-and-cleared path: it ends a used
-            // incarnation, so the tag advances. `Reserved` and `Linking` are
-            // never-used releases (a lost chain-extension election, or
-            // `MemoryPool::release_segment` handing back an unused segment) and
-            // must not advance it -- a 6-bit tag cannot afford bumps that are
-            // decoupled from segment lifecycles.
-            let ends_incarnation = match current_meta.state {
-                State::Locked => true,
-                State::Reserved | State::Linking => false,
-                State::Free => return false,
-                _ => {
-                    panic!(
-                        "Attempt to release segment {} in invalid state {:?}",
-                        self.id, current_meta.state
-                    );
-                }
-            };
-
-            let new_meta = current_meta
-                .with_state(State::Free)
-                .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
-            let new_meta = if ends_incarnation {
-                new_meta.bump_incarnation()
-            } else {
-                new_meta
-            };
-
-            match self.metadata.compare_exchange(
-                current_packed,
-                new_meta.pack(),
-                Ordering::Release,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    self.merge_count.store(0, Ordering::Relaxed);
-                    return true;
-                }
-                Err(_) => continue,
-            }
-        }
-    }
+        // Leaving Locked ends a used incarnation: the segment has been drained
+        // and cleared, and the layers recycle it as Locked -> Reserved before
+        // releasing it. Bumping here, inside the same CAS that publishes the
+        // new state, is what makes a stale location stop resolving -- and no
+        // thread can observe the new state with the old tag.
+        let new_meta = if current_meta.state == State::Locked {
+            new_meta.bump_incarnation()
+        } else {
+            new_meta
+        };
 ```
 
-In `SliceSegment::release_condemned` (`slice_segment.rs:1363`), replace the
-`new_meta` construction with:
+In `try_release` (both files), the same condition, since `Locked -> Free` is the
+other way out:
 
 ```rust
-        // AwaitingRelease -> Free ends a used incarnation: the tag advances in
-        // the same CAS that publishes Free, so no thread can reserve this
-        // segment and refill it under the old tag.
-        let new_meta = current_meta
-            .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
-            .bump_incarnation();
+            let ends_incarnation = current_meta.state == State::Locked;
 ```
 
-In `SliceSegment::force_free` (`slice_segment.rs:1334`), replace the `free_meta`
-construction and store with:
+and apply `.bump_incarnation()` to `new_meta` when it holds. `Reserved` and
+`Linking` must not bump.
 
-```rust
-        // Flush recycles every segment, so locations issued before it must stop
-        // resolving: this ends an incarnation like any other.
-        let current_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire));
-        let free_meta = current_meta
-            .with_state(State::Free)
-            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
-            .bump_incarnation();
-        self.metadata.store(free_meta.pack(), Ordering::Release);
-```
+In `release_condemned` (both files), always bump -- `AwaitingRelease -> Free` is
+unconditionally the end of a used incarnation.
 
-Add the same `incarnation()` implementation to the `Segment` impls in
-`cache/core/src/disk/file_segment.rs` (delegate: `self.inner.incarnation()`) and
-`cache/core/src/disk/disk_segment_meta.rs` (unpack its own metadata word, same
-body as `SliceSegment`). Apply the identical `try_release` / `release_condemned`
-/ `force_free` treatment to `disk_segment_meta.rs` wherever those transitions
-exist there.
+In `force_free` (and `DiskSegmentMeta::reset`), always bump.
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [ ] **Step 5: Update the Task 2b assertions this invalidates**
 
-Run: `cargo test -p cache-core --lib slice_segment::tests`
-Expected: PASS, including the three new tests.
+`test_segment_transitions_preserve_incarnation` and
+`test_disk_segment_transitions_preserve_incarnation` currently assert that
+`release_condemned` *preserves*. It now bumps. Change those assertions to expect
+`43`, and add a comment noting the test pins preservation for the
+non-incarnation-ending transitions only. Do not delete the tests -- they still
+guard the ten sites that must preserve.
 
-- [ ] **Step 6: Prove the transition table red**
+- [ ] **Step 6: Verify and prove red**
 
-Temporarily change the `State::Reserved | State::Linking => false` arm to
-`=> true`, then run:
+Run: `cargo test -p cache-core --lib`
+Expected: PASS.
 
-Run: `cargo test -p cache-core --lib test_incarnation_bumps_on_exactly`
-Expected: FAIL with `Reserved -> Free is a never-used release and must not bump`.
+Prove each arm red individually and quote the failure text:
+- Change the `cas_metadata` condition to `false`: `Locked -> Reserved is how a drained segment is recycled and must bump` must fail.
+- Change it to bump unconditionally: `transitions into Locked are mid-life and must not bump` must fail.
+- Change `try_release`'s condition to `true`: `Reserved -> Free is a never-used release and must not bump` must fail.
+- Remove `release_condemned`'s bump: its assertion must fail.
 
-Revert the change and re-run; expected PASS. Record the observed failure text in
-the commit message.
+That third one is the cache-rs#78 prerequisite and the reason the exclusions are
+tested at all -- a bump that fires on never-used releases drains the tag's
+hardness at a rate decoupled from segment lifecycles.
 
 - [ ] **Step 7: Commit**
 
 ```bash
 git add cache/core/src/segment.rs cache/core/src/slice_segment.rs cache/core/src/disk/
-git commit -m "feat(cache-core): bump the incarnation on used-incarnation ends only
+git commit -m "feat(cache-core): bump the incarnation when a used incarnation ends
 
-Locked -> Free and AwaitingRelease -> Free advance the tag; force_free does
-too, since flush recycles everything. Reserved|Linking -> Free does not:
-release_segment and lost chain elections would otherwise drain a 6-bit tag
-at a rate decoupled from segment lifecycles.
+Keys on leaving Locked rather than on a destination state. The layers
+recycle a drained segment as Locked -> Reserved and only then release it
+Reserved -> Free, so the design's original Locked -> Free never fires --
+that table would have left the tag at 0 forever with the suite green.
 
-Pinned as a full transition table. Proven red by flipping the never-used arm
-to bump: 'Reserved -> Free is a never-used release and must not bump'."
+Reserved|Linking -> Free still must not bump: release_segment and lost
+chain elections would otherwise drain a 6-bit tag at a rate decoupled from
+segment lifecycles. Pinned as a full transition table, every arm proven red."
 ```
-
----
 
 ### Task 4: `ItemLocation` becomes layout-aware
 

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -2851,20 +2851,36 @@ Proven red by neutering the oracle's tag comparison."
 
 ---
 
-### Task 9: Full verification and the residual issue
+### Task 9: Cleanup, full verification, and the residual
 
-- [ ] **Step 1: Run every gate**
+- [ ] **Step 1: Delete the leftover instrumentation**
+
+`KeyOracle::verify` (`cache/core/src/loom_oracle.rs:392,401`) carries two live
+`eprintln!("MISS occupant=… tombstone=…")` calls -- debugging instrumentation
+left behind by the #95 investigation. They flood every loom run's output and
+have to be filtered out to read a result. Delete both; the `HazardWitness`
+counters they predate now serve the purpose properly.
+
+- [ ] **Step 2: Run every gate**
 
 ```bash
 cargo test --workspace
 cargo test -p cache-core --features loom
 cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy -p cache-core --features loom --all-targets -- -D warnings
 cargo fmt --all -- --check
+RUSTDOCFLAGS="-D warnings" cargo doc -p cache-core -p cache-slab -p cache-heap --no-deps
 ```
 
-Expected: all PASS. Record the test counts.
+Record the actual counts. The baselines entering this task are **469**
+(`cache-core --lib`) and **59** under `--features loom`.
 
-- [ ] **Step 2: Run Miri**
+Note `cache::tests::test_increment_concurrent_no_lost_updates` is a known
+pre-existing flake at roughly 1 run in 4 (issue #105, measured on a clean tree
+at `ea96520`). If it fails, re-run and say so; do not attribute it to this
+branch and do not chase it.
+
+- [ ] **Step 3: Run Miri**
 
 ```bash
 MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test -p cache-core --lib -- \
@@ -2872,9 +2888,11 @@ MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test -p cache-core --li
   --skip disk::io_uring --skip disk::recovery --skip hugepage::
 ```
 
-Expected: PASS, 378 tests plus the ones added here.
+This branch changed how segment memory is addressed (`align_bytes` striding) and
+added a new atomic read on the verify path, so Miri is load-bearing here rather
+than a formality. Report the count and any failure in full.
 
-- [ ] **Step 3: File the residual**
+- [ ] **Step 4: File the residual**
 
 ```bash
 gh issue create \
@@ -2903,36 +2921,28 @@ BODY
 )"
 ```
 
-- [ ] **Step 4: Open the PR**
+- [ ] **Step 5: Open the PR**
 
-Body must state, in the author's own words: what the tag does and does not
-close; that capacity per pool is now `2^36 * align_bytes` and therefore
-invariant under `segment_size`; that memory pools are unchanged at 8-byte
-alignment while disk pools coarsen to 512; that the read-path cost is
-**unmeasured** and cache-rs#78's `+0.94 ns` figure does not transfer because
-crucible's shifts became layout-dependent loads; and the residual issue number
-from Step 3.
+The body must state plainly, in the author's own voice:
 
----
+- **What the tag does and does not close.** It closes the false positive; the
+  data race residual is issue number from Step 4.
+- **Capacity.** Per pool it is now `2^36 x align_bytes`, invariant under
+  `segment_size`. Memory stays at 8-byte alignment (512 GiB/pool). Disk moves to
+  512-byte alignment (32 TiB/pool) and **disk appends now stride by 512**, so a
+  100-byte disk item occupies 512 bytes. That fragmentation was a deliberate
+  trade for the capacity and for removing 4096-block straddling.
+- **The read-path cost is unmeasured.** cache-rs#78 measured its tag check at
+  +0.94 +/- 0.26 ns, and that figure **does not transfer**: crucible's shifts
+  became layout-dependent loads rather than constants. Say so rather than
+  implying the cost is known.
+- **Two design errors caught in review**, because they are the interesting part
+  of this branch: the bump table originally named `Locked -> Free`, a transition
+  that never occurs (the layers recycle `Locked -> Reserved` then release
+  `Reserved -> Free`), which would have left every tag at 0 with the suite
+  green; and 512-byte disk alignment was specified without the append-padding
+  change that makes it possible.
+- **Pre-existing bugs found and filed, not fixed here:** #105, #106, #107, #108.
+  Call out #107 specifically -- FLUSHALL leaves a running server unwritable.
 
-## Self-Review
-
-**Spec coverage.** Layout and the fixed 6-bit tag: Task 1. Capacity invariance
-and per-pool alignment: Tasks 1 and 5. `incarnation` in `Metadata` rather than
-`generation`: Task 2. Bump sites and the transition table: Task 3. The check:
-Task 7. GHOST unaliasable: Task 1 (`ghost_is_unaliasable`, `max_segment_count`).
-Construction validates: Tasks 1 and 5. Memory and disk together: Tasks 5, 6, 7.
-Evidence items 1-4: Tasks 7, 8, 3, 1 respectively. Residuals: Task 9 Steps 3-4.
-
-**Known soft spots**, called out rather than hidden:
-
-- Task 7's test uses `build_small_test_cache` / `locate` / `key_verifier`, and
-  Task 3's uses `make_segment`. These are the shapes the tests need, not names
-  verified to exist. Both steps say to adapt to the neighbouring tests' helpers.
-- Task 8's `KeyOracle` extension assumes the cells encode a key and can carry an
-  incarnation in spare bits. If the existing encoding has no room, widen the cell
-  rather than packing the tag into the key field.
-- The read-path cost of turning constant shifts into layout-dependent loads is
-  unmeasured, and no task measures it. That is deliberate: measuring it well
-  needs the counterbalanced A/B discipline cache-rs#78 used, which is its own
-  piece of work and should not be faked inside this one.
+Do not open the PR until every gate in Steps 2 and 3 is green.

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -2531,48 +2531,83 @@ bytes per disk item, which is the trade this was chosen for."
 
 ### Task 7: The check, and a test that recycles
 
-**Files:**
-- Modify: `cache/core/src/cache.rs:1559-1670` (`CacheKeyVerifier`)
-- Modify: `cache/core/src/item_location.rs` (`SinglePoolVerifier`, `MultiPoolVerifier`)
-- Test: `cache/core/src/cache.rs` tests module
+> **Rewritten 2026-09-06.** The original named four verifier sites. There are
+> **nine** production `KeyVerifier` impls that resolve a segment location, and a
+> missed one is a hole the whole feature leaks through -- that verifier keeps
+> resolving stale locations with nothing to indicate it. Same undercount shape
+> as Task 2b's `Metadata::new` sites and Task 6's unnamed publish sites.
+
+This is the task the entire plan exists for. Everything so far has been
+plumbing: the tag is carved out of the location, stamped at publish, and bumped
+when an incarnation ends. **Nothing reads it yet.**
+
+#### Prerequisite: the check belongs on `SegmentKeyVerify`
+
+`SinglePoolVerifier` and `MultiPoolVerifier` in `item_location.rs` are generic
+over `S: SegmentKeyVerify`, but `incarnation()` currently lives on `Segment`.
+Rather than widen those bounds to `Segment` -- which would defeat the point of
+`SegmentKeyVerify` being minimal so that types without full segment access can
+still back a hashtable -- **move the method onto `SegmentKeyVerify`**:
+
+```rust
+pub trait SegmentKeyVerify {
+    /// The incarnation tag this segment currently carries.
+    ///
+    /// A location whose tag differs names a previous incarnation of this
+    /// segment and must not be resolved: the segment has been drained and
+    /// refilled, and the offset now holds a different item.
+    ///
+    /// This lives here rather than on `Segment` because it is part of deciding
+    /// whether a location verifies, and the hashtable's verifiers are generic
+    /// over this trait alone.
+    fn incarnation(&self) -> u8;
+
+    fn verify_key_at_offset(&self, offset: u32, key: &[u8], allow_deleted: bool) -> bool;
+    // ... existing methods unchanged
+}
+```
+
+`Segment: SegmentKeyVerify`, so remove the duplicate declaration from `Segment`
+and leave the three impls where they are.
+
+**Files:** `cache/core/src/segment.rs`, `cache.rs`, `item_location.rs`,
+`layer/fifo_layer.rs`, `layer/ttl_layer.rs`, `disk/disk_layer.rs`,
+`disk/io_uring_layer.rs`, `cache/slab/src/verifier.rs`, `cache/heap/src/verifier.rs`
 
 - [ ] **Step 1: Write the failing test**
-
-Add to the `tests` module in `cache/core/src/cache.rs`:
 
 ```rust
     /// A location held across a segment recycle must stop resolving.
     ///
-    /// Without the tag this is the crucible#88 hazard: segments are append-only
-    /// from a fixed start, so with uniform item sizes the n-th item of every
-    /// incarnation lands at the same offset, and a stale location silently
-    /// resolves to a different item at the same address.
+    /// This is the crucible#88 hazard. Segments are append-only from a fixed
+    /// start, so with uniform item sizes the n-th item of every incarnation
+    /// lands at the same offset -- a stale location does not merely point at
+    /// free space, it points at a *different live item*.
     #[test]
     fn test_stale_location_is_rejected_after_recycle() {
         let cache = build_small_test_cache();
-        let verifier = cache.key_verifier();
 
         cache.set(b"key", b"value", None, Duration::from_secs(60)).unwrap();
         let stale = cache.locate(b"key").expect("key should be present");
 
         // Sanity: it resolves now, so a later rejection means something.
         assert!(
-            verifier.verify(b"key", stale.to_location(), false),
-            "location must resolve before the recycle"
+            cache.verifier().verify(b"key", stale.to_location(), false),
+            "the location must resolve before any recycle"
         );
 
         let mut rejections = 0usize;
         for _ in 0..64 {
             cache.flush();
             cache.set(b"key", b"value", None, Duration::from_secs(60)).unwrap();
-            if !verifier.verify(b"key", stale.to_location(), false) {
+            if !cache.verifier().verify(b"key", stale.to_location(), false) {
                 rejections += 1;
             }
         }
 
-        // Non-zero guards against vacuity: if the loop never recycled the
+        // Non-zero guards vacuity: if the loop never actually recycled the
         // segment the stale location names, this test proves nothing.
-        assert!(rejections > 0, "no recycle was observed; test is vacuous");
+        assert!(rejections > 0, "no recycle was observed; the test is vacuous");
         assert_eq!(
             rejections, 64,
             "every post-recycle resolution of a stale location must be rejected"
@@ -2580,151 +2615,97 @@ Add to the `tests` module in `cache/core/src/cache.rs`:
     }
 ```
 
-If `build_small_test_cache`, `locate` or `key_verifier` do not exist under those
-names, use the equivalents the neighbouring `cache.rs` tests already use rather
-than adding new public API; the shape of the test is what matters.
+Adapt `build_small_test_cache` / `locate` / `verifier` to whatever the
+neighbouring `cache.rs` tests already provide; do not add public API for the
+test's convenience.
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run to verify it fails**
 
 Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
-Expected: FAIL at the `rejections == 64` assertion (the stale location still
-resolves), or at compile time if a helper name differs.
+Expected: FAIL at the `rejections == 64` assertion -- the stale location still
+resolves, which is the bug.
 
-- [ ] **Step 3: Write the implementation**
+- [ ] **Step 3: Add the check at all nine sites**
 
-In `cache/core/src/cache.rs`, add layouts to the verifier:
-
-```rust
-struct CacheKeyVerifier<'a> {
-    /// Direct pool references with is_per_item_ttl flag, indexed by pool_id.
-    pools: [Option<(PoolRef<'a>, bool)>; 4],
-    /// Each pool's location layout, indexed by pool_id. Decoding a location
-    /// requires the layout of the pool it names, which is why `pool_id` sits at
-    /// a fixed position.
-    layouts: [Option<LocationLayout>; 4],
-}
-```
-
-Populate `layouts` wherever `pools` is populated, from each pool's `layout()`.
-
-Rewrite the body of `verify`:
+The shape is identical everywhere: after resolving the segment, **before any
+item bytes are touched**, compare the location's tag against the segment's.
 
 ```rust
-    #[inline(always)]
-    fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
-        let item_loc = ItemLocation::from_location(location);
-        let pool_id = item_loc.pool_id();
-
-        // SAFETY: pool_id is 2 bits, and both arrays are [_; 4].
-        let Some((pool_ref, _is_per_item_ttl)) =
-            (unsafe { *self.pools.get_unchecked(pool_id as usize) })
-        else {
-            return false;
-        };
-        let Some(layout) = (unsafe { *self.layouts.get_unchecked(pool_id as usize) }) else {
-            return false;
-        };
-
-        let (_, segment_id, incarnation, offset) = item_loc.unpack(&layout);
-
-        match pool_ref {
-            PoolRef::Memory(pool) => {
-                let Some(segment) = pool.get(segment_id) else {
-                    return false;
-                };
-                // Before any item bytes are touched: a location naming a
-                // previous incarnation of this segment is not ours to resolve.
+                // A location naming a previous incarnation of this segment is
+                // not ours to resolve: the segment was drained and refilled,
+                // and this offset now holds a different item. Checked before
+                // touching item bytes.
                 if segment.incarnation() != incarnation {
                     return false;
                 }
-                segment.verify_key_at_offset(offset, key, allow_deleted)
-            }
-            PoolRef::Disk(pool) => {
-                let Some(segment) = pool.get(segment_id) else {
-                    return false;
-                };
-                if segment.incarnation() != incarnation {
-                    return false;
-                }
-                segment.verify_key_at_offset(offset, key, allow_deleted)
-            }
-            PoolRef::IoUring(pool) => {
-                let Some(meta) = pool.get_meta(segment_id) else {
-                    return false;
-                };
-                if meta.incarnation() != incarnation {
-                    return false;
-                }
-                meta.verify_key_at_offset(offset, key, allow_deleted)
-            }
-        }
-    }
 ```
 
-Apply the same decode-and-check to `prefetch` in the same impl (it currently
-calls `unpack()` with no layout), and to `SinglePoolVerifier::verify` and
-`MultiPoolVerifier::verify` in `cache/core/src/item_location.rs`. Both of those
-need a `LocationLayout` field, supplied at construction:
+| # | File | Verifier | Note |
+|---|---|---|---|
+| 1 | `cache.rs:1578` | `CacheKeyVerifier` | **the hot path**; three arms (Memory/Disk/IoUring), each already unpacks and discards the tag as `_` -- bind it |
+| 2 | `cache.rs` | `CacheKeyVerifier::prefetch` | must not prefetch off a stale location either |
+| 3 | `item_location.rs:187` | `SinglePoolVerifier` (generic, exported) | |
+| 4 | `item_location.rs:233` | `MultiPoolVerifier` (generic, exported) | per-pool layout already carried |
+| 5 | `layer/fifo_layer.rs:577` | `SinglePoolVerifier` | |
+| 6 | `layer/ttl_layer.rs:66` | `SinglePoolVerifier` | |
+| 7 | `disk/disk_layer.rs:70` | `SinglePoolVerifier` | |
+| 8 | `disk/io_uring_layer.rs:87` | `IoUringPoolVerifier` | |
+| 9 | `cache/slab/src/verifier.rs:232` | `SlabTieredVerifier::verify_disk` | other crate |
+| 10 | `cache/heap/src/verifier.rs:138` | `HeapTieredVerifier::verify_disk` | other crate |
 
-```rust
-pub struct SinglePoolVerifier<'a, S> {
-    segments: &'a [S],
-    layout: LocationLayout,
-}
+**Do NOT add the check to:** `SlabVerifier` (`slab/verifier.rs:47`) and
+`HeapCacheVerifier` (`heap/verifier.rs:34`) -- those decode slab slots and heap
+slots, which are not segment locations and have no incarnation. Also not
+`FnVerifier`, `DummyVerifier` (`recovery.rs:238`), or any test verifier.
+Check `MultiTypeVerifier` (`heap/verifier.rs:191`) and classify it explicitly.
 
-impl<'a, S> SinglePoolVerifier<'a, S> {
-    /// Create a new single-pool verifier.
-    pub fn new(segments: &'a [S], layout: LocationLayout) -> Self {
-        Self { segments, layout }
-    }
-}
-```
+- [ ] **Step 4: Verify**
 
-and in its `verify`, after resolving the segment and before
-`verify_key_at_offset`:
-
-```rust
-        if segment.incarnation() != item_loc.incarnation(&self.layout) {
-            return false;
-        }
-```
-
-`MultiPoolVerifier::with_pool` gains a `layout` parameter and stores
-`[Option<(&'a [S], LocationLayout)>; 4]`.
-
-- [ ] **Step 4: Run the tests to verify they pass**
-
-Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
+Run: `cargo test -p cache-core --lib`, `cargo test --workspace`
 Expected: PASS.
 
-Run: `cargo test -p cache-core`
-Expected: PASS.
+Existing tests that hold a location across an eviction and expect it to still
+resolve are now **testing the old broken behaviour**. Fix them to expect
+rejection, and report each one -- a test that had to change here is evidence the
+feature does something, so it is worth naming rather than quietly editing.
 
-- [ ] **Step 5: Prove the check red**
+- [ ] **Step 5: Prove red, both ways**
 
-Temporarily change the memory arm's guard to `if false {`, then run:
+The guard: change site 1's comparison to `if false {` and confirm
+`test_stale_location_is_rejected_after_recycle` fails on the `rejections == 64`
+assertion.
 
-Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
-Expected: FAIL on the `rejections == 64` assertion.
+The vacuity trap: restore the guard, replace the loop body's `cache.flush()`
+with a no-op, and confirm the test fails on `no recycle was observed`. **This
+one matters most.** Without it a test that never recycles passes for the wrong
+reason and certifies nothing -- the exact trap that made a Task 1 guard test
+useless.
 
-Then temporarily replace the loop body's `cache.flush()` with a no-op and
-confirm the test fails on `no recycle was observed; test is vacuous` -- this is
-the vacuity trap, and it must fire. Revert both.
+Quote both failures.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Confirm every site is reachable**
+
+Nine near-identical checks invite one being wrong or dead. For each, either
+point at a test that exercises it, or say plainly that it is unexercised.
+An unexercised check is a hole the feature leaks through silently.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add cache/core/src/cache.rs cache/core/src/item_location.rs
+git add cache/core/src cache/slab/src cache/heap/src
 git commit -m "fix(cache-core): reject stale-incarnation locations before reading bytes
 
-Closes the false positive in the crucible#88 family: a location held across
-a segment recycle no longer resolves to whatever now occupies that offset.
+The point of the whole change: a location held across a segment recycle no
+longer resolves to whatever item now occupies that offset. Closes the false
+positive half of crucible#88.
 
-Proven red two ways -- neutering the guard fails the rejection assertion,
-and removing the recycle fails the vacuity assertion."
+incarnation() moves to SegmentKeyVerify -- it is part of deciding whether a
+location verifies, and the hashtable's verifiers are generic over that trait
+rather than over Segment.
+
+Proven red two ways: neutering the guard fails the rejection assertion, and
+removing the recycle fails the vacuity assertion."
 ```
-
----
 
 ### Task 8: Loom model
 

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -814,6 +814,144 @@ module exists to protect."
 
 ---
 
+### Task 1c: pin the guards Task 1b added
+
+The Task 1b re-review approved the fixes but found the most consequential new
+guard untested, plus four cheap items. N1 and N4 are the substantive ones.
+
+**Files:** Modify `cache/core/src/location_layout.rs`
+
+- [ ] **Step 1: N1 -- pin the `offset` assert**
+
+Deleting `pack`'s offset range check currently leaves all 14 tests green. It is
+the guard against silent incarnation corruption -- the failure this whole
+feature exists to prevent -- so it must be proven red like everything else.
+
+```rust
+    #[test]
+    #[should_panic(expected = "exceeds this layout's 17-bit offset field")]
+    fn pack_rejects_an_offset_past_the_offset_field() {
+        // One byte past a 1 MiB segment, and still 8-aligned, so the alignment
+        // assert waves it through. Without the range check this silently
+        // overflows into the incarnation field and returns a corrupted tag.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        layout.pack(0, 5, 0, 1024 * 1024);
+    }
+```
+
+- [ ] **Step 2: N4 -- tighten the `segment_id` assert to the issuable range**
+
+`ghost_is_unaliasable` now builds its word directly, so `pack` no longer needs
+to admit the top id. As written the assert is value-identical to the old one and
+still passes for `max_segment_count()` -- the GHOST-aliasing value. Tighten it to
+the range a pool can actually issue, which is the off-by-one Tasks 4-6 are most
+likely to make:
+
+```rust
+        debug_assert!(
+            segment_id < self.max_segment_count(),
+            "segment_id {segment_id} is outside the issuable range 0..{}",
+            self.max_segment_count()
+        );
+```
+
+and pin it:
+
+```rust
+    #[test]
+    #[should_panic(expected = "is outside the issuable range")]
+    fn pack_rejects_the_unissuable_top_segment_id() {
+        // The id reserved so Location::GHOST cannot be aliased. A pool must
+        // never issue it, and pack must say so rather than encode it.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        layout.pack(0, layout.max_segment_count(), 0, 0);
+    }
+```
+
+- [ ] **Step 3: N2 -- record the precondition on the new subtraction**
+
+`let seg_bits = PAYLOAD_BITS - TAG_BITS - offset_bits;` cannot underflow only
+because the ceiling above caps `offset_bits` at 29. Swapping the two blocks
+passes every test and then panics on a 1 TiB input. State it:
+
+```rust
+        // Safe from underflow only because the ceiling above already capped
+        // offset_bits at 29 (align_shift >= 3). This ordering is load-bearing.
+        let seg_bits = PAYLOAD_BITS - TAG_BITS - offset_bits;
+```
+
+- [ ] **Step 4: N3 and N5 -- pin `div_ceil`, drop the magic numbers**
+
+`div_ceil` is still unpinned: plain `/` survives every test because
+`next_power_of_two` masks it. It diverges only when `align` does not divide
+`segment_size` and the plain quotient is already a power of two. Add to
+`derives_offset_bits_for_non_power_of_two_segment_sizes`:
+
+```rust
+        // Pins div_ceil specifically: with plain division this is 7 bits, which
+        // cannot address the last 9 bytes of the segment.
+        assert_eq!(LocationLayout::new(1025, 8).unwrap().offset_bits(), 8);
+```
+
+In `ghost_is_unaliasable`, replace the literal `+ 6` and `>> 3` with
+`TAG_BITS` and the layout's own alignment, so the test tracks the constants it
+is meant to pin:
+
+```rust
+        let unissuable = (3u64 << LocationLayout::POOL_SHIFT)
+            | ((layout.max_segment_count() as u64) << (layout.offset_bits() + TAG_BITS))
+            | (0x3Fu64 << layout.offset_bits())
+            | ((max_offset / layout.align_bytes()) as u64);
+```
+
+- [ ] **Step 5: N7 -- pin the downcast contract**
+
+`From<LayoutError> for io::Error` preserving the structured error is a claimed
+capability the pool builders in Task 5 may rely on, and nothing pins it:
+
+```rust
+    #[test]
+    fn io_error_conversion_preserves_the_structured_error() {
+        let err = LocationLayout::new(4096, 512).unwrap_err();
+        let io: std::io::Error = err.into();
+        assert_eq!(io.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(matches!(
+            io.get_ref().and_then(|e| e.downcast_ref::<LayoutError>()),
+            Some(LayoutError::SegmentTooSmall { .. })
+        ));
+    }
+```
+
+- [ ] **Step 6: Verify and prove red**
+
+Run: `cargo test -p cache-core --lib location_layout`
+Expected: PASS, 18 tests.
+
+Prove each new guard red: delete `pack`'s offset assert and confirm
+`pack_rejects_an_offset_past_the_offset_field` fails; loosen the `segment_id`
+assert back to `<= max_segment_count()` and confirm
+`pack_rejects_the_unissuable_top_segment_id` fails; replace `div_ceil` with `/`
+and confirm the non-power-of-two test fails. Restore all three.
+
+Run: `cargo test -p cache-core --lib`, `cargo clippy -p cache-core --all-targets -- -D warnings`, `cargo fmt`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cache/core/src/location_layout.rs
+git commit -m "test(cache-core): pin the guards Task 1b added
+
+pack's offset range check -- the guard against silent incarnation
+corruption -- could be deleted with every test still green. Now pinned,
+along with the issuable-id bound, div_ceil, and the io::Error downcast.
+
+Tightens the segment_id assert from the field width to the issuable range,
+so it rejects the unissuable top id that keeps GHOST unaliasable rather
+than encoding it."
+```
+
+---
+
 ### Task 2: `Metadata` carries the incarnation
 
 Adding a field to `Metadata` deliberately breaks every struct-literal site at compile time, so the compiler enumerates the places that must decide whether to preserve or bump. Do not add a `Default`.

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -172,17 +172,35 @@ mod tests {
     fn every_accepted_layout_can_represent_its_own_widest_offset() {
         // Guards the truncation the u32 bound exists to prevent: if `new`
         // accepts a layout, packing its widest offset must round-trip.
+        //
+        // The list MUST contain a size past the 4 GiB boundary. 4 GiB is where
+        // offset_bits + align_shift == 32 exactly -- still representable -- so a
+        // list stopping there never constructs a truncating layout and the test
+        // cannot go red when the bound is removed. 8 GiB is the first size that
+        // `new` would wrongly accept without it.
         for segment_size in [
             1024 * 1024usize,
             8 * 1024 * 1024,
             128 * 1024 * 1024,
             4 * 1024 * 1024 * 1024,
+            8 * 1024 * 1024 * 1024,
         ] {
             for align in [8usize, 512] {
                 let Ok(layout) = LocationLayout::new(segment_size, align) else {
                     continue;
                 };
-                let widest = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+
+                // Computed in u64 on purpose: in u32 this multiply would itself
+                // overflow and panic, reddening the test for the wrong reason.
+                let widest =
+                    ((1u64 << layout.offset_bits()) - 1) * layout.align_bytes() as u64;
+                assert!(
+                    widest <= u32::MAX as u64,
+                    "segment_size {segment_size} align {align} was accepted but \
+                     addresses past u32 (widest offset {widest})"
+                );
+
+                let widest = widest as u32;
                 assert_eq!(
                     layout.offset(layout.pack(0, 0, 0, widest)),
                     widest,

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -55,7 +55,9 @@ mod tests {
         let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
         assert_eq!(layout.offset_bits(), 17);
         assert_eq!(layout.seg_bits(), 19); // 42 - 6 - 17
-        assert_eq!(layout.max_segments(), (1 << 19) - 1);
+        // A count, not a max id: ids run 0..max_segment_count(), so the top
+        // field value is never issued.
+        assert_eq!(layout.max_segment_count(), (1 << 19) - 1);
 
         // 8 MB segments: offset needs 20 bits.
         let layout = LocationLayout::new(8 * 1024 * 1024, 8).unwrap();
@@ -83,7 +85,7 @@ mod tests {
             128 * 1024 * 1024,
         ] {
             let layout = LocationLayout::new(segment_size, 8).unwrap();
-            let capacity = (layout.max_segments() as u64 + 1) * segment_size as u64;
+            let capacity = (1u64 << layout.seg_bits()) * segment_size as u64;
             assert_eq!(
                 capacity,
                 512 * 1024 * 1024 * 1024,
@@ -97,7 +99,7 @@ mod tests {
         for segment_size in [1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024] {
             for align in [8, 64, 512] {
                 let layout = LocationLayout::new(segment_size, align).unwrap();
-                for &seg in &[0u32, 1, 7, layout.max_segments()] {
+                for &seg in &[0u32, 1, 7, layout.max_segment_count() - 1] {
                     for incarnation in 0u8..64 {
                         for &offset in &[0u32, align, segment_size as u32 - align] {
                             let raw = layout.pack(3, seg, incarnation, offset);
@@ -114,16 +116,18 @@ mod tests {
 
     #[test]
     fn ghost_is_unaliasable() {
-        // The top segment id is never issued, so no real location can collide
-        // with Location::GHOST (all 44 bits set).
+        // The top segment id is never issued, so no issuable location can
+        // collide with Location::GHOST (all 44 bits set).
         let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
-        let highest = layout.pack(
-            3,
-            layout.max_segments(),
-            0x3F,
-            (1 << layout.offset_bits()) * 8 - 8,
-        );
+        let max_offset = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+
+        // The highest location any pool can actually issue.
+        let highest = layout.pack(3, layout.max_segment_count() - 1, 0x3F, max_offset);
         assert_ne!(highest, crate::location::Location::MAX_RAW);
+
+        // And the reason it cannot: only the unissuable top id reaches GHOST.
+        let unissuable = layout.pack(3, layout.max_segment_count(), 0x3F, max_offset);
+        assert_eq!(unissuable, crate::location::Location::MAX_RAW);
     }
 
     #[test]
@@ -144,9 +148,11 @@ mod tests {
 
     #[test]
     fn rejects_segment_too_large_to_address() {
-        // A segment so large that no bits are left for segment ids.
+        // offset_bits + 6 must leave room for segment ids, so at 8-byte
+        // alignment the ceiling is a 512 GiB segment (offset_bits == 36).
+        assert!(LocationLayout::new(256 * 1024 * 1024 * 1024, 8).is_ok());
         assert!(matches!(
-            LocationLayout::new(64 * 1024 * 1024 * 1024, 8),
+            LocationLayout::new(512 * 1024 * 1024 * 1024, 8),
             Err(LayoutError::SegmentTooLarge { .. })
         ));
     }
@@ -154,9 +160,11 @@ mod tests {
     #[test]
     fn rejects_more_segments_than_fit() {
         let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
-        assert!(layout.validate_segment_count(layout.max_segments() as usize).is_ok());
         assert!(layout
-            .validate_segment_count(layout.max_segments() as usize + 1)
+            .validate_segment_count(layout.max_segment_count() as usize)
+            .is_ok());
+        assert!(layout
+            .validate_segment_count(layout.max_segment_count() as usize + 1)
             .is_err());
     }
 }
@@ -346,21 +354,21 @@ impl LocationLayout {
         1 << self.align_shift
     }
 
-    /// Highest issuable segment id.
+    /// How many segments a pool may hold, so ids run `0..max_segment_count()`.
     ///
-    /// One below the field maximum: leaving the top id unissued is what keeps
-    /// `Location::GHOST` (all 44 bits set) unaliasable by construction.
+    /// One below the field's capacity: leaving the top id unissuable is what
+    /// keeps `Location::GHOST` (all 44 bits set) unaliasable by construction.
     #[inline(always)]
-    pub fn max_segments(&self) -> u32 {
+    pub fn max_segment_count(&self) -> u32 {
         (1u32 << self.seg_bits()) - 1
     }
 
     /// Reject a pool that has more segments than this layout can address.
     pub fn validate_segment_count(&self, count: usize) -> Result<(), LayoutError> {
-        if count > self.max_segments() as usize {
+        if count > self.max_segment_count() as usize {
             return Err(LayoutError::TooManySegments {
                 requested: count,
-                max: self.max_segments(),
+                max: self.max_segment_count(),
             });
         }
         Ok(())
@@ -375,8 +383,11 @@ impl LocationLayout {
     #[inline(always)]
     pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
         debug_assert!(pool_id <= 3, "pool_id must be 0-3");
+        // `<=` not `<`: pack is a pure bit function, and the top id is a
+        // representable value -- it is `validate_segment_count` that keeps a
+        // pool from ever issuing it, which is what protects GHOST.
         debug_assert!(
-            segment_id <= self.max_segments(),
+            segment_id <= self.max_segment_count(),
             "segment_id exceeds this layout"
         );
         debug_assert!(
@@ -1808,7 +1819,7 @@ from Step 3.
 **Spec coverage.** Layout and the fixed 6-bit tag: Task 1. Capacity invariance
 and per-pool alignment: Tasks 1 and 5. `incarnation` in `Metadata` rather than
 `generation`: Task 2. Bump sites and the transition table: Task 3. The check:
-Task 7. GHOST unaliasable: Task 1 (`ghost_is_unaliasable`, `max_segments`).
+Task 7. GHOST unaliasable: Task 1 (`ghost_is_unaliasable`, `max_segment_count`).
 Construction validates: Tasks 1 and 5. Memory and disk together: Tasks 5, 6, 7.
 Evidence items 1-4: Tasks 7, 8, 3, 1 respectively. Residuals: Task 9 Steps 3-4.
 

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -954,7 +954,12 @@ than encoding it."
 
 ### Task 2: `Metadata` carries the incarnation
 
-Adding a field to `Metadata` deliberately breaks every struct-literal site at compile time, so the compiler enumerates the places that must decide whether to preserve or bump. Do not add a `Default`.
+Adding a field to `Metadata` deliberately breaks every struct-literal site at compile time. Do not add a `Default`.
+
+**The compiler does NOT enumerate every site.** It catches struct literals only;
+`Metadata::new(state)` calls compile clean and silently zero the tag. Six live
+transition sites take that form and are handled in Task 2b, which must land
+before Task 3 introduces any bump.
 
 **Files:**
 - Modify: `cache/core/src/state.rs:186-260`
@@ -1195,6 +1200,168 @@ Puts the tag in the packed word's unused byte so bumping it is atomic with
 the state transition. Adding the field deliberately breaks every struct
 literal, forcing each transition site to say whether it preserves or bumps;
 with_state and with_chain_ids are the preserving forms."
+```
+
+---
+
+### Task 2b: the six transition sites the compiler could not catch
+
+Task 2's premise was incomplete. Adding the field breaks struct *literals*, but
+`Metadata::new(state)` compiles clean and returns incarnation 0, so six live
+transitions silently reset the tag.
+
+This is harmless **only** while nothing bumps. It becomes a real aliasing bug the
+moment Task 3 lands, and `disk_segment_meta.rs`'s `try_reserve` is the worst of
+them: a `Free -> Reserved` reset would wipe a tag that was just advanced by the
+release which freed the segment.
+
+Every one of these sites already loads the metadata it needs on the line above,
+so each is a one-line change -- except `reset`, which stores unconditionally and
+needs a load added, exactly as `force_free` did in Task 2.
+
+**Files:** Modify `cache/core/src/cache_trait.rs`, `cache/core/src/disk/disk_segment_meta.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+The `SliceSegment` twin of this test already exists from Task 2
+(`test_segment_transitions_preserve_incarnation`). The disk path has no
+equivalent, which is why these six went unnoticed. Add to the `tests` module in
+`cache/core/src/disk/disk_segment_meta.rs`, following that test's shape and
+whatever segment-construction helper the neighbouring tests there already use:
+
+```rust
+    /// Every disk-segment transition must carry the incarnation forward.
+    ///
+    /// `Metadata::new` zeroes it and compiles clean, so nothing but this test
+    /// stands between a refactor and a silently reset tag -- which resurrects
+    /// stale locations rather than failing loudly.
+    #[test]
+    fn test_disk_segment_transitions_preserve_incarnation() {
+        let (meta, _pool) = make_disk_segment_meta(4096);
+
+        // Seed a non-zero tag directly, the way a prior incarnation's release
+        // would have left it.
+        let seeded = Metadata::unpack(meta.metadata.load(Ordering::Acquire))
+            .with_state(State::Free);
+        meta.metadata
+            .store(Metadata { incarnation: 42, ..seeded }.pack(), Ordering::Release);
+
+        assert!(meta.try_reserve());
+        assert_eq!(meta.incarnation_for_test(), 42, "try_reserve reset the tag");
+
+        assert!(meta.try_release());
+        assert_eq!(meta.incarnation_for_test(), 42, "try_release reset the tag");
+
+        assert!(meta.try_reserve());
+        assert!(meta.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert!(meta.release_condemned());
+        assert_eq!(
+            meta.incarnation_for_test(),
+            42,
+            "release_condemned reset the tag"
+        );
+
+        assert!(meta.try_reserve());
+        meta.reset();
+        assert_eq!(meta.incarnation_for_test(), 42, "reset cleared the tag");
+    }
+```
+
+`incarnation_for_test` is a private test helper reading
+`Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation` -- Task 3
+adds the real `Segment::incarnation()` trait method, and this task must not
+anticipate it.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cache-core --lib disk_segment_meta::tests::test_disk_segment_transitions_preserve_incarnation`
+Expected: FAIL with `try_reserve reset the tag`, left `0`, right `42`.
+
+- [ ] **Step 3: Fix all six sites**
+
+Each replaces `Metadata::new(State::X)` with `.with_state(State::X)` on the
+metadata already in hand:
+
+| File | Line | Site | Transition |
+|---|---|---|---|
+| `cache_trait.rs` | 231 | guard `drop` | `AwaitingRelease -> Free` |
+| `disk/disk_segment_meta.rs` | 365 | `try_reserve` | `Free -> Reserved` |
+| `disk/disk_segment_meta.rs` | 388 | `try_release` | `Reserved\|Linking\|Locked -> Free` |
+| `disk/disk_segment_meta.rs` | 437 | `release_condemned` | `AwaitingRelease -> Free` |
+| `disk/disk_segment_meta.rs` | 767 | `reset` | `* -> Free` |
+
+That is five; the sixth is whichever remaining `Metadata::new` call in a
+non-test transition path the compiler-independent audit in Step 4 turns up.
+
+For example, `cache_trait.rs:231` already has `meta` from the line above:
+
+```rust
+            if meta.state == State::AwaitingRelease {
+                // Preserve the incarnation: freeing a condemned segment is
+                // Task 3's business, and zeroing here would resurrect stale
+                // locations naming this segment.
+                let new_meta = meta.with_state(State::Free);
+```
+
+and `disk_segment_meta.rs:767` `reset` needs the load added:
+
+```rust
+        let current = Metadata::unpack(self.metadata.load(Ordering::Acquire));
+        let new_meta = current.with_state(State::Free);
+        self.metadata.store(new_meta.pack(), Ordering::Release);
+```
+
+- [ ] **Step 4: Audit for any site the table missed**
+
+The compiler cannot find these, so grep and classify every one by hand:
+
+```bash
+grep -rn "Metadata::new\|Metadata::with_chain" --include='*.rs' cache/
+```
+
+For each hit, decide: is it constructing a brand-new segment (correct to zero),
+or seeding a test's metadata word (correct to zero), or a state transition on a
+live segment (**must preserve**)? Report the full classified list. There are 23
+`Metadata::new` and 2 `Metadata::with_chain` call sites; most are test setup.
+
+- [ ] **Step 5: Sharpen the doc comment so the next reader is warned**
+
+`Metadata::new`'s doc currently says transitions must carry the incarnation
+forward, while six call sites did the opposite. Make the hazard explicit:
+
+```rust
+    /// Create metadata for a brand-new segment: no chain links, incarnation 0.
+    ///
+    /// # This is not a transition
+    ///
+    /// Zeroing the incarnation is correct **only** when constructing a segment
+    /// that has never been used, or when seeding a test's metadata word.
+    /// Calling this on a live segment silently resets its tag, which
+    /// resurrects every stale location naming it -- and unlike a struct
+    /// literal, it compiles clean. For a state change use `with_state`.
+```
+
+- [ ] **Step 6: Verify and prove red**
+
+Run: `cargo test -p cache-core --lib`
+Expected: PASS, 446 (445 plus this test).
+
+Re-break one site -- revert `disk_segment_meta.rs:365` `try_reserve` to
+`Metadata::new(State::Reserved)` -- and confirm the new test fails with
+`try_reserve reset the tag`. Restore it and quote the failure text.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cache/core/src/cache_trait.rs cache/core/src/disk/disk_segment_meta.rs
+git commit -m "fix(cache-core): preserve the incarnation across disk-segment transitions
+
+Task 2 assumed adding the field made the compiler enumerate every site. It
+enumerates struct literals only -- Metadata::new(state) compiles clean and
+returns incarnation 0, and six live transitions took that form.
+
+No effect yet, since nothing bumps until Task 3. Landing it first so the
+bump cannot be introduced on top of a silent reset."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -2683,11 +2683,20 @@ useless.
 
 Quote both failures.
 
-- [ ] **Step 6: Confirm every site is reachable**
+- [ ] **Step 6: Mutate every site individually -- do not merely point at a test**
 
-Nine near-identical checks invite one being wrong or dead. For each, either
-point at a test that exercises it, or say plainly that it is unexercised.
-An unexercised check is a hole the feature leaks through silently.
+Nine near-identical checks invite one being wrong or dead, and pointing at a
+test that "covers" a site is not evidence. Task 6b learned this the hard way:
+its new test passed, looked like proof, and touched **none** of the 18
+production scan sites -- 17 of 18 turned out to be entirely unprotected, found
+only by reverting each one and watching for red.
+
+So for each of the ten rows in Step 3's table: remove that check, run the suite,
+record RED or GREEN, restore. Report the table.
+
+Any site that stays GREEN is unprotected. Either add a test that reddens it, or
+state plainly that it is unexercised and why. Do not close this step with a
+site whose status you have not observed.
 
 - [ ] **Step 7: Commit**
 

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -2342,6 +2342,193 @@ into."
 
 ---
 
+### Task 6b: make disk appends honour `align_bytes`
+
+Task 5 was specified with disk pools defaulting to 512-byte alignment, and the
+Task 4-6 implementer correctly refused to ship it: **every segment type pads
+appends to a hardcoded 8 bytes** (`disk_segment_meta.rs:570,643` and seven more
+across `slice_segment.rs`). With `align_bytes = 512` the second item in any disk
+segment lands unaligned -- `LocationLayout::pack`'s `debug_assert` fires in
+debug, and in release the offset is silently truncated into a corrupted
+location.
+
+The design's justification ("an item straddling a 4096-byte block costs an extra
+block read today; sector alignment cuts that") only holds if items actually
+*start* on sector boundaries. That requires the append change this task makes,
+which the plan never scoped.
+
+**Decision taken: implement the padding.** Disk pools go back to 512-byte
+alignment, buying 32 TiB/pool (vs 512 GiB at align 8, itself a 4x regression on
+today's 2 TiB) and genuinely removing block straddling. The cost is real and was
+accepted: a 100-byte disk item occupies 512 bytes.
+
+Memory pools stay at 8. Only the disk paths change.
+
+**Files:** Modify `cache/core/src/disk/disk_segment_meta.rs`, `disk/file_segment.rs`,
+`disk/file_pool.rs`, `disk/io_uring_pool.rs`, `disk/disk_layer.rs`,
+`disk/io_uring_layer.rs`, `disk/recovery.rs`
+
+#### The trap: stride, not just offset
+
+Padding the append is half the job. Every scan advances `offset += header.padded_size()`,
+and `padded_size()` rounds to **8**. If appends stride by 512 and scans stride by
+8, every segment walk desyncs after the first item -- silently, since the walk
+just reads garbage headers and stops. There are **13 such sites** in the disk
+paths (`recovery.rs` x2, `disk_layer.rs` x2, `disk_segment_meta.rs` x2,
+`io_uring_layer.rs` x3, plus the append-side uses).
+
+The safe formulation: `align_bytes` is always a power of two and at least 8, so
+rounding an already-8-padded value up to `align_bytes` equals rounding the raw
+size up. **Every stride site can simply wrap what it already computes** -- no
+unpadded size needs threading through.
+
+- [ ] **Step 1: Write the failing test**
+
+In `disk_segment_meta.rs`'s tests:
+
+```rust
+    /// Appends must stride by the pool's alignment, and a scan must agree.
+    ///
+    /// If appends pad to 512 and scans still advance by `header.padded_size()`
+    /// (which rounds to 8), the walk desyncs after the first item and silently
+    /// reads garbage. Offsets must also be representable: an unaligned offset
+    /// is truncated by `LocationLayout::pack` in release.
+    #[test]
+    fn test_disk_appends_stride_by_the_pools_alignment() {
+        let (meta, _pool) = segment_with_alignment(64 * 1024, 512);
+        assert!(meta.try_reserve());
+
+        // Three small items, each far below the alignment factor.
+        let mut offsets = Vec::new();
+        for i in 0..3u8 {
+            let key = [b'k', i];
+            let offset = meta.append_item(&key, b"v", &[]).expect("append");
+            offsets.push(offset);
+        }
+
+        for (i, &offset) in offsets.iter().enumerate() {
+            assert_eq!(
+                offset % 512,
+                0,
+                "item {i} at offset {offset} is not 512-aligned"
+            );
+        }
+        assert_eq!(offsets, vec![0, 512, 1024], "stride must be the alignment");
+
+        // A scan must land on exactly those offsets, not 8-byte ones.
+        let mut walked = Vec::new();
+        let mut offset = 0u32;
+        while offset < meta.write_offset() {
+            let ptr = meta.header_ptr(offset, BasicHeader::SIZE).expect("header");
+            let header = unsafe { BasicHeader::try_from_ptr(ptr) }.expect("valid header");
+            walked.push(offset);
+            offset += meta.item_stride(header.padded_size());
+        }
+        assert_eq!(walked, offsets, "the scan stride disagrees with the append stride");
+    }
+
+    /// Memory-style 8-byte alignment must be unaffected.
+    #[test]
+    fn test_disk_alignment_of_eight_is_unchanged() {
+        let (meta, _pool) = segment_with_alignment(64 * 1024, 8);
+        assert!(meta.try_reserve());
+        let a = meta.append_item(b"k1", b"v", &[]).expect("append");
+        let b = meta.append_item(b"k2", b"v", &[]).expect("append");
+        assert_eq!(a, 0);
+        assert_eq!(b, 8, "an 8-aligned pool must still pack items at 8 bytes");
+    }
+```
+
+Add a `segment_with_alignment(capacity, align)` helper beside the existing test
+helpers rather than reworking them.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p cache-core --lib test_disk_appends_stride`
+Expected: FAIL -- offsets `[0, 8, 16]`, and `item_stride` does not exist.
+
+- [ ] **Step 3: Give the segment its alignment**
+
+`DiskSegmentMeta` gains `align_shift: u8`, set at construction from the owning
+pool's `layout.align_bytes().trailing_zeros()`. Add:
+
+```rust
+    /// Round an item size up to this segment's alignment.
+    ///
+    /// Appends stride by this, and every scan must advance by it too -- a scan
+    /// that advances by `header.padded_size()` (which rounds to 8) desyncs
+    /// after the first item on a coarser-aligned pool.
+    ///
+    /// Safe to apply to an already-8-padded size: `align_bytes` is a power of
+    /// two and at least 8, so rounding twice is the same as rounding once.
+    #[inline]
+    pub fn item_stride(&self, item_size: usize) -> u32 {
+        let align = 1usize << self.align_shift;
+        ((item_size + align - 1) & !(align - 1)) as u32
+    }
+```
+
+Replace both `(item_size + 7) & !7` sites in `disk_segment_meta.rs` with
+`self.item_stride(item_size) as usize`.
+
+- [ ] **Step 4: Fix all 13 stride sites**
+
+Every disk-path `offset += header.padded_size()` (and the `item_size` bindings
+feeding them) becomes `segment.item_stride(header.padded_size())`. Grep to find
+them all -- the compiler will **not** catch these, since both are `u32`:
+
+```bash
+grep -rn "padded_size" --include='*.rs' cache/core/src/disk/
+```
+
+This is the same class as the `Metadata::new` sites in Task 2b: a silent
+behaviour difference that compiles clean. Report the classified list.
+
+- [ ] **Step 5: Restore the 512-byte disk default**
+
+`FilePoolBuilder::align_bytes` defaults to 512; `IoUringPool::new` uses 512 and
+keeps its `align_bytes <= block_size` assert. Update the doc comments the
+Task 4-6 implementer added saying coarser alignment is unsupported -- it is now
+supported, and this task is what supports it.
+
+- [ ] **Step 6: Check what the fragmentation breaks**
+
+Fewer items now fit per disk segment. Run the full workspace and look
+specifically at disk-tier tests that assume a segment holds N items or that a
+given number of writes triggers eviction. Fix by adjusting the test's
+expectations, **not** by lowering the alignment. Report any test whose meaning
+changed.
+
+- [ ] **Step 7: Verify and prove red**
+
+Run: `cargo test -p cache-core --lib`, `cargo test --workspace`, clippy, fmt,
+loom check.
+
+Prove the stride coupling red: revert one scan site to `header.padded_size()`
+and confirm `test_disk_appends_stride_by_the_pools_alignment` fails on the
+walked-offsets assertion. Quote it. That is the assertion standing between this
+change and a silent segment-walk desync.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cache/core/src/disk/
+git commit -m "feat(cache-core): stride disk appends by the pool's align_bytes
+
+The 512-byte disk alignment the layout was designed around was never
+implementable: every append padded to a hardcoded 8, so the second item in
+a segment landed unaligned -- debug_assert in debug, a silently truncated
+offset in release.
+
+Padding the append is only half of it. Scans advance by header.padded_size(),
+which rounds to 8, so a coarser-aligned pool desyncs its own segment walk
+after one item. item_stride() is now the single definition both sides use.
+
+Restores disk pools to 512-byte alignment: 32 TiB per pool against 512 GiB
+at align 8, and items no longer straddle 4096-byte blocks. Costs up to 511
+bytes per disk item, which is the trade this was chosen for."
+```
+
 ### Task 7: The check, and a test that recycles
 
 **Files:**

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -1623,6 +1623,113 @@ chain elections would otherwise drain a 6-bit tag at a rate decoupled from
 segment lifecycles. Pinned as a full transition table, every arm proven red."
 ```
 
+### Task 3b: the guard-drop path that actually frees condemned segments
+
+Task 3 made `release_condemned` bump. It missed the two sites that perform the
+identical `AwaitingRelease -> Free` transition from a guard's `Drop` -- and those
+are the **main** path, not the exception:
+
+```rust
+// fifo_layer.rs:171
+// Draining -> AwaitingRelease (last reader's ValueRef::drop will free it)
+segment.cas_metadata(State::Draining, State::AwaitingRelease, None, None);
+// Race fix: if the last reader dropped between our ref_count check and the
+// CAS above, the segment is now AwaitingRelease with ref_count == 0 and
+// nobody will free it. Reclaim it now.
+if segment.ref_count() == 0 && segment.release_condemned() { return true; }
+```
+
+`release_condemned` here is the **fallback** for a narrow race. Whenever a reader
+is actually outstanding -- `ref_count() > 0`, which is the branch this whole code
+path exists for -- the segment is freed by the last guard drop instead.
+
+That is precisely the case a stale `Location` is most likely to exist for: a
+reader holding a reference across the recycle is the scenario the incarnation tag
+was built to defend against. As Task 3 stands, those segments keep their tag and
+the stale location still resolves.
+
+This is the same error as the `Locked -> Free` one, in the same shape: the
+fallback transition was tagged and the dominant one was not.
+
+**Files:** Modify `cache/core/src/item.rs`, `cache/core/src/cache_trait.rs`
+
+- [ ] **Step 1: Update the two drop tests to expect a bump**
+
+`test_item_guard_drop_preserves_incarnation` and
+`test_value_ref_drop_preserves_incarnation` (added in Task 2b) currently assert
+the tag is preserved at these sites. Invert them: seed 42, drop the guard, assert
+the tag is now **43** and the state is `Free` and the segment reached the free
+queue. Rename both from `_preserves_` to `_bumps_the_incarnation`, and keep the
+free-queue assertion -- it is what proves the transition actually ran rather than
+the CAS silently failing.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test -p cache-core --lib drop_bumps_the_incarnation`
+Expected: FAIL, tag 42 where 43 was expected, at both sites.
+
+- [ ] **Step 3: Bump at both sites**
+
+`item.rs:813` (`BasicItemGuard::drop`) and `cache_trait.rs:231`
+(`ValueRef::drop`), replacing the "Task 3 decides" comments:
+
+```rust
+                // AwaitingRelease -> Free ends a used incarnation, so the tag
+                // advances in the same CAS that publishes Free.
+                //
+                // This is the *main* condemned-free path, not an edge case: the
+                // layers condemn a segment with readers outstanding and leave
+                // the last guard drop to free it, calling `release_condemned`
+                // only as a fallback when the last reader vanished during the
+                // condemn window. A reader holding a location across this
+                // recycle is exactly what the tag defends against.
+                let new_meta = meta
+                    .with_state(State::Free)
+                    .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+                    .bump_incarnation();
+```
+
+Keep the `with_chain_ids` call. Dropping it would return a freed segment to the
+free queue still linked to its neighbours -- the defect caught in the Task 2b
+review.
+
+- [ ] **Step 4: Verify and prove red**
+
+Run: `cargo test -p cache-core --lib`
+Expected: PASS, 452.
+
+Remove each bump in turn and confirm the matching test reddens. Quote both.
+
+- [ ] **Step 5: Check for any remaining unbumped end-of-incarnation**
+
+Both misses so far were a dominant transition overlooked beside a tagged
+fallback. Grep every write that publishes `State::Free` or moves out of
+`State::Locked` and confirm each either bumps or is a documented never-used
+release:
+
+```bash
+grep -rn "State::Free\|State::Locked" --include='*.rs' cache/core/src | grep -v "^.*test"
+```
+
+Report the classified list. A site that ends a used incarnation without bumping
+is the failure this whole task exists to prevent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cache/core/src/item.rs cache/core/src/cache_trait.rs
+git commit -m "fix(cache-core): bump the incarnation on the guard-drop free path
+
+Task 3 tagged release_condemned, which is the fallback. The layers condemn
+a segment with readers outstanding and leave the last guard drop to free
+it, so BasicItemGuard::drop and ValueRef::drop are the main path -- and a
+reader holding a location across that recycle is exactly the case the tag
+defends against.
+
+Same shape as the Locked -> Free error: the fallback was tagged and the
+dominant transition was not."
+```
+
 ### Task 4: `ItemLocation` becomes layout-aware
 
 Accessors take the layout rather than `ItemLocation` storing one: the type stays

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -1730,6 +1730,141 @@ Same shape as the Locked -> Free error: the fallback was tagged and the
 dominant transition was not."
 ```
 
+### Task 3c: key the bump on *leaving* Locked, not on being Locked
+
+The Task 3/3b review approved the table but found `cas_metadata` implementing a
+broader rule than the spec states.
+
+The design says the bump fires on **leaving** `Locked`. The code says
+`if current_meta.state == State::Locked` -- source state alone. Those differ for
+a transition that stays in `Locked`, i.e. a chain-pointer-only rewrite.
+
+Eleven call sites use the identity form
+`seg.cas_metadata(seg.state(), seg.state(), Some(x), None)` --
+`organization/fifo.rs:265,333,348,358` and
+`organization/ttl_buckets.rs:438,503,514,611,623,749,763`. If any ever ran
+against a `Locked` neighbour, the tag would advance **mid-life**. The reviewer
+demonstrated it in a scratch copy:
+
+```text
+PROBE-IDCAS Locked identity CAS: 0 -> 1 (state Locked)
+PROBE-IDCAS after recycle: 2          # two bumps, one lifetime
+```
+
+**It is currently unreachable**, and the reviewer traced why: every unlink
+(`fifo::pop_head`/`try_remove`, `TtlBucket::evict_head_segment`/`remove_segment`)
+fixes its neighbours' pointers *under `chain_mutex`* before the layer drives
+`Draining -> Locked` *outside* it, so a chain member never names a `Locked`
+segment.
+
+That invariant is stated nowhere and tested nowhere. It is also exactly the
+"tag advancing at a rate decoupled from segment lifecycles" failure the
+exclusions exist to prevent -- and it stops being merely latent once Task 7's
+read-side check lands, because `process_evicted_segment`'s drain loop builds
+`ItemLocation`s *while* the segment is `Locked`.
+
+Fix the rule rather than rely on an unstated invariant.
+
+**Files:** Modify `cache/core/src/slice_segment.rs`, `cache/core/src/disk/disk_segment_meta.rs`
+
+- [ ] **Step 1: Add the failing arm to the transition table test**
+
+In `test_incarnation_bumps_on_exactly_the_used_incarnation_transitions` (and its
+disk twin), after the `Locked -> Reserved` arm:
+
+```rust
+        // A chain-pointer-only rewrite that stays in Locked is mid-life, not
+        // the end of an incarnation. Eleven identity CASes in organization/
+        // take this shape; if one ever ran against a Locked neighbour, keying
+        // the bump on the source state alone would advance the tag twice in
+        // one lifetime.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        let before = segment.incarnation();
+        assert!(segment.cas_metadata(State::Locked, State::Locked, Some(7), None));
+        assert_eq!(
+            segment.incarnation(),
+            before,
+            "a Locked -> Locked chain rewrite must not bump"
+        );
+        assert_eq!(segment.next(), Some(7), "the chain pointer must still be written");
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            before + 1,
+            "leaving Locked must still bump exactly once"
+        );
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p cache-core --lib test_incarnation_bumps_on_exactly`
+Expected: FAIL, `a Locked -> Locked chain rewrite must not bump`.
+
+- [ ] **Step 3: Tighten the condition in both files**
+
+```rust
+        // *Leaving* Locked ends a used incarnation -- not merely being Locked.
+        // A chain-pointer rewrite that stays in Locked is mid-life; bumping
+        // there would advance the tag twice in one lifetime.
+        let new_meta = if current_meta.state == State::Locked && new_state != State::Locked {
+            new_meta.bump_incarnation()
+        } else {
+            new_meta
+        };
+```
+
+- [ ] **Step 4: Correct the two docs that rest on a dead function**
+
+`MemoryPool::release_segment`'s doc claims it is "called by guard Drop when a
+segment in AwaitingRelease state has its last reader drop". It calls
+`try_release`, which **panics** on `AwaitingRelease`, and it has no production
+callers. Both the `try_release` comment and `state.rs`'s `bump_incarnation` doc
+cite it as the justification for the `Reserved|Linking -> Free` exclusion.
+
+The classification is right but the citation is wrong. Point both at the live
+callers -- `MemoryPool::release` (`memory_pool.rs:270`), `FilePool::release`
+(`file_pool.rs:322`), `IoUringPool::release` (`io_uring_pool.rs:222`) -- and fix
+`release_segment`'s own doc to say what it actually does.
+
+- [ ] **Step 5: Note the two asymmetries the review flagged**
+
+Neither is a defect; both now carry semantics they did not before, so record
+them where a reader will find them:
+
+- `force_free` bumps through a plain load-modify-`store`, not a CAS. Racing a
+  concurrent `BasicItemGuard::drop` CAS could drop or duplicate a bump. Add this
+  to its existing `# Safety` note, which already requires flush-only use.
+- `Segment::reset()` is asymmetric: `DiskSegmentMeta::reset` publishes `Free`
+  and bumps, `SliceSegment::reset` touches only statistics. Say so on the trait
+  method, since a bump now hangs off one side of it.
+
+- [ ] **Step 6: Verify and prove red**
+
+Run: `cargo test -p cache-core --lib`, expect 452.
+
+Prove the new arm red by reverting the condition to `state == State::Locked`,
+and confirm the rest of the table still passes (the tightening must not disturb
+`Locked -> Reserved` or `Locked -> Free`). Quote the failure.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cache/core/src/slice_segment.rs cache/core/src/disk/disk_segment_meta.rs cache/core/src/memory_pool.rs cache/core/src/state.rs cache/core/src/segment.rs
+git commit -m "fix(cache-core): bump on leaving Locked, not on being Locked
+
+cas_metadata keyed on the source state alone, so a chain-pointer-only
+rewrite that stays in Locked would bump mid-life -- two bumps in one
+lifetime, halving the tag space the collision argument depends on.
+
+Unreachable today: unlinks fix neighbour pointers under chain_mutex before
+the layer drives Draining -> Locked outside it, so a chain member never
+names a Locked segment. That invariant was unstated and untested, and it
+stops being latent once the read-side check lands, since the drain loop
+builds locations while the segment is Locked. Fix the rule rather than
+depend on it."
+```
+
 ### Task 4: `ItemLocation` becomes layout-aware
 
 Accessors take the layout rather than `ItemLocation` storing one: the type stays

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -1,0 +1,1826 @@
+# Incarnation-Tagged Locations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every `ItemLocation` a 6-bit incarnation tag so a stale location naming a recycled segment is rejected before any item bytes are read.
+
+**Architecture:** The 44 location bits are repartitioned per pool. `pool_id` stays at a fixed position (bits 43..42) so a decoder reads it first and then selects that pool's `LocationLayout`, which derives the offset-field width from `segment_size / align_bytes` and gives 6 bits to the tag. The tag itself lives in the unused byte of the segment's packed `Metadata` word, so bumping it is atomic with the state transition that ends an incarnation.
+
+**Tech Stack:** Rust, `cache-core`. Testing: `cargo test -p cache-core`, `cargo test -p cache-core --features loom`, `cargo +nightly miri test -p cache-core --lib`.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `cache/core/src/location_layout.rs` | Derive and validate the per-pool bit split | **create** |
+| `cache/core/src/state.rs` | `Metadata` carries a 6-bit `incarnation` | modify |
+| `cache/core/src/slice_segment.rs` | Bump sites; `incarnation()` accessor | modify |
+| `cache/core/src/segment.rs` | `Segment::incarnation()` trait method | modify |
+| `cache/core/src/item_location.rs` | Layout-aware pack/unpack; verifier tag check | modify |
+| `cache/core/src/memory_pool.rs` | `align_bytes` config, layout construction | modify |
+| `cache/core/src/disk/file_pool.rs`, `disk/io_uring_pool.rs` | same, defaulting to 512 B | modify |
+| `cache/core/src/pool.rs` | `RamPool::layout()` | modify |
+| `cache/core/src/cache.rs` | `CacheKeyVerifier` holds layouts; the tag check | modify |
+| `cache/core/src/layer/{fifo,ttl}_layer.rs`, `disk/disk_layer.rs` | Stamp the tag when publishing a location | modify |
+| `cache/core/src/loom_oracle.rs` | Model incarnations | modify |
+
+`location_layout.rs` is a new file rather than more code in `item_location.rs` (501 lines) because layout derivation and validation is a self-contained unit with its own error cases, and it is the piece the property test targets.
+
+---
+
+### Task 1: `LocationLayout`
+
+**Files:**
+- Create: `cache/core/src/location_layout.rs`
+- Modify: `cache/core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cache/core/src/location_layout.rs` containing only this test module:
+
+```rust
+//! Per-pool bit split for `Location`.
+
+#[cfg(all(test, not(feature = "loom")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_defaults_split_as_documented() {
+        // 1 MB segments, 8-byte alignment: offset needs log2(1MB/8) = 17 bits.
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 17);
+        assert_eq!(layout.seg_bits(), 19); // 42 - 6 - 17
+        assert_eq!(layout.max_segments(), (1 << 19) - 1);
+
+        // 8 MB segments: offset needs 20 bits.
+        let layout = LocationLayout::new(8 * 1024 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 20);
+        assert_eq!(layout.seg_bits(), 16);
+    }
+
+    #[test]
+    fn disk_default_alignment_buys_capacity() {
+        // 8 MB segments at 512-byte alignment: offset needs log2(8MB/512) = 14 bits.
+        let layout = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
+        assert_eq!(layout.offset_bits(), 14);
+        assert_eq!(layout.seg_bits(), 22);
+    }
+
+    #[test]
+    fn capacity_is_invariant_under_segment_size() {
+        // The design's central claim: offset bits gained are segment bits lost,
+        // so capacity depends only on the alignment factor. If this ever fails,
+        // the justification for the disk alignment change is gone.
+        for segment_size in [
+            1024 * 1024,
+            8 * 1024 * 1024,
+            32 * 1024 * 1024,
+            128 * 1024 * 1024,
+        ] {
+            let layout = LocationLayout::new(segment_size, 8).unwrap();
+            let capacity = (layout.max_segments() as u64 + 1) * segment_size as u64;
+            assert_eq!(
+                capacity,
+                512 * 1024 * 1024 * 1024,
+                "segment_size {segment_size} should still yield 512 GiB"
+            );
+        }
+    }
+
+    #[test]
+    fn roundtrips_every_field() {
+        for segment_size in [1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024] {
+            for align in [8, 64, 512] {
+                let layout = LocationLayout::new(segment_size, align).unwrap();
+                for &seg in &[0u32, 1, 7, layout.max_segments()] {
+                    for incarnation in 0u8..64 {
+                        for &offset in &[0u32, align, segment_size as u32 - align] {
+                            let raw = layout.pack(3, seg, incarnation, offset);
+                            assert_eq!(layout.pool_id(raw), 3);
+                            assert_eq!(layout.segment_id(raw), seg);
+                            assert_eq!(layout.incarnation(raw), incarnation);
+                            assert_eq!(layout.offset(raw), offset);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ghost_is_unaliasable() {
+        // The top segment id is never issued, so no real location can collide
+        // with Location::GHOST (all 44 bits set).
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        let highest = layout.pack(
+            3,
+            layout.max_segments(),
+            0x3F,
+            (1 << layout.offset_bits()) * 8 - 8,
+        );
+        assert_ne!(highest, crate::location::Location::MAX_RAW);
+    }
+
+    #[test]
+    fn rejects_bad_alignment() {
+        assert!(matches!(
+            LocationLayout::new(1024 * 1024, 3),
+            Err(LayoutError::AlignNotPowerOfTwo { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(1024 * 1024, 4),
+            Err(LayoutError::AlignTooSmall { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(1024, 4096),
+            Err(LayoutError::AlignExceedsSegment { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_segment_too_large_to_address() {
+        // A segment so large that no bits are left for segment ids.
+        assert!(matches!(
+            LocationLayout::new(64 * 1024 * 1024 * 1024, 8),
+            Err(LayoutError::SegmentTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_more_segments_than_fit() {
+        let layout = LocationLayout::new(1024 * 1024, 8).unwrap();
+        assert!(layout.validate_segment_count(layout.max_segments() as usize).is_ok());
+        assert!(layout
+            .validate_segment_count(layout.max_segments() as usize + 1)
+            .is_err());
+    }
+}
+```
+
+Register the module. In `cache/core/src/lib.rs`, next to the existing `mod location;` line, add:
+
+```rust
+pub mod location_layout;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib location_layout`
+Expected: FAIL to compile, `cannot find type LocationLayout in this scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Insert above the test module in `cache/core/src/location_layout.rs`:
+
+```rust
+//! Per-pool bit split for `Location`.
+//!
+//! A `Location` is 44 bits. `pool_id` occupies the top 2 at a fixed position so
+//! a decoder can read it before knowing anything else, then select that pool's
+//! layout to decode the rest. The remaining 42 bits split three ways:
+//!
+//! ```text
+//! [43..42] pool_id      2 bits, fixed
+//! [41..  ] segment_id   42 - 6 - offset_bits
+//! [  ..  ] incarnation  6 bits
+//! [  ..0 ] offset/align offset_bits
+//! ```
+//!
+//! # Capacity is invariant under `segment_size`
+//!
+//! With a fixed tag width, offset bits gained are segment bits lost, exactly:
+//!
+//! ```text
+//! capacity/pool = 2^(42 - TAG_BITS) * align_bytes = 2^36 * align_bytes
+//! ```
+//!
+//! `segment_size` does not appear. The alignment factor is the only capacity
+//! lever, which is why disk pools default to 512-byte alignment (32 TiB/pool)
+//! while memory pools stay at 8 (512 GiB/pool).
+
+use std::fmt;
+
+/// Bits available below `pool_id`.
+const PAYLOAD_BITS: u32 = 42;
+
+/// Width of the incarnation tag. Fixed: see the module docs on why widening it
+/// would cost capacity rather than segment size.
+pub const TAG_BITS: u32 = 6;
+
+/// Mask for a 6-bit incarnation tag.
+pub const TAG_MASK: u8 = (1 << TAG_BITS) - 1;
+
+/// Why a pool's location layout could not be built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutError {
+    /// `align_bytes` was not a power of two.
+    AlignNotPowerOfTwo { align: usize },
+    /// `align_bytes` was below the 8-byte item alignment.
+    AlignTooSmall { align: usize },
+    /// `align_bytes` exceeded `segment_size`.
+    AlignExceedsSegment { align: usize, segment_size: usize },
+    /// `segment_size / align_bytes` needs so many offset bits that no segment
+    /// ids are left.
+    SegmentTooLarge {
+        segment_size: usize,
+        align: usize,
+        offset_bits: u32,
+    },
+    /// The pool has more segments than the layout can address.
+    TooManySegments { requested: usize, max: u32 },
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlignNotPowerOfTwo { align } => {
+                write!(f, "align_bytes ({align}) must be a power of two")
+            }
+            Self::AlignTooSmall { align } => write!(
+                f,
+                "align_bytes ({align}) must be at least 8, the item alignment"
+            ),
+            Self::AlignExceedsSegment {
+                align,
+                segment_size,
+            } => write!(
+                f,
+                "align_bytes ({align}) must not exceed segment_size ({segment_size})"
+            ),
+            Self::SegmentTooLarge {
+                segment_size,
+                align,
+                offset_bits,
+            } => write!(
+                f,
+                "segment_size ({segment_size}) needs {offset_bits} offset bits at \
+                 align_bytes ({align}), leaving none for segment ids; \
+                 reduce segment_size or raise align_bytes"
+            ),
+            Self::TooManySegments { requested, max } => write!(
+                f,
+                "pool needs {requested} segments but the layout addresses at most \
+                 {max}; reduce heap_size, raise segment_size, or raise align_bytes"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
+impl From<LayoutError> for std::io::Error {
+    fn from(e: LayoutError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
+    }
+}
+
+/// How one pool splits the 44 location bits.
+///
+/// Small and `Copy`: two shifts is all that is stored, everything else derives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocationLayout {
+    /// `log2(align_bytes)`.
+    align_shift: u8,
+    /// Width of the offset field.
+    offset_bits: u8,
+}
+
+impl LocationLayout {
+    /// Position of the 2-bit `pool_id`, identical for every pool.
+    pub const POOL_SHIFT: u32 = 42;
+
+    /// Build the layout for a pool.
+    pub fn new(segment_size: usize, align_bytes: usize) -> Result<Self, LayoutError> {
+        if !align_bytes.is_power_of_two() {
+            return Err(LayoutError::AlignNotPowerOfTwo { align: align_bytes });
+        }
+        if align_bytes < 8 {
+            return Err(LayoutError::AlignTooSmall { align: align_bytes });
+        }
+        if align_bytes > segment_size {
+            return Err(LayoutError::AlignExceedsSegment {
+                align: align_bytes,
+                segment_size,
+            });
+        }
+
+        // Offset units needed to address the segment. `segment_size` need not be
+        // a power of two, so round the unit count up before taking its width.
+        let units = segment_size.div_ceil(align_bytes);
+        let offset_bits = units.next_power_of_two().trailing_zeros();
+
+        if offset_bits + TAG_BITS >= PAYLOAD_BITS {
+            return Err(LayoutError::SegmentTooLarge {
+                segment_size,
+                align: align_bytes,
+                offset_bits,
+            });
+        }
+
+        Ok(Self {
+            align_shift: align_bytes.trailing_zeros() as u8,
+            offset_bits: offset_bits as u8,
+        })
+    }
+
+    /// Width of the offset field.
+    #[inline(always)]
+    pub fn offset_bits(&self) -> u32 {
+        self.offset_bits as u32
+    }
+
+    /// Width of the segment id field.
+    #[inline(always)]
+    pub fn seg_bits(&self) -> u32 {
+        PAYLOAD_BITS - TAG_BITS - self.offset_bits as u32
+    }
+
+    /// Alignment factor in bytes.
+    #[inline(always)]
+    pub fn align_bytes(&self) -> u32 {
+        1 << self.align_shift
+    }
+
+    /// Highest issuable segment id.
+    ///
+    /// One below the field maximum: leaving the top id unissued is what keeps
+    /// `Location::GHOST` (all 44 bits set) unaliasable by construction.
+    #[inline(always)]
+    pub fn max_segments(&self) -> u32 {
+        (1u32 << self.seg_bits()) - 1
+    }
+
+    /// Reject a pool that has more segments than this layout can address.
+    pub fn validate_segment_count(&self, count: usize) -> Result<(), LayoutError> {
+        if count > self.max_segments() as usize {
+            return Err(LayoutError::TooManySegments {
+                requested: count,
+                max: self.max_segments(),
+            });
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn seg_shift(&self) -> u32 {
+        self.offset_bits as u32 + TAG_BITS
+    }
+
+    /// Pack the four fields into raw location bits.
+    #[inline(always)]
+    pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
+        debug_assert!(pool_id <= 3, "pool_id must be 0-3");
+        debug_assert!(
+            segment_id <= self.max_segments(),
+            "segment_id exceeds this layout"
+        );
+        debug_assert!(
+            offset.is_multiple_of(self.align_bytes()),
+            "offset must be {}-byte aligned",
+            self.align_bytes()
+        );
+
+        ((pool_id as u64) << Self::POOL_SHIFT)
+            | ((segment_id as u64) << self.seg_shift())
+            | (((incarnation & TAG_MASK) as u64) << self.offset_bits as u32)
+            | ((offset >> self.align_shift) as u64)
+    }
+
+    /// Extract `pool_id`. Layout-independent by design.
+    #[inline(always)]
+    pub fn pool_id(&self, raw: u64) -> u8 {
+        ((raw >> Self::POOL_SHIFT) & 0b11) as u8
+    }
+
+    #[inline(always)]
+    pub fn segment_id(&self, raw: u64) -> u32 {
+        ((raw >> self.seg_shift()) & ((1 << self.seg_bits()) - 1)) as u32
+    }
+
+    #[inline(always)]
+    pub fn incarnation(&self, raw: u64) -> u8 {
+        ((raw >> self.offset_bits as u32) as u8) & TAG_MASK
+    }
+
+    #[inline(always)]
+    pub fn offset(&self, raw: u64) -> u32 {
+        ((raw & ((1u64 << self.offset_bits as u32) - 1)) as u32) << self.align_shift
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p cache-core --lib location_layout`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cache/core/src/location_layout.rs cache/core/src/lib.rs
+git commit -m "feat(cache-core): add per-pool LocationLayout
+
+Derives the offset field width from segment_size/align_bytes and gives a
+fixed 6 bits to the incarnation tag. Capacity per pool is invariant under
+segment_size and depends only on the alignment factor -- pinned by
+capacity_is_invariant_under_segment_size, since that claim is what
+justifies coarsening disk alignment."
+```
+
+---
+
+### Task 2: `Metadata` carries the incarnation
+
+Adding a field to `Metadata` deliberately breaks every struct-literal site at compile time, so the compiler enumerates the places that must decide whether to preserve or bump. Do not add a `Default`.
+
+**Files:**
+- Modify: `cache/core/src/state.rs:186-260`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `cache/core/src/state.rs`:
+
+```rust
+    #[test]
+    fn test_metadata_incarnation_roundtrip() {
+        for incarnation in 0u8..64 {
+            let meta = Metadata {
+                next: 123,
+                prev: 456,
+                state: State::Live,
+                incarnation,
+            };
+            let unpacked = Metadata::unpack(meta.pack());
+            assert_eq!(unpacked.incarnation, incarnation);
+            assert_eq!(unpacked.next, 123);
+            assert_eq!(unpacked.prev, 456);
+            assert_eq!(unpacked.state, State::Live);
+        }
+    }
+
+    #[test]
+    fn test_metadata_incarnation_masks_to_six_bits() {
+        let meta = Metadata {
+            next: 0,
+            prev: 0,
+            state: State::Free,
+            incarnation: 0xFF,
+        };
+        assert_eq!(Metadata::unpack(meta.pack()).incarnation, 0x3F);
+    }
+
+    #[test]
+    fn test_metadata_incarnation_does_not_disturb_other_fields() {
+        // The tag lives in the byte above `state`; a full-width tag must not
+        // bleed into the state or chain pointers.
+        let meta = Metadata {
+            next: INVALID_SEGMENT_ID,
+            prev: INVALID_SEGMENT_ID,
+            state: State::AwaitingRelease,
+            incarnation: 0x3F,
+        };
+        let unpacked = Metadata::unpack(meta.pack());
+        assert_eq!(unpacked.state, State::AwaitingRelease);
+        assert_eq!(unpacked.next, INVALID_SEGMENT_ID);
+        assert_eq!(unpacked.prev, INVALID_SEGMENT_ID);
+    }
+
+    #[test]
+    fn test_metadata_bump_incarnation_wraps_at_six_bits() {
+        let meta = Metadata {
+            next: 0,
+            prev: 0,
+            state: State::Locked,
+            incarnation: 0x3F,
+        };
+        assert_eq!(meta.bump_incarnation().incarnation, 0);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib state::tests`
+Expected: FAIL to compile, `struct Metadata has no field named incarnation`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `cache/core/src/state.rs`, replace the `Metadata` doc comment, struct, and the `new`/`with_chain`/`pack`/`unpack` methods with:
+
+```rust
+/// Packed representation of segment metadata in a single AtomicU64.
+///
+/// Layout: `[2 unused][6 bits incarnation][8 bits state][24 prev][24 next]`
+///
+/// This packing allows atomic updates to state and chain pointers together,
+/// which is essential for lock-free chain operations.
+///
+/// # Why the incarnation lives here
+///
+/// The incarnation tag is the low 6 bits of a per-segment counter that rides
+/// inside every `Location` issued during that incarnation. It must be bumped
+/// *atomically with the state transition that ends the incarnation*. Keeping it
+/// in a separate atomic would leave a window where the segment is already
+/// `Free` but still carries the old counter, and a thread reserving inside that
+/// window would refill under the old tag -- exactly the aliasing the tag exists
+/// to prevent.
+///
+/// This is distinct from `Segment::generation()`, a 16-bit counter bumped on
+/// `Free -> Reserved` that feeds `CasToken`. The two answer different questions
+/// and have different bump sites on purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Metadata {
+    /// Next segment ID in the chain (24 bits, INVALID_SEGMENT_ID if none).
+    pub next: u32,
+    /// Previous segment ID in the chain (24 bits, INVALID_SEGMENT_ID if none).
+    pub prev: u32,
+    /// Current state of the segment.
+    pub state: State,
+    /// Incarnation tag (6 bits). See the struct docs.
+    pub incarnation: u8,
+}
+
+impl Metadata {
+    /// Bits of incarnation stored in the packed word.
+    const INCARNATION_BITS: u32 = 6;
+    const INCARNATION_MASK: u8 = (1 << Self::INCARNATION_BITS) - 1;
+    const INCARNATION_SHIFT: u32 = 56;
+
+    /// Create new metadata with the given state, no chain links, incarnation 0.
+    ///
+    /// Only correct at segment construction. Every *transition* must carry the
+    /// incarnation forward -- use `with_state` or `bump_incarnation`.
+    pub fn new(state: State) -> Self {
+        Self {
+            next: INVALID_SEGMENT_ID,
+            prev: INVALID_SEGMENT_ID,
+            state,
+            incarnation: 0,
+        }
+    }
+
+    /// Create metadata with state and chain pointers, incarnation 0.
+    ///
+    /// Only correct at segment construction; see `new`.
+    pub fn with_chain(state: State, next: Option<u32>, prev: Option<u32>) -> Self {
+        Self {
+            next: next.unwrap_or(INVALID_SEGMENT_ID),
+            prev: prev.unwrap_or(INVALID_SEGMENT_ID),
+            state,
+            incarnation: 0,
+        }
+    }
+
+    /// This metadata with a different state, preserving the incarnation.
+    ///
+    /// The correct helper for a transition that does not end an incarnation.
+    #[inline]
+    pub fn with_state(self, state: State) -> Self {
+        Self { state, ..self }
+    }
+
+    /// This metadata with the incarnation advanced by one, wrapping at 6 bits.
+    ///
+    /// Call this on exactly the transitions that end a *used* incarnation --
+    /// `Locked -> Free` and `AwaitingRelease -> Free`. See
+    /// `slice_segment.rs`'s bump-site test for why the set matters.
+    #[inline]
+    pub fn bump_incarnation(self) -> Self {
+        Self {
+            incarnation: self.incarnation.wrapping_add(1) & Self::INCARNATION_MASK,
+            ..self
+        }
+    }
+
+    /// Pack the metadata into a single u64 for atomic storage.
+    #[inline]
+    pub fn pack(self) -> u64 {
+        // Mask to ensure we only use 24 bits for IDs
+        let next_24 = (self.next & 0xFF_FFFF) as u64;
+        let prev_24 = (self.prev & 0xFF_FFFF) as u64;
+        let state_8 = self.state as u64;
+        let inc = ((self.incarnation & Self::INCARNATION_MASK) as u64) << Self::INCARNATION_SHIFT;
+
+        // Pack: [2 unused][6 incarnation][8 state][24 prev][24 next]
+        inc | (state_8 << 48) | (prev_24 << 24) | next_24
+    }
+
+    /// Unpack metadata from a u64.
+    #[inline]
+    pub fn unpack(packed: u64) -> Self {
+        let state_val = ((packed >> 48) & 0xFF) as u8;
+        let state = State::from_u8(state_val);
+
+        Self {
+            next: (packed & 0xFF_FFFF) as u32,
+            prev: ((packed >> 24) & 0xFF_FFFF) as u32,
+            state,
+            incarnation: ((packed >> Self::INCARNATION_SHIFT) as u8) & Self::INCARNATION_MASK,
+        }
+    }
+```
+
+Leave the rest of the `impl` (`next_id`, `prev_id`) unchanged.
+
+- [ ] **Step 4: Fix every struct-literal site the compiler now rejects**
+
+Run: `cargo build -p cache-core 2>&1 | grep -A2 "missing field"`
+
+Each site must preserve the incarnation rather than reset it. In
+`cache/core/src/state.rs`'s own test module (lines ~323, ~339, ~357) add
+`incarnation: 0`. For the six sites in `cache/core/src/slice_segment.rs`, one
+in `cache/core/src/item.rs:813`, and one in
+`cache/core/src/disk/disk_segment_meta.rs:414`, replace the struct literal with
+the `with_state` helper built from the metadata that site already loaded. For
+example at `slice_segment.rs:862` (`try_reserve`):
+
+```rust
+        // Preserve the incarnation: reserving does not end one.
+        let new_meta = current_meta
+            .with_state(State::Reserved)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+```
+
+Add the small helper this needs to `Metadata` in `cache/core/src/state.rs`:
+
+```rust
+    /// This metadata with different chain pointers, preserving everything else.
+    #[inline]
+    pub fn with_chain_ids(self, next: u32, prev: u32) -> Self {
+        Self { next, prev, ..self }
+    }
+```
+
+The one site that legitimately starts at zero is `SliceSegment::new`
+(`slice_segment.rs:159`), which constructs a brand-new segment: leave it as
+`Metadata::new(State::Free)`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p cache-core --lib state::tests`
+Expected: PASS, including the four new tests.
+
+Run: `cargo test -p cache-core --lib`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cache/core/src/state.rs cache/core/src/slice_segment.rs cache/core/src/item.rs cache/core/src/disk/disk_segment_meta.rs
+git commit -m "feat(cache-core): carry a 6-bit incarnation in Metadata
+
+Puts the tag in the packed word's unused byte so bumping it is atomic with
+the state transition. Adding the field deliberately breaks every struct
+literal, forcing each transition site to say whether it preserves or bumps;
+with_state and with_chain_ids are the preserving forms."
+```
+
+---
+
+### Task 3: Bump sites, and a transition table that pins them
+
+**Files:**
+- Modify: `cache/core/src/segment.rs` (trait method)
+- Modify: `cache/core/src/slice_segment.rs:888-921` (`try_release`), `:1363-1400` (`release_condemned`), `:1334-1353` (`force_free`)
+- Modify: `cache/core/src/disk/file_segment.rs`, `cache/core/src/disk/disk_segment_meta.rs` (trait impls)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `cache/core/src/slice_segment.rs`:
+
+```rust
+    /// The incarnation advances on exactly the transitions that end a *used*
+    /// incarnation, and on no others.
+    ///
+    /// This is not a tidiness test. `MemoryPool::release_segment`,
+    /// `MemoryPool::release` and `FilePool::release` all return never-used
+    /// segments through `try_release`. If the bump fired there too, a burst of
+    /// reserve/release with no item lifecycle at all would drain the 6-bit
+    /// tag's collision hardness for free. A future change moving the bump would
+    /// look locally harmless and break exactly that.
+    #[test]
+    fn test_incarnation_bumps_on_exactly_the_used_incarnation_transitions() {
+        // Reserved -> Free: reserved but never used. Must NOT bump.
+        let (segment, _mem) = make_segment(4096);
+        assert_eq!(segment.incarnation(), 0);
+        assert!(segment.try_reserve());
+        assert_eq!(segment.incarnation(), 0, "try_reserve must not bump");
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            0,
+            "Reserved -> Free is a never-used release and must not bump"
+        );
+
+        // Locked -> Free: drained and cleared. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            1,
+            "Locked -> Free ends a used incarnation and must bump"
+        );
+
+        // AwaitingRelease -> Free: condemned. Must bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::AwaitingRelease, None, None));
+        assert!(segment.release_condemned());
+        assert_eq!(
+            segment.incarnation(),
+            2,
+            "AwaitingRelease -> Free ends a used incarnation and must bump"
+        );
+
+        // Linking -> Free: lost a chain-extension election. Must NOT bump.
+        assert!(segment.try_reserve());
+        assert!(segment.cas_metadata(State::Reserved, State::Linking, None, None));
+        assert!(segment.try_release());
+        assert_eq!(
+            segment.incarnation(),
+            2,
+            "Linking -> Free is a lost election and must not bump"
+        );
+    }
+
+    #[test]
+    fn test_incarnation_wraps_at_64_and_stays_in_range() {
+        let (segment, _mem) = make_segment(4096);
+        for _ in 0..70 {
+            assert!(segment.try_reserve());
+            assert!(segment.cas_metadata(State::Reserved, State::Locked, None, None));
+            assert!(segment.try_release());
+            assert!(segment.incarnation() < 64, "tag must stay within 6 bits");
+        }
+        assert_eq!(segment.incarnation(), 70 % 64);
+    }
+
+    #[test]
+    fn test_force_free_bumps_the_incarnation() {
+        // Flush recycles every segment. Locations issued before the flush must
+        // not resolve afterwards, so this ends an incarnation like any other.
+        let (segment, _mem) = make_segment(4096);
+        assert!(segment.try_reserve());
+        let before = segment.incarnation();
+        segment.force_free();
+        assert_eq!(segment.incarnation(), (before + 1) & 0x3F);
+        assert_eq!(segment.state(), State::Free);
+    }
+```
+
+If a `make_segment(capacity) -> (SliceSegment<'static>, Vec<u8>)` helper does not
+already exist in that test module, reuse whatever the neighbouring tests use to
+build a segment (`test_segment_generation` at `slice_segment.rs:1823` shows the
+established pattern) and adapt these tests to it rather than inventing a helper.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib slice_segment::tests::test_incarnation`
+Expected: FAIL to compile, `no method named incarnation found`.
+
+- [ ] **Step 3: Add the trait method**
+
+In `cache/core/src/segment.rs`, in `pub trait Segment`, immediately after
+`fn increment_generation(&self);`:
+
+```rust
+    /// Get the incarnation tag (6 bits) currently stamped on this segment.
+    ///
+    /// This is the value carried inside every `Location` issued while the
+    /// segment holds it. A location whose tag differs names a previous
+    /// incarnation and must not be resolved.
+    ///
+    /// Distinct from `generation()`: that is a 16-bit counter bumped on
+    /// `Free -> Reserved` and consumed by `CasToken`. This one is 6 bits and
+    /// bumps only on the transitions that end a *used* incarnation.
+    fn incarnation(&self) -> u8;
+```
+
+- [ ] **Step 4: Write the implementation**
+
+In `cache/core/src/slice_segment.rs`, in `impl Segment for SliceSegment<'_>`,
+next to `fn generation`:
+
+```rust
+    #[inline(always)]
+    fn incarnation(&self) -> u8 {
+        Metadata::unpack(self.metadata.load(Ordering::Acquire)).incarnation
+    }
+```
+
+Replace the body of `try_release` (`slice_segment.rs:888`) with:
+
+```rust
+    fn try_release(&self) -> bool {
+        loop {
+            let current_packed = self.metadata.load(Ordering::Acquire);
+            let current_meta = Metadata::unpack(current_packed);
+
+            // `Locked` is the drained-and-cleared path: it ends a used
+            // incarnation, so the tag advances. `Reserved` and `Linking` are
+            // never-used releases (a lost chain-extension election, or
+            // `MemoryPool::release_segment` handing back an unused segment) and
+            // must not advance it -- a 6-bit tag cannot afford bumps that are
+            // decoupled from segment lifecycles.
+            let ends_incarnation = match current_meta.state {
+                State::Locked => true,
+                State::Reserved | State::Linking => false,
+                State::Free => return false,
+                _ => {
+                    panic!(
+                        "Attempt to release segment {} in invalid state {:?}",
+                        self.id, current_meta.state
+                    );
+                }
+            };
+
+            let new_meta = current_meta
+                .with_state(State::Free)
+                .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID);
+            let new_meta = if ends_incarnation {
+                new_meta.bump_incarnation()
+            } else {
+                new_meta
+            };
+
+            match self.metadata.compare_exchange(
+                current_packed,
+                new_meta.pack(),
+                Ordering::Release,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.merge_count.store(0, Ordering::Relaxed);
+                    return true;
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+```
+
+In `SliceSegment::release_condemned` (`slice_segment.rs:1363`), replace the
+`new_meta` construction with:
+
+```rust
+        // AwaitingRelease -> Free ends a used incarnation: the tag advances in
+        // the same CAS that publishes Free, so no thread can reserve this
+        // segment and refill it under the old tag.
+        let new_meta = current_meta
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
+```
+
+In `SliceSegment::force_free` (`slice_segment.rs:1334`), replace the `free_meta`
+construction and store with:
+
+```rust
+        // Flush recycles every segment, so locations issued before it must stop
+        // resolving: this ends an incarnation like any other.
+        let current_meta = Metadata::unpack(self.metadata.load(Ordering::Acquire));
+        let free_meta = current_meta
+            .with_state(State::Free)
+            .with_chain_ids(INVALID_SEGMENT_ID, INVALID_SEGMENT_ID)
+            .bump_incarnation();
+        self.metadata.store(free_meta.pack(), Ordering::Release);
+```
+
+Add the same `incarnation()` implementation to the `Segment` impls in
+`cache/core/src/disk/file_segment.rs` (delegate: `self.inner.incarnation()`) and
+`cache/core/src/disk/disk_segment_meta.rs` (unpack its own metadata word, same
+body as `SliceSegment`). Apply the identical `try_release` / `release_condemned`
+/ `force_free` treatment to `disk_segment_meta.rs` wherever those transitions
+exist there.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p cache-core --lib slice_segment::tests`
+Expected: PASS, including the three new tests.
+
+- [ ] **Step 6: Prove the transition table red**
+
+Temporarily change the `State::Reserved | State::Linking => false` arm to
+`=> true`, then run:
+
+Run: `cargo test -p cache-core --lib test_incarnation_bumps_on_exactly`
+Expected: FAIL with `Reserved -> Free is a never-used release and must not bump`.
+
+Revert the change and re-run; expected PASS. Record the observed failure text in
+the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cache/core/src/segment.rs cache/core/src/slice_segment.rs cache/core/src/disk/
+git commit -m "feat(cache-core): bump the incarnation on used-incarnation ends only
+
+Locked -> Free and AwaitingRelease -> Free advance the tag; force_free does
+too, since flush recycles everything. Reserved|Linking -> Free does not:
+release_segment and lost chain elections would otherwise drain a 6-bit tag
+at a rate decoupled from segment lifecycles.
+
+Pinned as a full transition table. Proven red by flipping the never-used arm
+to bump: 'Reserved -> Free is a never-used release and must not bump'."
+```
+
+---
+
+### Task 4: `ItemLocation` becomes layout-aware
+
+Accessors take the layout rather than `ItemLocation` storing one: the type stays
+8 bytes on a hot path that passes it by value, and every call site that decodes
+already holds the pool (they all guard on `location.pool_id() != self.pool.pool_id()`
+first).
+
+**Files:**
+- Modify: `cache/core/src/item_location.rs:26-130`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the existing bit-packing tests in `cache/core/src/item_location.rs`'s
+`tests` module with:
+
+```rust
+    fn mem_layout() -> LocationLayout {
+        LocationLayout::new(1024 * 1024, 8).unwrap()
+    }
+
+    #[test]
+    fn test_new_and_accessors() {
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 2, 1000, 5, 4096);
+        assert_eq!(loc.pool_id(), 2);
+        assert_eq!(loc.segment_id(&l), 1000);
+        assert_eq!(loc.incarnation(&l), 5);
+        assert_eq!(loc.offset(&l), 4096);
+        assert!(!loc.is_ghost());
+    }
+
+    #[test]
+    fn test_unpack_matches_individual_accessors() {
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 1, 12345, 63, 8192);
+        assert_eq!(
+            loc.unpack(&l),
+            (
+                loc.pool_id(),
+                loc.segment_id(&l),
+                loc.incarnation(&l),
+                loc.offset(&l)
+            )
+        );
+    }
+
+    #[test]
+    fn test_incarnation_survives_a_location_roundtrip() {
+        let l = mem_layout();
+        let loc = ItemLocation::new(&l, 1, 12345, 42, 8192);
+        let back = ItemLocation::from_location(loc.to_location());
+        assert_eq!(back.incarnation(&l), 42);
+        assert_eq!(back.segment_id(&l), 12345);
+        assert_eq!(back.offset(&l), 8192);
+    }
+
+    #[test]
+    fn test_pool_id_decodes_without_the_layout() {
+        // pool_id must be readable before the layout is known -- that is what
+        // lets pools with different segment sizes share one location space.
+        let mem = LocationLayout::new(1024 * 1024, 8).unwrap();
+        let disk = LocationLayout::new(8 * 1024 * 1024, 512).unwrap();
+        assert_eq!(ItemLocation::new(&mem, 1, 5, 0, 0).pool_id(), 1);
+        assert_eq!(ItemLocation::new(&disk, 3, 5, 0, 0).pool_id(), 3);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib item_location`
+Expected: FAIL to compile, `this function takes 3 arguments but 5 arguments were supplied`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `cache/core/src/item_location.rs`, replace the `ItemLocation` doc comment and
+the whole `impl ItemLocation` block (lines ~11-130) with:
+
+```rust
+use crate::hashtable::KeyVerifier;
+use crate::location::Location;
+use crate::location_layout::LocationLayout;
+use crate::segment::SegmentKeyVerify;
+use std::fmt;
+
+/// Segment-specific location interpretation.
+///
+/// Interprets the 44-bit `Location` as `(pool_id, segment_id, incarnation,
+/// offset)`. Only `pool_id` sits at a fixed position; the rest of the split is
+/// per-pool and described by that pool's [`LocationLayout`], which is why the
+/// accessors take one.
+///
+/// ```text
+/// +--------+------------+-------------+--------------+
+/// | 43..42 |    ...     |     ...     |     ...      |
+/// |  pool  |  seg_id    | incarnation | offset/align |
+/// | 2 bits |  variable  |   6 bits    |   variable   |
+/// +--------+------------+-------------+--------------+
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ItemLocation(Location);
+
+impl ItemLocation {
+    /// Create a new item location from segment coordinates.
+    ///
+    /// `incarnation` must be the tag the segment carries *at the moment the
+    /// item is written into it* -- read it from the same segment reference the
+    /// append used, not from a later lookup.
+    #[inline]
+    pub fn new(
+        layout: &LocationLayout,
+        pool_id: u8,
+        segment_id: u32,
+        incarnation: u8,
+        offset: u32,
+    ) -> Self {
+        Self(Location::new(
+            layout.pack(pool_id, segment_id, incarnation, offset),
+        ))
+    }
+
+    /// Create from an opaque `Location`.
+    #[inline]
+    pub fn from_location(location: Location) -> Self {
+        Self(location)
+    }
+
+    /// Convert to an opaque `Location`.
+    #[inline]
+    pub fn to_location(self) -> Location {
+        self.0
+    }
+
+    /// Get the pool ID (0-3).
+    ///
+    /// Layout-independent: this is what a decoder reads first, to find out
+    /// which layout decodes the rest.
+    #[inline]
+    pub fn pool_id(&self) -> u8 {
+        ((self.0.as_raw() >> LocationLayout::POOL_SHIFT) & 0b11) as u8
+    }
+
+    /// Get the segment ID within the pool.
+    #[inline]
+    pub fn segment_id(&self, layout: &LocationLayout) -> u32 {
+        layout.segment_id(self.0.as_raw())
+    }
+
+    /// Get the incarnation tag this location was issued under.
+    #[inline]
+    pub fn incarnation(&self, layout: &LocationLayout) -> u8 {
+        layout.incarnation(self.0.as_raw())
+    }
+
+    /// Get the byte offset within the segment.
+    #[inline]
+    pub fn offset(&self, layout: &LocationLayout) -> u32 {
+        layout.offset(self.0.as_raw())
+    }
+
+    /// Unpack all fields in a single pass.
+    ///
+    /// Returns `(pool_id, segment_id, incarnation, offset)`. Cheaper than the
+    /// individual accessors when more than one field is needed, since the raw
+    /// bits are loaded once.
+    #[inline]
+    pub fn unpack(&self, layout: &LocationLayout) -> (u8, u32, u8, u32) {
+        let raw = self.0.as_raw();
+        (
+            ((raw >> LocationLayout::POOL_SHIFT) & 0b11) as u8,
+            layout.segment_id(raw),
+            layout.incarnation(raw),
+            layout.offset(raw),
+        )
+    }
+
+    /// Check if this location represents a ghost entry.
+    #[inline]
+    pub fn is_ghost(&self) -> bool {
+        self.0.is_ghost()
+    }
+}
+```
+
+Delete the now-stale `POOL_SHIFT`/`SEG_SHIFT`/`OFFSET_MASK`/`MAX_SEGMENT_ID`/
+`MAX_OFFSET`/`OFFSET_ALIGN` constants. `Debug` and `Display` can no longer
+decode without a layout: reduce both to printing `GHOST` or the raw value:
+
+```rust
+impl fmt::Debug for ItemLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_ghost() {
+            write!(f, "ItemLocation::GHOST")
+        } else {
+            // Decoding requires the owning pool's layout, which a Debug impl
+            // does not have. pool_id is the one field at a fixed position.
+            f.debug_struct("ItemLocation")
+                .field("pool_id", &self.pool_id())
+                .field("raw", &format_args!("0x{:011X}", self.0.as_raw()))
+                .finish()
+        }
+    }
+}
+
+impl fmt::Display for ItemLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_ghost() {
+            write!(f, "GHOST")
+        } else {
+            write!(f, "pool{}:0x{:011X}", self.pool_id(), self.0.as_raw())
+        }
+    }
+}
+```
+
+Update `test_display` and `test_debug` in the same module to match, and delete
+`test_max_values`, `test_offset_alignment`, `test_invalid_pool_id`,
+`test_unaligned_offset` and `test_bit_packing` -- Task 1's property test now
+covers all of that against the layout, which is where the invariants live.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p cache-core --lib item_location`
+Expected: PASS. Note that `cache-core` as a whole will not build yet -- Task 5
+and Task 6 fix the call sites.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cache/core/src/item_location.rs
+git commit -m "feat(cache-core): make ItemLocation layout-aware
+
+Accessors take the layout rather than the type storing one, so ItemLocation
+stays 8 bytes on a path that passes it by value. Every decoding call site
+already holds its pool. pool_id keeps a fixed position so it can be read
+before the layout is known."
+```
+
+---
+
+### Task 5: Pools own a layout
+
+**Files:**
+- Modify: `cache/core/src/pool.rs` (add `RamPool::layout()`)
+- Modify: `cache/core/src/memory_pool.rs:340-505`
+- Modify: `cache/core/src/disk/file_pool.rs`, `cache/core/src/disk/io_uring_pool.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `cache/core/src/memory_pool.rs`:
+
+```rust
+    #[test]
+    fn test_pool_exposes_a_layout_matching_its_segment_size() {
+        let pool = MemoryPoolBuilder::new(0)
+            .heap_size(4 * 1024 * 1024)
+            .segment_size(1024 * 1024)
+            .build()
+            .unwrap();
+        assert_eq!(pool.layout().offset_bits(), 17);
+        assert_eq!(pool.layout().align_bytes(), 8);
+    }
+
+    #[test]
+    fn test_pool_rejects_more_segments_than_the_layout_addresses() {
+        // 128 MB segments leave 12 segment bits (4095 issuable ids). Ask for
+        // more and construction must fail by name rather than alias silently.
+        let err = MemoryPoolBuilder::new(0)
+            .heap_size(5000 * 128 * 1024 * 1024)
+            .segment_size(128 * 1024 * 1024)
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("addresses at most"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pool_rejects_alignment_below_item_alignment() {
+        let err = MemoryPoolBuilder::new(0)
+            .heap_size(4 * 1024 * 1024)
+            .segment_size(1024 * 1024)
+            .align_bytes(4)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("at least 8"), "unexpected: {err}");
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib memory_pool::tests::test_pool_`
+Expected: FAIL to compile, `no method named layout`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `cache/core/src/pool.rs`, add to `pub trait RamPool`, after `fn segment_size`:
+
+```rust
+    /// Get this pool's location layout.
+    ///
+    /// Locations naming this pool must be packed and unpacked with it; pools
+    /// with different segment sizes or alignment factors have different splits.
+    fn layout(&self) -> &crate::location_layout::LocationLayout;
+```
+
+In `cache/core/src/memory_pool.rs`, add `align_bytes: usize` to both
+`MemoryPool` and `MemoryPoolBuilder`, defaulting the builder's to `8` alongside
+`segment_size: 1024 * 1024`, plus a `layout: LocationLayout` field on
+`MemoryPool` and this builder method next to `segment_size`:
+
+```rust
+    /// Set the offset alignment factor in bytes.
+    ///
+    /// Locations store `offset / align_bytes`, so this is the only lever on a
+    /// pool's addressable capacity: `2^36 * align_bytes`. Memory pools default
+    /// to 8, matching the item alignment, because a minimal item is 8 bytes and
+    /// coarser alignment would round small items up. Must be a power of two, at
+    /// least 8, and no larger than `segment_size`.
+    pub fn align_bytes(mut self, align: usize) -> Self {
+        self.align_bytes = align;
+        self
+    }
+```
+
+In `MemoryPoolBuilder::build`, immediately after the existing `num_segments == 0`
+check:
+
+```rust
+        let layout = LocationLayout::new(self.segment_size, self.align_bytes)?;
+        layout.validate_segment_count(num_segments)?;
+```
+
+`LayoutError` converts into `std::io::Error` via the `From` impl from Task 1, so
+`?` works against the existing `Result<MemoryPool, std::io::Error>`. Add
+`layout` and `align_bytes` to the returned `MemoryPool { .. }` literal, and
+implement the trait method:
+
+```rust
+    fn layout(&self) -> &LocationLayout {
+        &self.layout
+    }
+```
+
+Apply the same three changes to `FilePool` and `IoUringPool`, with two
+differences: their builders default `align_bytes` to **512**, and their `build`
+adds one further check after the layout is built:
+
+```rust
+        // Aligning coarser than the I/O block buys nothing on the read path:
+        // `item_disk_range` already rounds reads down to a block boundary.
+        if layout.align_bytes() as usize > self.block_size {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "align_bytes ({}) must not exceed block_size ({})",
+                    layout.align_bytes(),
+                    self.block_size
+                ),
+            ));
+        }
+```
+
+Document the 512 default on the disk builders' `align_bytes` method:
+
+```rust
+    /// Set the offset alignment factor in bytes.
+    ///
+    /// Disk pools default to 512 (a sector) rather than 8. The justification is
+    /// the read path, not capacity: `item_disk_range` already rounds reads down
+    /// to a `block_size` boundary, so an item straddling a block costs an extra
+    /// block read today. Sector alignment cuts that, wastes 256 bytes per item
+    /// on average, and yields 32 TiB per pool as a side effect.
+    pub fn align_bytes(mut self, align: usize) -> Self {
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p cache-core --lib memory_pool::tests`
+Expected: PASS, including the three new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cache/core/src/pool.rs cache/core/src/memory_pool.rs cache/core/src/disk/file_pool.rs cache/core/src/disk/io_uring_pool.rs
+git commit -m "feat(cache-core): pools own a LocationLayout and validate capacity
+
+Construction now fails by name when a config needs more segments than the
+layout addresses, instead of aliasing them silently. align_bytes is a per-pool
+knob defaulting to 8 for memory and 512 for disk."
+```
+
+---
+
+### Task 6: Stamp the tag at every publish site
+
+This task is compiler-driven: Tasks 4 and 5 make every stale call site a build
+error. Work through them until `cargo build -p cache-core` is clean.
+
+**Files:**
+- Modify: `cache/core/src/layer/fifo_layer.rs` (7 sites), `cache/core/src/layer/ttl_layer.rs` (~10 sites), `cache/core/src/disk/disk_layer.rs` (4 sites)
+
+- [ ] **Step 1: List the sites**
+
+Run: `cargo build -p cache-core 2>&1 | grep -E "^error" | sort | uniq -c`
+
+- [ ] **Step 2: Fix each publish site**
+
+Every site already holds the `segment` it just appended to. The tag must come
+from *that* reference, so the location cannot be stamped with an incarnation the
+item was not written into. For example at `fifo_layer.rs:585`:
+
+```rust
+                if let Some(offset) = segment.append_item_with_ttl(key, value, optional, expire_at)
+                {
+                    return Ok(ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    ));
+                }
+```
+
+and at `fifo_layer.rs:723`:
+
+```rust
+                if let Some((offset, item_size, value_ptr)) =
+                    segment.begin_append_with_ttl(key, value_len, optional, expire_at)
+                {
+                    let location = ItemLocation::new(
+                        self.pool.layout(),
+                        self.pool.pool_id(),
+                        segment_id,
+                        segment.incarnation(),
+                        offset,
+                    );
+                    return Ok((location, value_ptr, item_size));
+                }
+```
+
+- [ ] **Step 3: Fix each decode site**
+
+Calls like `location.offset()` and `location.segment_id()` now need the layout.
+Every one of these sits after a `location.pool_id() != self.pool.pool_id()`
+guard, so `self.pool.layout()` is the correct layout. Prefer `unpack` where two
+or more fields are read:
+
+```rust
+        let (_, segment_id, incarnation, offset) = location.unpack(self.pool.layout());
+```
+
+- [ ] **Step 4: Build clean**
+
+Run: `cargo build -p cache-core`
+Expected: no errors.
+
+Run: `cargo test -p cache-core`
+Expected: PASS. Tests that construct locations by hand (for example
+`fifo_layer.rs:1051`'s `wrong_location`) need the layout and an incarnation
+argument; pass the real segment's incarnation so those tests keep testing what
+they were testing (a wrong *pool*), not accidentally testing the new tag.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cache/core/src/layer/ cache/core/src/disk/
+git commit -m "feat(cache-core): stamp the incarnation when publishing a location
+
+Each publish site reads the tag from the same segment reference the append
+used, so a location can never carry an incarnation its item was not written
+into."
+```
+
+---
+
+### Task 7: The check, and a test that recycles
+
+**Files:**
+- Modify: `cache/core/src/cache.rs:1559-1670` (`CacheKeyVerifier`)
+- Modify: `cache/core/src/item_location.rs` (`SinglePoolVerifier`, `MultiPoolVerifier`)
+- Test: `cache/core/src/cache.rs` tests module
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `cache/core/src/cache.rs`:
+
+```rust
+    /// A location held across a segment recycle must stop resolving.
+    ///
+    /// Without the tag this is the crucible#88 hazard: segments are append-only
+    /// from a fixed start, so with uniform item sizes the n-th item of every
+    /// incarnation lands at the same offset, and a stale location silently
+    /// resolves to a different item at the same address.
+    #[test]
+    fn test_stale_location_is_rejected_after_recycle() {
+        let cache = build_small_test_cache();
+        let verifier = cache.key_verifier();
+
+        cache.set(b"key", b"value", None, Duration::from_secs(60)).unwrap();
+        let stale = cache.locate(b"key").expect("key should be present");
+
+        // Sanity: it resolves now, so a later rejection means something.
+        assert!(
+            verifier.verify(b"key", stale.to_location(), false),
+            "location must resolve before the recycle"
+        );
+
+        let mut rejections = 0usize;
+        for _ in 0..64 {
+            cache.flush();
+            cache.set(b"key", b"value", None, Duration::from_secs(60)).unwrap();
+            if !verifier.verify(b"key", stale.to_location(), false) {
+                rejections += 1;
+            }
+        }
+
+        // Non-zero guards against vacuity: if the loop never recycled the
+        // segment the stale location names, this test proves nothing.
+        assert!(rejections > 0, "no recycle was observed; test is vacuous");
+        assert_eq!(
+            rejections, 64,
+            "every post-recycle resolution of a stale location must be rejected"
+        );
+    }
+```
+
+If `build_small_test_cache`, `locate` or `key_verifier` do not exist under those
+names, use the equivalents the neighbouring `cache.rs` tests already use rather
+than adding new public API; the shape of the test is what matters.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
+Expected: FAIL at the `rejections == 64` assertion (the stale location still
+resolves), or at compile time if a helper name differs.
+
+- [ ] **Step 3: Write the implementation**
+
+In `cache/core/src/cache.rs`, add layouts to the verifier:
+
+```rust
+struct CacheKeyVerifier<'a> {
+    /// Direct pool references with is_per_item_ttl flag, indexed by pool_id.
+    pools: [Option<(PoolRef<'a>, bool)>; 4],
+    /// Each pool's location layout, indexed by pool_id. Decoding a location
+    /// requires the layout of the pool it names, which is why `pool_id` sits at
+    /// a fixed position.
+    layouts: [Option<LocationLayout>; 4],
+}
+```
+
+Populate `layouts` wherever `pools` is populated, from each pool's `layout()`.
+
+Rewrite the body of `verify`:
+
+```rust
+    #[inline(always)]
+    fn verify(&self, key: &[u8], location: Location, allow_deleted: bool) -> bool {
+        let item_loc = ItemLocation::from_location(location);
+        let pool_id = item_loc.pool_id();
+
+        // SAFETY: pool_id is 2 bits, and both arrays are [_; 4].
+        let Some((pool_ref, _is_per_item_ttl)) =
+            (unsafe { *self.pools.get_unchecked(pool_id as usize) })
+        else {
+            return false;
+        };
+        let Some(layout) = (unsafe { *self.layouts.get_unchecked(pool_id as usize) }) else {
+            return false;
+        };
+
+        let (_, segment_id, incarnation, offset) = item_loc.unpack(&layout);
+
+        match pool_ref {
+            PoolRef::Memory(pool) => {
+                let Some(segment) = pool.get(segment_id) else {
+                    return false;
+                };
+                // Before any item bytes are touched: a location naming a
+                // previous incarnation of this segment is not ours to resolve.
+                if segment.incarnation() != incarnation {
+                    return false;
+                }
+                segment.verify_key_at_offset(offset, key, allow_deleted)
+            }
+            PoolRef::Disk(pool) => {
+                let Some(segment) = pool.get(segment_id) else {
+                    return false;
+                };
+                if segment.incarnation() != incarnation {
+                    return false;
+                }
+                segment.verify_key_at_offset(offset, key, allow_deleted)
+            }
+            PoolRef::IoUring(pool) => {
+                let Some(meta) = pool.get_meta(segment_id) else {
+                    return false;
+                };
+                if meta.incarnation() != incarnation {
+                    return false;
+                }
+                meta.verify_key_at_offset(offset, key, allow_deleted)
+            }
+        }
+    }
+```
+
+Apply the same decode-and-check to `prefetch` in the same impl (it currently
+calls `unpack()` with no layout), and to `SinglePoolVerifier::verify` and
+`MultiPoolVerifier::verify` in `cache/core/src/item_location.rs`. Both of those
+need a `LocationLayout` field, supplied at construction:
+
+```rust
+pub struct SinglePoolVerifier<'a, S> {
+    segments: &'a [S],
+    layout: LocationLayout,
+}
+
+impl<'a, S> SinglePoolVerifier<'a, S> {
+    /// Create a new single-pool verifier.
+    pub fn new(segments: &'a [S], layout: LocationLayout) -> Self {
+        Self { segments, layout }
+    }
+}
+```
+
+and in its `verify`, after resolving the segment and before
+`verify_key_at_offset`:
+
+```rust
+        if segment.incarnation() != item_loc.incarnation(&self.layout) {
+            return false;
+        }
+```
+
+`MultiPoolVerifier::with_pool` gains a `layout` parameter and stores
+`[Option<(&'a [S], LocationLayout)>; 4]`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
+Expected: PASS.
+
+Run: `cargo test -p cache-core`
+Expected: PASS.
+
+- [ ] **Step 5: Prove the check red**
+
+Temporarily change the memory arm's guard to `if false {`, then run:
+
+Run: `cargo test -p cache-core --lib test_stale_location_is_rejected_after_recycle`
+Expected: FAIL on the `rejections == 64` assertion.
+
+Then temporarily replace the loop body's `cache.flush()` with a no-op and
+confirm the test fails on `no recycle was observed; test is vacuous` -- this is
+the vacuity trap, and it must fire. Revert both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cache/core/src/cache.rs cache/core/src/item_location.rs
+git commit -m "fix(cache-core): reject stale-incarnation locations before reading bytes
+
+Closes the false positive in the crucible#88 family: a location held across
+a segment recycle no longer resolves to whatever now occupies that offset.
+
+Proven red two ways -- neutering the guard fails the rejection assertion,
+and removing the recycle fails the vacuity assertion."
+```
+
+---
+
+### Task 8: Loom model
+
+`cache/core/src/loom_oracle.rs:42` currently records that the oracle owns all 44
+bits with no generation riding in them. That is exactly what blocked the cache-rs
+model port, and it is now false.
+
+**Files:**
+- Modify: `cache/core/src/loom_oracle.rs`
+
+- [ ] **Step 1: Write the failing model**
+
+Add to `cache/core/src/loom_oracle.rs`, and update the module comment at line 42
+to say the oracle now models incarnations:
+
+```rust
+    /// A reader holding a location races the recycle of the segment it names.
+    ///
+    /// Without the incarnation tag the reader can observe the *new* occupant
+    /// through the *old* location. The tag makes that resolution fail, so the
+    /// reader must see either its own item or nothing -- never a different one.
+    #[test]
+    fn loom_stale_location_never_resolves_to_the_new_occupant() {
+        loom::model(|| {
+            let oracle = std::sync::Arc::new(KeyOracle::new());
+            let ht = std::sync::Arc::new(MultiChoiceHashtable::new(16));
+
+            oracle.place(SRC, KEY);
+            let stale = oracle.location_tagged(SRC, 0);
+            ht.insert(KEY, stale, &*oracle).unwrap();
+
+            let recycler = {
+                let oracle = oracle.clone();
+                loom::thread::spawn(move || {
+                    // End the incarnation, then refill the same cell with a
+                    // different key under the next tag.
+                    oracle.bump_incarnation(SRC);
+                    oracle.place(SRC, OTHER);
+                })
+            };
+
+            let reader = {
+                let oracle = oracle.clone();
+                let ht = ht.clone();
+                loom::thread::spawn(move || ht.get(KEY, &*oracle))
+            };
+
+            let observed = reader.join().unwrap();
+            recycler.join().unwrap();
+
+            if let Some((loc, _freq)) = observed {
+                assert_eq!(
+                    loc, stale,
+                    "a resolved location must be the one we published"
+                );
+                assert!(
+                    oracle.resolves_to(loc, KEY),
+                    "a stale location resolved to the new occupant"
+                );
+            }
+        });
+    }
+```
+
+Extend `KeyOracle` with the three methods this needs, keeping the existing cells
+representation. `bump_incarnation` must be a single atomic read-modify-write for
+the same reason `tombstone` is -- a `load` then `store` collapses loom's
+exploration and the model silently stops observing the hazard:
+
+```rust
+    /// Advance a cell's incarnation.
+    ///
+    /// # This MUST be one atomic read-modify-write
+    ///
+    /// Splitting it into a load and a store collapses loom's interleaving
+    /// space: the hazard this model exists to find stops being reachable, and
+    /// the model goes green while proving nothing. The same trap cost this
+    /// fixture 183 hazard observations once already -- see `tombstone`.
+    pub(crate) fn bump_incarnation(&self, cell: usize) {
+        self.cells[cell].fetch_add(INCARNATION_UNIT, Ordering::AcqRel);
+    }
+
+    /// The location naming `cell` under a specific incarnation.
+    pub(crate) fn location_tagged(&self, cell: usize, incarnation: u8) -> Location {
+        Location::new(((cell as u64) << 8) | (incarnation as u64 & 0x3F))
+    }
+
+    /// Whether `loc` still names the cell/incarnation it was issued for, and
+    /// that cell currently holds `key`.
+    pub(crate) fn resolves_to(&self, loc: Location, key: &[u8]) -> bool {
+        let cell = (loc.as_raw() >> 8) as usize;
+        let tag = (loc.as_raw() & 0x3F) as u8;
+        let current = self.cells[cell].load(Ordering::Acquire);
+        Self::incarnation_of(current) == tag && Self::key_of(current) == key
+    }
+```
+
+- [ ] **Step 2: Run the model to verify it fails**
+
+Run: `cargo test -p cache-core --features loom --lib loom_stale_location`
+Expected: FAIL with `a stale location resolved to the new occupant`, if the
+oracle is wired so `verify` does not consult the tag.
+
+- [ ] **Step 3: Make it pass**
+
+Route the oracle's `KeyVerifier::verify` through the incarnation comparison, the
+same way the real verifiers do in Task 7.
+
+- [ ] **Step 4: Prove it can fail**
+
+Neuter the oracle's incarnation comparison and re-run:
+
+Run: `cargo test -p cache-core --features loom --lib loom_stale_location`
+Expected: FAIL. A model that cannot fail proves nothing -- if it stays green,
+the interleaving is not being reached and the model must be fixed, not kept.
+
+Then run the full loom suite and confirm the count went 61 -> 62:
+
+Run: `cargo test -p cache-core --features loom 2>&1 | tail -5`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cache/core/src/loom_oracle.rs
+git commit -m "test(cache-core): loom model for stale-incarnation resolution
+
+The oracle can model incarnations now, which is what the module comment
+recorded as blocking the cache-rs model port. bump_incarnation is a single
+fetch_add for the same reason tombstone is -- a load/store pair collapses
+loom's exploration and the model goes green proving nothing.
+
+Proven red by neutering the oracle's tag comparison."
+```
+
+---
+
+### Task 9: Full verification and the residual issue
+
+- [ ] **Step 1: Run every gate**
+
+```bash
+cargo test --workspace
+cargo test -p cache-core --features loom
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all PASS. Record the test counts.
+
+- [ ] **Step 2: Run Miri**
+
+```bash
+MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri test -p cache-core --lib -- \
+  --skip disk::file_pool --skip disk::disk_layer \
+  --skip disk::io_uring --skip disk::recovery --skip hugepage::
+```
+
+Expected: PASS, 378 tests plus the ones added here.
+
+- [ ] **Step 3: File the residual**
+
+```bash
+gh issue create \
+  --title "cache-core: a stale location can still race a header write after passing the incarnation check" \
+  --body "$(cat <<'BODY'
+Split out from the incarnation-tag work so it is not implied fixed.
+
+The 6-bit incarnation tag removes the *false positive* half of #88: a stale
+location naming a recycled segment no longer resolves to whatever now occupies
+that offset. It does not remove the *data race*.
+
+A reader can pass the tag check and then be preempted before reading item
+bytes, and the segment can be drained and refilled in that window.
+`append_with_header` publishes an offset via `reserve_space`'s CAS and then
+lays the header down with a plain `copy_nonoverlapping`, so the reader's bytes
+race that write.
+
+Closing it requires the read to happen under a ref guard taken *before* the
+tag check, so the incarnation cannot advance underneath: guard, then check,
+then read. The guard establishes "this incarnation cannot be reclaimed while I
+hold it"; the tag establishes "this is the incarnation my location names".
+Neither alone is sufficient.
+
+Design context: docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md
+BODY
+)"
+```
+
+- [ ] **Step 4: Open the PR**
+
+Body must state, in the author's own words: what the tag does and does not
+close; that capacity per pool is now `2^36 * align_bytes` and therefore
+invariant under `segment_size`; that memory pools are unchanged at 8-byte
+alignment while disk pools coarsen to 512; that the read-path cost is
+**unmeasured** and cache-rs#78's `+0.94 ns` figure does not transfer because
+crucible's shifts became layout-dependent loads; and the residual issue number
+from Step 3.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Layout and the fixed 6-bit tag: Task 1. Capacity invariance
+and per-pool alignment: Tasks 1 and 5. `incarnation` in `Metadata` rather than
+`generation`: Task 2. Bump sites and the transition table: Task 3. The check:
+Task 7. GHOST unaliasable: Task 1 (`ghost_is_unaliasable`, `max_segments`).
+Construction validates: Tasks 1 and 5. Memory and disk together: Tasks 5, 6, 7.
+Evidence items 1-4: Tasks 7, 8, 3, 1 respectively. Residuals: Task 9 Steps 3-4.
+
+**Known soft spots**, called out rather than hidden:
+
+- Task 7's test uses `build_small_test_cache` / `locate` / `key_verifier`, and
+  Task 3's uses `make_segment`. These are the shapes the tests need, not names
+  verified to exist. Both steps say to adapt to the neighbouring tests' helpers.
+- Task 8's `KeyOracle` extension assumes the cells encode a key and can carry an
+  incarnation in spare bits. If the existing encoding has no room, widen the cell
+  rather than packing the tag into the key field.
+- The read-path cost of turning constant shifts into layout-dependent loads is
+  unmeasured, and no task measures it. That is deliberate: measuring it well
+  needs the counterbalanced A/B discipline cache-rs#78 used, which is its own
+  piece of work and should not be faked inside this one.

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -508,6 +508,312 @@ justifies coarsening disk alignment."
 
 ---
 
+### Task 1b: fixes from the Task 1 code-quality review
+
+The review found a Critical plus four Important issues. C1 is the third instance
+of one defect class in this module -- **an unvalidated bound on a derived
+shift** -- so it must be closed before Tasks 2-9 wire the type into pools, where
+a wrong-but-`Ok` layout surfaces as an inexplicable pool-construction failure
+rather than a layout error.
+
+**Files:** Modify `cache/core/src/location_layout.rs`, `cache/core/src/lib.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module:
+
+```rust
+    #[test]
+    fn rejects_segments_with_too_few_addressable_slots() {
+        // The floor, mirroring the u32 ceiling. `segment_id` is a u32
+        // throughout the crate, so a layout leaving more than 31 segment-id
+        // bits is meaningless -- and `1u32 << seg_bits` overflows computing
+        // `max_segment_count()`. A 4 KiB disk segment at the 512-byte disk
+        // default lands here, and 4 KiB is exactly the block size the design
+        // names, so this is reachable rather than theoretical.
+        assert!(matches!(
+            LocationLayout::new(4096, 512),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+        assert!(matches!(
+            LocationLayout::new(8192, 512),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+        assert!(LocationLayout::new(16 * 1024, 512).is_ok());
+
+        // The degenerate align == segment_size case is subsumed by the same
+        // floor: it derives offset_bits 0, hence seg_bits 36.
+        assert!(matches!(
+            LocationLayout::new(4 * 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024),
+            Err(LayoutError::SegmentTooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn every_accepted_layout_has_computable_fields() {
+        // Companion to `every_accepted_layout_can_represent_its_own_widest_offset`
+        // at the other end: if `new` accepts a layout, every derived quantity
+        // must be computable rather than overflowing a shift.
+        for segment_size in [
+            4096usize,
+            8192,
+            16 * 1024,
+            64 * 1024,
+            1024 * 1024,
+            8 * 1024 * 1024,
+            128 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ] {
+            for align in [8usize, 512, 4096] {
+                let Ok(layout) = LocationLayout::new(segment_size, align) else {
+                    continue;
+                };
+                assert!(
+                    layout.seg_bits() <= 31,
+                    "segment_size {segment_size} align {align} was accepted with \
+                     {} segment-id bits, which overflows a u32 shift",
+                    layout.seg_bits()
+                );
+                assert!(layout.max_segment_count() > 0);
+                assert_eq!(layout.align_bytes() as usize, align);
+                assert_eq!(layout.offset(layout.pack(0, 0, 0, 0)), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn derives_offset_bits_for_non_power_of_two_segment_sizes() {
+        // `segment_size` is an arbitrary usize from the pool builder, and the
+        // div_ceil/next_power_of_two derivation exists solely for this case --
+        // nothing else pins it. The naive
+        // `segment_size.trailing_zeros() - align_shift` gives 16 here and would
+        // silently truncate most of the segment.
+        let layout = LocationLayout::new(1536 * 1024, 8).unwrap();
+        assert_eq!(layout.offset_bits(), 18);
+
+        let last = 1536 * 1024 - 8;
+        assert_eq!(layout.offset(layout.pack(0, 0, 0, last)), last);
+    }
+
+    #[test]
+    fn segment_too_large_names_the_ceiling_that_actually_fired() {
+        // The message must not advise raising align_bytes: for a power-of-two
+        // segment_size, offset_bits + align_shift is invariant, so coarser
+        // alignment provably cannot get past this ceiling. Advising it sends an
+        // operator down a dead end.
+        let err = LocationLayout::new(8 * 1024 * 1024 * 1024, 8).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("u32"), "message should name the real limit: {msg}");
+        assert!(
+            !msg.contains("raise align_bytes"),
+            "message advises a remedy that cannot work: {msg}"
+        );
+    }
+
+    #[test]
+    fn pool_id_decodes_without_a_layout_instance() {
+        // The module's premise: pool_id is read to CHOOSE a layout, so reading
+        // it must not require already having one.
+        let raw = LocationLayout::new(1024 * 1024, 8).unwrap().pack(2, 5, 0, 0);
+        assert_eq!(LocationLayout::pool_id(raw), 2);
+    }
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cargo test -p cache-core --lib location_layout`
+Expected: FAIL. `rejects_segments_with_too_few_addressable_slots` and
+`every_accepted_layout_has_computable_fields` panic on a shift overflow in
+debug (`attempt to shift left with overflow`);
+`derives_offset_bits_for_non_power_of_two_segment_sizes` passes already (it
+documents existing correct behaviour, and is the regression guard I4 asked
+for); `segment_too_large_names_the_ceiling_that_actually_fired` and
+`pool_id_decodes_without_a_layout_instance` fail to compile or assert.
+
+- [ ] **Step 3: Fix C1 -- add the floor**
+
+Add the variant to `LayoutError`:
+
+```rust
+    /// `segment_size / align_bytes` yields so few offset units that more than
+    /// 31 segment-id bits remain, which a `u32` segment id cannot hold.
+    SegmentTooSmall {
+        /// The rejected segment size.
+        segment_size: usize,
+        /// The alignment factor in force.
+        align: usize,
+        /// Segment-id bits the split would have left.
+        seg_bits: u32,
+    },
+```
+
+and its `Display` arm:
+
+```rust
+            Self::SegmentTooSmall {
+                segment_size,
+                align,
+                seg_bits,
+            } => write!(
+                f,
+                "segment_size ({segment_size}) at align_bytes ({align}) addresses \
+                 too few slots, leaving {seg_bits} segment-id bits -- more than the \
+                 31 a u32 segment id can hold; raise segment_size or lower align_bytes"
+            ),
+```
+
+In `new()`, replace the ceiling block with both bounds:
+
+```rust
+        let align_shift = align_bytes.trailing_zeros();
+
+        // Both fields are u32 in every consumer -- `SliceSegment::capacity`,
+        // `write_offset` and `ItemLocation::new` for the offset, and `segment_id`
+        // for the id -- so a layout that addresses past u32 on either end is
+        // meaningless and must be rejected rather than silently truncated.
+        //
+        // Note the id-space bound (`offset_bits + TAG_BITS >= PAYLOAD_BITS`) is
+        // NOT checked: it is unreachable. `align_bytes >= 8` forces
+        // `align_shift >= 3`, so the offset ceiling below caps `offset_bits` at
+        // 29, well under the 36 that bound would need.
+        if offset_bits + align_shift > 32 {
+            return Err(LayoutError::SegmentTooLarge {
+                segment_size,
+                align: align_bytes,
+                offset_bits,
+            });
+        }
+
+        let seg_bits = PAYLOAD_BITS - TAG_BITS - offset_bits;
+        if seg_bits > 31 {
+            return Err(LayoutError::SegmentTooSmall {
+                segment_size,
+                align: align_bytes,
+                seg_bits,
+            });
+        }
+```
+
+- [ ] **Step 4: Fix I2 -- correct the `SegmentTooLarge` message**
+
+It currently describes the unreachable ceiling and advises a remedy that
+provably cannot work. Replace its `Display` arm:
+
+```rust
+            Self::SegmentTooLarge {
+                segment_size,
+                align,
+                offset_bits,
+            } => write!(
+                f,
+                "segment_size ({segment_size}) at align_bytes ({align}) needs \
+                 {offset_bits} offset bits, and offsets past u32 cannot be \
+                 represented; reduce segment_size. Raising align_bytes does not \
+                 help -- it lowers offset_bits by exactly as much as it raises \
+                 the shift"
+            ),
+```
+
+- [ ] **Step 5: Fix I3 -- range-check `offset` in `pack`**
+
+An out-of-range offset currently overflows into the incarnation field, silently
+corrupting the tag this module exists to protect. Also document the
+`incarnation` masking, and express the `segment_id` bound as a field width (M2)
+so the assert can catch a caller's off-by-one:
+
+```rust
+    /// Pack the four fields into raw location bits.
+    ///
+    /// `incarnation` is masked to 6 bits; the other three are `debug_assert`ed
+    /// in range.
+    #[inline]
+    pub fn pack(&self, pool_id: u8, segment_id: u32, incarnation: u8, offset: u32) -> u64 {
+        debug_assert!(pool_id <= 3, "pool_id must be 0-3");
+        debug_assert!(
+            segment_id < (1u32 << self.seg_bits()),
+            "segment_id {segment_id} exceeds this layout's {}-bit field",
+            self.seg_bits()
+        );
+        debug_assert!(
+            offset.is_multiple_of(self.align_bytes()),
+            "offset must be {}-byte aligned",
+            self.align_bytes()
+        );
+        debug_assert!(
+            (offset >> self.align_shift) < (1u32 << self.offset_bits as u32),
+            "offset {offset} exceeds this layout's {}-bit offset field",
+            self.offset_bits
+        );
+```
+
+`ghost_is_unaliasable` packs the unissuable top segment id deliberately, so it
+must construct that value directly rather than through `pack`:
+
+```rust
+        // Built directly, not via pack: this id is out of the layout's field
+        // range by construction, which is the whole point.
+        let unissuable = ((3u64) << LocationLayout::POOL_SHIFT)
+            | ((layout.max_segment_count() as u64) << (layout.offset_bits() + 6))
+            | ((0x3F as u64) << layout.offset_bits())
+            | ((max_offset >> 3) as u64);
+        assert_eq!(unissuable, crate::location::Location::MAX_RAW);
+```
+
+- [ ] **Step 6: Fix I5 and the minors**
+
+`pool_id` becomes an associated function -- the module's premise is that it is
+read *before* a layout is known:
+
+```rust
+    /// Extract `pool_id`. Layout-independent by design: this is what a decoder
+    /// reads first, to find out which layout decodes the rest.
+    #[inline]
+    pub fn pool_id(raw: u64) -> u8 {
+        ((raw >> Self::POOL_SHIFT) & 0b11) as u8
+    }
+```
+
+Then:
+- **M1:** `pub const POOL_SHIFT: u32 = PAYLOAD_BITS;` so the two cannot drift.
+- **M5:** `io::Error::new(ErrorKind::InvalidInput, e)` instead of `e.to_string()`, so pool builders can `downcast_ref::<LayoutError>()`.
+- **M6:** follow the crate convention `lib.rs` already uses for `Location` -- `mod location_layout;` plus `pub use location_layout::{LayoutError, LocationLayout, TAG_BITS, TAG_MASK};`.
+- **M7:** `#[inline]` rather than `#[inline(always)]` on the accessors. The design doc flags the layout-dependent shifts as an open measurement; forcing inlining removes the compiler's judgment from the exact thing that needs measuring.
+
+- [ ] **Step 7: Verify**
+
+Run: `cargo test -p cache-core --lib location_layout`
+Expected: PASS, 14 tests.
+
+Run: `cargo test -p cache-core --lib`, `cargo clippy -p cache-core --all-targets -- -D warnings`, `cargo fmt`
+Expected: all clean.
+
+- [ ] **Step 8: Prove the floor red**
+
+Remove the `seg_bits > 31` rejection and confirm BOTH
+`rejects_segments_with_too_few_addressable_slots` and
+`every_accepted_layout_has_computable_fields` fail. Restore it. Quote the
+observed failure text in the commit message.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cache/core/src/location_layout.rs cache/core/src/lib.rs
+git commit -m "fix(cache-core): bound LocationLayout on both ends, not just the ceiling
+
+Third instance of one defect class in this module: an unvalidated bound on a
+derived shift. seg_bits is 36 - offset_bits, so a small segment leaves more
+than 31 segment-id bits and 1u32 << seg_bits overflows -- reachable with a
+4 KiB disk segment at the 512-byte disk default.
+
+Also: the id-space ceiling was dead code (align_bytes >= 8 caps offset_bits
+at 29), and its message misdescribed the live ceiling while advising a remedy
+that provably cannot work. pack now range-checks offset, which previously
+overflowed into the incarnation field -- silently corrupting the very tag this
+module exists to protect."
+```
+
+---
+
 ### Task 2: `Metadata` carries the incarnation
 
 Adding a field to `Metadata` deliberately breaks every struct-literal site at compile time, so the compiler enumerates the places that must decide whether to preserve or bump. Do not add a `Default`.

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -925,7 +925,7 @@ capability the pool builders in Task 5 may rely on, and nothing pins it:
 - [ ] **Step 6: Verify and prove red**
 
 Run: `cargo test -p cache-core --lib location_layout`
-Expected: PASS, 18 tests.
+Expected: PASS, 17 tests (three new; N2/N3/N5 modify existing tests).
 
 Prove each new guard red: delete `pack`'s offset assert and confirm
 `pack_rejects_an_offset_past_the_offset_field` fails; loosen the `segment_id`

--- a/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
+++ b/docs/superpowers/plans/2026-09-06-location-incarnation-tag.md
@@ -148,13 +148,48 @@ mod tests {
 
     #[test]
     fn rejects_segment_too_large_to_address() {
-        // offset_bits + 6 must leave room for segment ids, so at 8-byte
-        // alignment the ceiling is a 512 GiB segment (offset_bits == 36).
-        assert!(LocationLayout::new(256 * 1024 * 1024 * 1024, 8).is_ok());
+        // Offsets are u32 throughout the crate (`SliceSegment::capacity`,
+        // `write_offset`, `ItemLocation::new`), so the real ceiling is a layout
+        // whose widest offset still fits in u32: offset_bits + align_shift <= 32.
+        // At 8-byte alignment that is a 4 GiB segment, an order of magnitude
+        // above the 128 MB the tests exercise.
+        assert!(LocationLayout::new(4 * 1024 * 1024 * 1024, 8).is_ok());
         assert!(matches!(
-            LocationLayout::new(512 * 1024 * 1024 * 1024, 8),
+            LocationLayout::new(8 * 1024 * 1024 * 1024, 8),
             Err(LayoutError::SegmentTooLarge { .. })
         ));
+
+        // Coarser alignment does not buy past it: the offset field shifts left
+        // by align_shift, so the two trade off exactly.
+        assert!(LocationLayout::new(4 * 1024 * 1024 * 1024, 512).is_ok());
+        assert!(matches!(
+            LocationLayout::new(512 * 1024 * 1024 * 1024, 512),
+            Err(LayoutError::SegmentTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn every_accepted_layout_can_represent_its_own_widest_offset() {
+        // Guards the truncation the u32 bound exists to prevent: if `new`
+        // accepts a layout, packing its widest offset must round-trip.
+        for segment_size in [
+            1024 * 1024usize,
+            8 * 1024 * 1024,
+            128 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ] {
+            for align in [8usize, 512] {
+                let Ok(layout) = LocationLayout::new(segment_size, align) else {
+                    continue;
+                };
+                let widest = ((1u32 << layout.offset_bits()) - 1) * layout.align_bytes();
+                assert_eq!(
+                    layout.offset(layout.pack(0, 0, 0, widest)),
+                    widest,
+                    "segment_size {segment_size} align {align} truncates its widest offset"
+                );
+            }
+        }
     }
 
     #[test]
@@ -322,7 +357,17 @@ impl LocationLayout {
         let units = segment_size.div_ceil(align_bytes);
         let offset_bits = units.next_power_of_two().trailing_zeros();
 
-        if offset_bits + TAG_BITS >= PAYLOAD_BITS {
+        let align_shift = align_bytes.trailing_zeros();
+
+        // Two independent ceilings, both reported as SegmentTooLarge:
+        //
+        // 1. The offset field must leave room for segment ids.
+        // 2. The widest offset must fit in u32. Offsets are u32 throughout the
+        //    crate -- `SliceSegment::capacity`, `write_offset`, and
+        //    `ItemLocation::new` all use it -- so a layout that addresses past
+        //    u32 would truncate in `pack`/`offset` rather than error, and the
+        //    round trip would silently lose the high bits.
+        if offset_bits + TAG_BITS >= PAYLOAD_BITS || offset_bits + align_shift > 32 {
             return Err(LayoutError::SegmentTooLarge {
                 segment_size,
                 align: align_bytes,
@@ -331,7 +376,7 @@ impl LocationLayout {
         }
 
         Ok(Self {
-            align_shift: align_bytes.trailing_zeros() as u8,
+            align_shift: align_shift as u8,
             offset_bits: offset_bits as u8,
         })
     }
@@ -428,7 +473,7 @@ impl LocationLayout {
 - [ ] **Step 4: Run the test to verify it passes**
 
 Run: `cargo test -p cache-core --lib location_layout`
-Expected: PASS, 8 tests.
+Expected: PASS, 9 tests.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md
+++ b/docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md
@@ -1,0 +1,215 @@
+# Incarnation-tagged locations
+
+**Date:** 2026-09-06
+**Ports:** pelikan-io/cache-rs#78 (`segcache: generation-tagged locations`)
+**Addresses:** the stale-location residual recorded in crucible#88
+
+## Problem
+
+An `ItemLocation` names `(pool_id, segment_id, offset)` and carries no incarnation
+identity. A segment can be drained, recycled, re-reserved and refilled while a
+thread still holds a location naming it, so a stale location can silently resolve
+to a *different item at the same address*.
+
+`CacheKeyVerifier::verify` (`cache/core/src/cache.rs:1631`) hands a
+hashtable-supplied offset straight to `verify_key_at_offset` with no check that
+the segment is still the incarnation the location was issued against. Two
+consequences:
+
+1. **False positive.** Segments are append-only from a fixed start, so with
+   uniform item sizes the n-th item of every incarnation lands at the same
+   offset. If the recycled segment holds the same key at that offset, `verify`
+   returns true for an item the caller never asked for.
+2. **Data race.** `append_with_header` publishes an offset via `reserve_space`'s
+   CAS and *then* lays the header down with a plain `copy_nonoverlapping`. A
+   stale-location reader aims at an offset being written right now.
+
+crucible already has `SliceSegment.generation: AtomicU16`, but it is consumed
+only by `CasToken` — *beside* the location, not inside it — which is precisely
+why the read path cannot see it.
+
+## Why this is not a straight port
+
+cache-rs#78 had slack: it repartitioned `[24 seg][20 off]` into
+`[18 seg][6 tag][20 off]` by shrinking an oversized segment id field.
+
+Crucible's 44 bits are fully spent — `[2 pool][18 seg][24 off/8]` — and the
+offset field is genuinely used. `server/tests/large_value_io_tests.rs` runs
+32 MB segments in CI (22 offset bits) and 64/128 MB under `#[ignore]`
+(23–24 bits). There is nothing free to take.
+
+## Design
+
+### 1. Per-pool layout, fixed 6-bit tag
+
+```
+Location (44 bits)
+  [43..42]  pool_id       2 bits, FIXED POSITION
+  [41..  ]  segment_id    42 - 6 - offset_bits
+  [  ..  ]  incarnation   6 bits
+  [  ..0 ]  offset/align  ceil(log2(segment_size / align_bytes))
+```
+
+`pool_id` stays at a fixed position so a decoder reads it *first* and then
+selects that pool's layout. This is what lets four pools with different segment
+sizes and different alignment factors share one 44-bit word.
+
+```rust
+#[derive(Clone, Copy)]
+pub struct LocationLayout {
+    align_shift: u8,   // log2(align_bytes)
+    offset_bits: u8,
+    seg_shift: u8,
+    seg_mask: u64,
+    tag_shift: u8,
+    offset_mask: u64,
+}
+```
+
+Built once at pool construction and stored on the pool. `CacheKeyVerifier` holds
+`[Option<LocationLayout>; 4]` beside its existing `pools` array; layers hold
+their own pool's layout for `ItemLocation::new`.
+
+### 2. Capacity is invariant under `segment_size`
+
+With a fixed tag width, offset bits gained are segment bits lost, exactly:
+
+```
+capacity/pool = 2^(42 - tag_bits) x align_bytes = 2^36 x align_bytes
+```
+
+`segment_size` does not appear. **The alignment factor is the only capacity
+lever.**
+
+| pool   | align | offset bits (8 MB segs) | seg bits | capacity/pool |
+|--------|-------|-------------------------|----------|---------------|
+| memory | 8 B   | 20                      | 16       | 512 GiB       |
+| disk   | 512 B | 14                      | 22       | 32 TiB        |
+
+Memory keeps 8-byte alignment: a minimal item is `BasicHeader(6) + 1 + 1 = 8`
+bytes, so 16-byte alignment would double the smallest items, and 512 GiB x 4
+pools is already beyond any single host's RAM.
+
+Disk coarsens to 512 B, and the justification is the read path rather than
+capacity. `IoUringPool::item_disk_range` already rounds reads down to a
+4096-byte block and returns an intra-block offset
+(`cache/core/src/disk/io_uring_pool.rs`), so a disk item straddling a block
+boundary costs an extra block read today. Sector alignment cuts that. Average
+waste is 256 B, landing on the tier built for larger cold values.
+
+`align_bytes` is a per-pool config field: a power of two, at least 8, and no
+larger than `segment_size`. Disk pools additionally cap it at `block_size`,
+since aligning coarser than the I/O block buys nothing on the read path.
+Defaults are 8 for memory and 512 for disk.
+
+### 3. `incarnation` lives in `Metadata`, not in `generation`
+
+`Metadata` packs `[8 unused][8 state][24 prev][24 next]`. The 6-bit tag goes in
+that unused byte.
+
+This is a correctness requirement, not tidiness. **The bump must be atomic with
+the state transition.** Storing the tag in the existing `AtomicU16 generation`
+would leave a window where the segment is already `Free` but still carries the
+old counter; a thread reserving inside that window refills under the old tag,
+reintroducing exactly the aliasing being removed.
+
+`generation: AtomicU16` is left untouched — still bumped in `try_reserve`, still
+feeding `CasToken`. No CAS-token semantics change. The two counters answer
+different questions and this must be documented on both fields.
+
+### 4. Bump sites
+
+`incarnation` bumps on exactly the transitions that end a **used** incarnation:
+
+| transition                  | bumps | why                                  |
+|-----------------------------|-------|--------------------------------------|
+| `Locked -> Free`            | yes   | drained and cleared                  |
+| `AwaitingRelease -> Free`   | yes   | condemned, last reader released      |
+| `Reserved\|Linking -> Free` | NO    | reserved but never used              |
+
+The exclusion is the substance of cache-rs#78's prerequisite. `memory_pool.rs:175`,
+`memory_pool.rs:270`, `file_pool.rs:322` and `io_uring_pool.rs:222` all release
+never-used segments; under crucible's current `try_reserve` bump site each of
+those burns a generation for free, at a rate decoupled from segment lifecycles.
+A 6-bit tag cannot afford that.
+
+This bump site carries the tag's collision hardness. A future change moving it
+would look locally harmless while silently draining that hardness, so it is
+pinned by a full transition-table test.
+
+### 5. The check
+
+In `CacheKeyVerifier::verify`, after resolving the segment and **before any item
+bytes are touched**:
+
+```rust
+if segment.incarnation() != item_loc.incarnation() {
+    return false;
+}
+```
+
+`metadata` is the first field of a 64-byte-aligned `SliceSegment`, and `verify`
+already reads `capacity` and `pool_flags` from that line, so this should cost a
+compare rather than a miss. The same check goes in `SinglePoolVerifier`,
+`MultiPoolVerifier` (`cache/core/src/item_location.rs`) and the disk verifier.
+
+### 6. GHOST stays unaliasable
+
+`Location::GHOST` is all 44 bits set. Construction rejects `num_segments >
+2^seg_bits - 1` so the top segment id is never issued and GHOST cannot be
+aliased by construction.
+
+### 7. Construction validates instead of aliasing
+
+Pool construction computes the layout and fails with an error naming the limit
+and pointing at `segment_size` and `align_bytes` as the levers. Current configs
+top out at 100 GB (disk) and 4 GB (heap), so nothing in the tree breaks.
+
+## Scope
+
+Memory and disk pools change together — `MemoryPool`, `FilePool`, `IoUringPool`,
+and all `ItemLocation::new` sites in `fifo_layer`, `ttl_layer` and `disk_layer`.
+
+A half-tagged location space is worse than an untagged one: a verifier holding a
+location cannot tell whether a zero tag means "untagged pool" or "incarnation 0",
+so the check would have to skip, and could decay into a no-op with no test
+noticing.
+
+## Evidence
+
+Every item below must be proven red by neutering the thing it tests.
+
+1. **Deterministic recycle test.** Drive N drain/recycle/refill cycles against a
+   held stale location; assert it is rejected every time, *and* that the
+   rejection count is non-zero so the test cannot pass vacuously.
+2. **Loom model.** Extend `loom_oracle` to model incarnations. It currently
+   records that the oracle owns all 44 bits with no generation riding in them —
+   which is exactly what blocked the cache-rs model port. Races a reader holding
+   a stale location against a recycle.
+3. **Bump-site transition table.** Assert `incarnation` advances on exactly
+   `Locked -> Free` and `AwaitingRelease -> Free`, and not on
+   `Reserved|Linking -> Free`.
+4. **Layout property test.** Roundtrip every `(segment_size, align_bytes,
+   heap_size)` combination through pack/unpack; assert construction rejects
+   overflowing configs rather than aliasing them.
+
+## Residuals
+
+- **This does not fully close the crucible#88 data race.** It removes the false
+  positive and shrinks the window, but a reader can pass the tag check and then
+  be preempted before reading item bytes. Closing that requires the read to
+  happen under a ref guard. Separate work; to be filed, not claimed here.
+- **The tag is probabilistic.** Aliasing requires a thread to stall across 64
+  lifecycles of one specific segment id. "Same offset" is not an independent
+  coincidence — segments are append-only from a fixed start, so with uniform
+  item sizes the n-th item of every incarnation lands at the same offset. A real,
+  bounded residual: tracked, not hidden.
+- **Read-path cost is unmeasured.** cache-rs#78 measured its tag check at
+  +0.94 +/- 0.26 ns, though net versus its parent was indistinguishable from zero.
+  Crucible's arithmetic differs (the shifts become layout-dependent loads rather
+  than constants), so that figure does not transfer and must be measured here.
+- **Layout-dependent shifts are a new hot-path load.** Today's accessors are
+  constant shifts an optimiser can fold. They become loads from the layout
+  descriptor. Keeping the descriptor in the same cache line as the pool pointer
+  the verifier already reads is the mitigation; whether it is sufficient is an
+  open measurement.

--- a/docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md
+++ b/docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md
@@ -119,13 +119,39 @@ different questions and this must be documented on both fields.
 
 ### 4. Bump sites
 
-`incarnation` bumps on exactly the transitions that end a **used** incarnation:
+> **Corrected 2026-09-06** after the Task 2 review traced the real recycle path.
+> The original table said `Locked -> Free` bumps. **That transition does not
+> occur on crucible's main eviction path**, so implementing the table literally
+> would have left the tag at 0 forever and made the feature inert while every
+> test passed. The actual path is:
+>
+> ```text
+> Sealed -> Draining -> Locked -> Reserved     (cas_metadata, in the layers)
+>                                    |
+>                                    v
+>                        pool.release() -> try_release  =>  Reserved -> Free
+> ```
+>
+> `fifo_layer.rs:227,324,425,517`, `ttl_layer.rs:283,486,734,841`,
+> `disk_layer.rs:270`. The `Reserved -> Free` that follows is precisely the
+> transition the original table forbade bumping.
 
-| transition                  | bumps | why                                  |
-|-----------------------------|-------|--------------------------------------|
-| `Locked -> Free`            | yes   | drained and cleared                  |
-| `AwaitingRelease -> Free`   | yes   | condemned, last reader released      |
-| `Reserved\|Linking -> Free` | NO    | reserved but never used              |
+`incarnation` bumps when a **used** incarnation ends. Stated as a property of
+the segment rather than as a list of state pairs, because the pair list is what
+went wrong:
+
+| transition                   | bumps | why                                        |
+|------------------------------|-------|--------------------------------------------|
+| **leaving `Locked`**, to any state | yes   | drained and cleared; covers both `Locked -> Reserved` (the real recycle path) and `Locked -> Free` |
+| `AwaitingRelease -> Free`    | yes   | condemned, last reader released            |
+| `force_free` (`* -> Free`)   | yes   | flush recycles every segment at once       |
+| `Free -> Reserved`           | NO    | start of an incarnation, not the end       |
+| `Reserved\|Linking -> Free`  | NO    | reserved but never used                    |
+
+Keying on *leaving `Locked`* rather than on a destination state is deliberate:
+`Locked` is reached only after a drain, so any exit from it ends a used
+incarnation regardless of which path took it. Enumerating destination pairs is
+what produced the original error.
 
 The exclusion is the substance of cache-rs#78's prerequisite. `memory_pool.rs:175`,
 `memory_pool.rs:270`, `file_pool.rs:322` and `io_uring_pool.rs:222` all release


### PR DESCRIPTION
Adds a 6-bit incarnation tag to every segment location, so a `Location` held
across a segment recycle stops resolving instead of resolving to whatever item
now sits at that offset.

Implements the design in
`docs/superpowers/specs/2026-09-06-location-incarnation-tag-design.md`.

## What this closes, and what it does not

crucible#88 has two halves. This closes the **false positive**: the hashtable
can no longer hand back a location whose segment was drained and refilled
underneath it. Segments are append-only from a fixed start, so with uniform
item sizes the n-th item of every incarnation lands at the same offset — a
stale location did not merely point at free space, it pointed at a *different
live item*, and the key compare alone could not tell them apart.

It does **not** close the **data race**. A reader can pass the tag check and
then be preempted before it reads item bytes, and the segment can be drained
and refilled inside that window; `append_with_header` publishes an offset with
a CAS and then writes the bytes with plain `copy_nonoverlapping`. Closing that
needs the read to happen under a ref guard taken *before* the tag check —
guard, then check, then read. Filed separately as #109 so this PR
is not read as fixing it.

## The layout

`Location` is 44 bits. `pool_id` keeps a fixed position in the top 2 so a
decoder can read it before knowing anything else and then pick that pool's
layout; the remaining 42 split into `segment_id`, a 6-bit incarnation, and
`offset / align_bytes`.

Offset bits gained are segment bits lost, exactly, so capacity per pool is
`2^36 x align_bytes` — **invariant under `segment_size`**. The alignment factor
is the only lever:

| pool | align_bytes | capacity/pool |
|---|---|---|
| memory | 8 | 512 GiB |
| disk | 512 | 32 TiB |

The old 18/24 split gave `2^18 x segment_size`, which *did* vary with segment
size, so the comparison depends on the config. Against the sizes we actually
ship:

| segment_size | old | new (memory, align 8) | new (disk, align 512) |
|---|---|---|---|
| 1 MB | 256 GiB | 512 GiB | 32 TiB |
| 8 MB | 2 TiB | 512 GiB | 32 TiB |

Two consequences an operator should know:

- **A memory pool with segments above 2 MB loses addressable capacity.** Below
  2 MB it gains. At the 8 MB `example.toml` uses it is a 4x reduction, to
  512 GiB per pool — still far past any machine we run on, but it is a
  reduction and worth knowing. Pool construction now fails **by name** when a
  config needs more segments than the layout addresses, rather than aliasing
  them silently.
- **Disk items now occupy at least 512 bytes each.** Disk appends stride by
  `align_bytes`, so a 100-byte disk item takes a full sector. That
  fragmentation is real and was taken deliberately: it is what buys the 32 TiB
  (against 512 GiB at align 8, or 256 GiB under the old split at the 1 MB the
  disk configs inherit), and it stops items straddling a 4096-byte I/O block,
  which costs an extra block read today. Note the floor is per *item*, so a
  larger `segment_size` does not recover it. Shipped disk configs leave
  `[cache.disk] segment_size` unset and inherit the RAM value, so
  `directio.toml`'s 32 MB disk tier now tops out near 65k items; those configs
  deserve a separate pass.

## Read-path cost is unmeasured

cache-rs#78 measured the equivalent check at +0.94 +/- 0.26 ns. **That figure
does not transfer.** There, the shifts were compile-time constants; here the
layout is per-pool, so decoding is a load of the pool's `LocationLayout`
followed by variable shifts, plus one extra atomic load of the segment's
metadata word on the verify path. I have not benchmarked it. Treat the cost as
unknown rather than small.

## Two design errors caught in review

Both would have shipped, and neither would have been caught by a green suite.
They are the more interesting half of this branch.

1. **The bump table named a transition that never fires.** The plan keyed the
   incarnation bump on `Locked -> Free`. The layers never drive that: eviction
   recycles a drained segment `Locked -> Reserved` and only then releases it
   `Reserved -> Free`. Shipping it would have left every tag at 0 forever with
   the whole suite green — the feature inert and indistinguishable from working.
   The rule is now *leaving* `Locked` for any other state, and a transition
   table test pins every arm including the exclusions.

2. **512-byte disk alignment was specified without the append change that makes
   it possible.** Every segment type padded appends to a hardcoded 8, so the
   second item in any disk segment would have landed unaligned: a `debug_assert`
   in debug, and a silently truncated offset — a corrupted location — in
   release. Padding the append turned out to be only half of it; 18 scan sites
   advance by `header.padded_size()`, which rounds to 8, so a coarser-aligned
   pool would have desynced its own segment walk after one item. Both sides now
   go through one `Segment::item_stride`.

## What landed

- `LocationLayout`: per-pool bit split, derived from `segment_size` and
  `align_bytes`, bounded at both ends and rejecting configs it cannot address.
- `Metadata` carries the tag; it advances on exactly the transitions that end a
  *used* incarnation, and the exclusions are pinned too — returning a
  never-used segment must not burn tag space.
- 28 publish sites stamp the tag from the same segment reference the append
  used, so a location can never carry an incarnation its item was not written
  into.
- 14 guards across 10 verifiers in 3 crates reject a stale tag before touching
  item bytes.
- Disk appends and all 18 segment walks stride by the pool's `align_bytes`.
- A loom model for a reader racing a recycle that refills with the **same** key,
  which is the one shape the key compare cannot catch.

## Testing

`cache-core --lib` **421 -> 469**. Loom **59 passed**. Full workspace green,
`clippy --workspace --all-targets -D warnings` clean (and again under
`--features loom`), `rustdoc -D warnings` clean, `cargo fmt --check` clean.

**Miri (Stacked Borrows) found one real defect**, which is why the run was
worth doing rather than ticking off: the disk-segment test fixture built its
free-queue injector in a `Box`, handed the segment a raw pointer derived from
it, and then returned the `Box` — a `Unique` retag that pops the pointer the
segment is still holding, which `release_condemned` then dereferences. This is
the exact failure `MemoryPool::free_queue` and `FilePool::free_queue` already
document and use an `Arc` to avoid; the fixture had not followed. Fixed, and
417 tests then pass under Miri with 0 failures.

Excluded from Miri and why: the four `disk::` pool modules and `hugepage::`
(the pre-existing skips — file-backed `mmap` and `MAP_HUGETLB`);
`test_stale_location_is_rejected_on_the_disk_arms`, which is new here and needs
the same treatment for the same reason but sits in `cache::tests`, so the CI
skip list is updated in this PR; and `test_increment_concurrent_no_lost_updates`
(#105), whose 4x250 CAS loop was still running after 15 minutes under Miri.

Every new guard and every new stride site was checked by mutation — remove it,
run the suite, observe red or green, restore. That step earned its place twice.
The 18 stride sites came back with **none** genuinely protected on the first
pass (the single apparent red was #105 flaking), and the 14 verifier guards
came back **1 of 14**. In both cases the new test that looked like proof
touched none of the sites it appeared to cover. After adding tests:

- **6 of 6** disk stride sites red. The other 12 are in the memory layers,
  where `align_bytes` is 8 and `item_stride(x) == x`, so the mutation is a
  semantic no-op and no test can distinguish it. They were converted anyway,
  because `MemoryPoolBuilder::align_bytes` is public and leaving them would
  make that knob a silent-corruption switch.
- **11 of 14** verifier guards red. The three that are not are
  `CacheKeyVerifier::prefetch`'s arms, which return `()` and issue a hardware
  hint — unobservable by construction, and called out as such rather than
  claimed as covered.

## Pre-existing bugs found while working, filed and NOT fixed here

- **#107 — `TieredCache::flush()` leaves the cache permanently unwritable.**
  Worth reading first: `flush()` resets the pools but not the layers' chains and
  bucket state, so every subsequent `set` returns `OutOfMemory`. `flush()` is
  FLUSHALL, so **FLUSHALL kills a running server**. Reproduced on a clean tree
  at the branch point.
- **#108** — the heap backend's disk tier is unreachable:
  `SlotLocation::pool_id_from_location` is hardcoded to return 0, so every
  disk-tier location is decoded as a RAM slot.
- **#105** — `increment` loses updates under concurrency. I measured 3 failures
  in 10 runs on a clean tree at the branch point, which also makes mutation
  probes on this crate unreliable until it is fixed; every probe above was run
  with it skipped.
- **#106** — `IoUringPool::release` discards `try_release`'s result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu
