### PR TITLE
docs: add cargo test --release to the build commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ cargo test test_name
 # Run tests with loom for concurrency testing
 cargo test -p cache-core --features loom
 
+# Run tests in release mode - NOT redundant with `cargo test`
+# `debug_assert!` is compiled out in release, so any `#[should_panic]` test
+# covering one silently stops testing anything. Gate those with
+# `#[cfg(debug_assertions)]` (see `cache/core/src/location.rs`).
+cargo test --release
+
 # Format code
 cargo fmt
 


### PR DESCRIPTION
`debug_assert!` is compiled out in release, so a `#[should_panic]` test covering one silently stops testing anything — it passes in debug and fails in release, and nothing local catches it.

That is not hypothetical. Two such tests in `LocationLayout` rode from their first commit all the way to CI on #110:

```
---- location_layout::tests::pack_rejects_an_offset_past_the_offset_field stdout ----
note: test did not panic as expected
---- location_layout::tests::pack_rejects_the_unissuable_top_segment_id stdout ----
note: test did not panic as expected
```

Every other class of defect on that branch was caught by a gate someone had thought to specify. This one got through because nobody had — `cargo test --release` runs only in CI, and it is the sole check that finds it.

The fix pattern already exists in the crate (`cache/core/src/location.rs` gates its equivalent with `#[cfg(debug_assertions)]`); the comment points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD891duvo6DAVHha6e1YKu